### PR TITLE
Set base path for side nav links in new Playgrounds and Videos

### DIFF
--- a/src/pages/playgrounds/commerce-services.astro
+++ b/src/pages/playgrounds/commerce-services.astro
@@ -1,6 +1,7 @@
 ---
 import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 import GraphiQLEditor from '@components/Graphiql/GraphiQLEditor.jsx';
+import { setBasePath } from '@utils/basePath';
 ---
 
 <StarlightPage
@@ -16,7 +17,7 @@ import GraphiQLEditor from '@components/Graphiql/GraphiQLEditor.jsx';
       label: 'Playgrounds',
       items: [
         // { label: 'Overview', href: '/playgrounds/' },
-        { label: 'Commerce APIs', href: '/developer/commerce/storefront/playgrounds/commerce-services/' },
+        { label: 'Commerce APIs', href: setBasePath('/playgrounds/commerce-services/') },
         // { label: 'Commerce Boilerplate', href: '/playgrounds/commerce-boilerplate/' },
       ],
     },

--- a/src/pages/playgrounds/index.astro
+++ b/src/pages/playgrounds/index.astro
@@ -1,6 +1,7 @@
 ---
 import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 import Aside from '@components/Aside.astro';
+import { setBasePath } from '@utils/basePath';
 ---
 
 <StarlightPage
@@ -16,7 +17,7 @@ import Aside from '@components/Aside.astro';
       label: 'Playgrounds',
       items: [
         // { label: 'Overview', href: '/playgrounds/' },
-        { label: 'Commerce APIs', href: '/developer/commerce/storefront/playgrounds/commerce-services/' },
+        { label: 'Commerce APIs', href: setBasePath('/playgrounds/commerce-services/') },
         // { label: 'Commerce Boilerplate', href: '/playgrounds/commerce-boilerplate/' },
       ],
     },

--- a/src/pages/videos/customize-pdp.astro
+++ b/src/pages/videos/customize-pdp.astro
@@ -1,6 +1,7 @@
 ---
 import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 import Aside from '@components/Aside.astro';
+import { setBasePath } from '@utils/basePath';
 ---
 
 <StarlightPage
@@ -15,8 +16,8 @@ import Aside from '@components/Aside.astro';
     {
       label: 'Training Videos',
       items: [
-        { label: 'Overview', href: '/videos/' },
-        { label: 'Customize the PDP', href: '/developer/commerce/storefront/videos/customize-pdp/' },
+        { label: 'Overview', href: setBasePath('/videos/') },
+        { label: 'Customize the PDP', href: setBasePath('/videos/customize-pdp/') },
         // { label: 'Customize the Cart', href: '/videos/customize-cart/' },
         // { label: 'Customize the Checkout', href: '/videos/customize-checkout/' },
       ],

--- a/src/pages/videos/index.astro
+++ b/src/pages/videos/index.astro
@@ -1,6 +1,7 @@
 ---
 import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 import Aside from '@components/Aside.astro';
+import { setBasePath } from '@utils/basePath';
 ---
 
 <StarlightPage
@@ -15,8 +16,8 @@ import Aside from '@components/Aside.astro';
     {
       label: 'Training Videos',
       items: [
-        { label: 'Overview', href: '/developer/commerce/storefront/videos/' },
-        { label: 'Customize the PDP', href: '/developer/commerce/storefront/videos/customize-pdp/' },
+        { label: 'Overview', href: setBasePath('/videos/') },
+        { label: 'Customize the PDP', href: setBasePath('/videos/customize-pdp/') },
         // { label: 'Customize the Cart', href: '/videos/customize-cart/' },
         // { label: 'Customize the Checkout', href: '/videos/customize-checkout/' },
       ],


### PR DESCRIPTION
Currently, side nav links in the new **[Playgrounds](https://experienceleague.adobe.com/developer/commerce/storefront/playgrounds/commerce-services/)** and **[Videos](https://experienceleague.adobe.com/developer/commerce/storefront/videos/)** pages 404 because the expected base path isn't being prepended in the `<StarlightPage>` config.

At a minimum, we should use a common function to set the base path for these pages so that the nav links resolve properly on production (see #18 for reference implementation).

Ideally, we would have a more efficient way to manage the navigation across pages in a section. It looks like there's a lot of sidenav duplication across the new **Playgrounds** and **Videos** pages.

When there are more pages to link, maybe we can use the `autogenerate` [sidebar](https://starlight.astro.build/reference/configuration/#sidebar) property.