### PR TITLE
Remove base path from external links in hero component

### DIFF
--- a/src/components/overrides/Hero.astro
+++ b/src/components/overrides/Hero.astro
@@ -56,7 +56,7 @@ if (image) {
             <CallToAction
               {...attrs}
               variant={attrs.variant}
-              link={attrs.link.startsWith('/') ? setBasePath(attrs.link) : attrs.link}
+              link = {attrs.link.startsWith('https://') ? attrs.link : setBasePath(attrs.link)}
               set:html={text}
             />
           ))}


### PR DESCRIPTION
My first PR in this repo! I noticed that all links in the hero component are prepended with the base path. That's fine for internal links, but causes malformed links for external links.

For example, the link for the **Join our Discord** button on the [home page](https://experienceleague.adobe.com/developer/commerce/storefront/) 404s because this:

```
https://experienceleague.adobe.com/developer/commerce/storefronthttps://discord.com/channels/1131492224371277874/1220042081209421945
```

![Screenshot 2024-06-05 at 4 40 09 PM](https://github.com/commerce-docs/microsite-commerce-storefront/assets/13662379/e8dd4653-c13c-4cf5-9dc5-5e5b31f91990)
