### PR TITLE
Run preview on pages workflow only by request

### DIFF
--- a/.github/workflows/preview-on-pages.yml
+++ b/.github/workflows/preview-on-pages.yml
@@ -1,9 +1,6 @@
 name: Deploy to GitHub Pages
 
 on:
-  pull_request:
-    branches:
-      - develop
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Changing the Pages deployment workflow to not run on pull request changes to avoid unexpected overwrites of the preview on [Pages](https://special-adventure-vywvyqo.pages.github.io/).