### PR TITLE
USF-1295: The docs have the Overview of Cart dropin

### DIFF
--- a/src/content/docs/dropins/cart/index.mdx
+++ b/src/content/docs/dropins/cart/index.mdx
@@ -8,11 +8,11 @@ sidebar:
 
 import Aside from '@components/Aside.astro';
 
+The Cart dropin provides a variety of fully-editabled controls to help you view, update, and merge the products in your cart and mini-cart, including image thumbnails, pricing, descriptions, quantities, estimated shipping and taxes, order summary, merging guest and authenticated cart, and more.
+
 <Aside type="wip" title="In Development">
   The Cart dropin is in active development. Stay tuned for updates.
 </Aside>
-
-The Cart dropin provides a variety of fully-customizable controls to help you showcase your products, including image carousels, thumbnails, pricing, descriptions, and more.
 
 ## Section topics
 


### PR DESCRIPTION
- Add content to the overview page for Cart

- [x] The docs site has an "Overview" page in the Cart dropin that closely mirrors the "Overview" page in the PDP dropin


Closes [USF-1295](https://jira.corp.adobe.com/browse/USF-1295)