### PR TITLE
Clarify mountpoint vocabulary based on partner day feedback

### DIFF
--- a/src/content/docs/get-started/index.mdx
+++ b/src/content/docs/get-started/index.mdx
@@ -77,7 +77,7 @@ Sidekick is an extension that makes it easy for creators to connect, edit, previ
 
 ### mountpoint
 
-The `mountpoint` is the URL that points to your content folder on Google Drive or SharePoint. By specifying the `mountpoint` in your GitHub repo's **`fstab.yaml`** file, Edge Delivery Services can link your code to the content for your storefront.
+The `mountpoint` is the URL that points to your content folder on Google Drive or SharePoint. By specifying the `mountpoint` in the **`fstab.yaml`** file on the `main` branch of your remote GitHub repo, Edge Delivery Services can link your code to the content for your storefront.
 
 </Vocabulary>
 


### PR DESCRIPTION
During Partner Day, a partner was confused about the relationship between a local and remote git repo in the context of the [storefront tutorial](https://experienceleague.adobe.com/developer/commerce/storefront/get-started/). This PR attempts to clarify that EDS looks for the `fstab.yaml` file on the `main` branch  of the remote repo only (i.e., not local).

The steps in the [Connect repo to folder content](https://experienceleague.adobe.com/developer/commerce/storefront/get-started/#connect-repo-to-folder-content) section are clear about this, but it might help to mention it earlier.