### PR TITLE
Fix broken ExL links

### DIFF
--- a/src/content/docs/get-started/configurations.mdx
+++ b/src/content/docs/get-started/configurations.mdx
@@ -65,19 +65,19 @@ Each `key` is described below with links to more details. The `value` for each k
 
 1. **commerce-core-endpoint:** (read/write) Core GraphQL endpoint for a variety of queries and mutations. See [Adobe Commerce GraphQL API](https://developer.adobe.com/commerce/webapi/graphql/reference/) for details.
 
-1. **commerce-environment-id:** Connects the storefront to the cloud instance that serves it. See [Cloud Environment overview](https://experienceleague.adobe.com/docs/commerce-cloud-service/user-guide/project/overview.html#environment-overview) for details.
+1. **commerce-environment-id:** Connects the storefront to the cloud instance that serves it. See [Cloud Environment overview](https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/project/overview#environment-overview) for details.
 
-1. **commerce-root-category-id:** Determines the products in the storefront's main menu. See [Step 1: Create root categories](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/multi-sites/ms-admin.html#step-1%3A-create-root-categories), [Catagories overview](https://experienceleague.adobe.com/docs/commerce-admin/catalog/categories/categories.html), and [Root category and hierarchy](https://experienceleague.adobe.com/docs/commerce-admin/catalog/categories/category-root.html) for details.
+1. **commerce-root-category-id:** Determines the products in the storefront's main menu. See [Step 1: Create root categories](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/multi-sites/ms-admin#step-1-create-root-categories), [Catagories overview](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/categories/categories), and [Root category and hierarchy](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/categories/category-root) for details.
 
-1. **commerce-website-code:** Determines the website to connect to. See [Step 2: Create websites](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/multi-sites/ms-admin.html#step-2%3A-create-websites) for details.
+1. **commerce-website-code:** Determines the website to connect to. See [Step 2: Create websites](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/multi-sites/ms-admin#step-2-create-websites) for details.
 
-1. **commerce-store-code:** Determines the store to connect to. See [Step 3: Create stores](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/multi-sites/ms-admin.html#step-3%3A-create-stores) for details.
+1. **commerce-store-code:** Determines the store to connect to. See [Step 3: Create stores](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/multi-sites/ms-admin#step-3-create-stores) for details.
 
-1. **commerce-store-view-code:** Determines the store view to connect to. See [Step 4: Create store views](https://experienceleague.adobe.com/docs/commerce-operations/configuration-guide/multi-sites/ms-admin.html#step-4%3A-create-store-views) and [Store views](https://experienceleague.adobe.com/docs/commerce-admin/stores-sales/site-store/store-views.html) for details.
+1. **commerce-store-view-code:** Determines the store view to connect to. See [Step 4: Create store views](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/multi-sites/ms-admin#step-4-create-store-views) and [Store views](https://experienceleague.adobe.com/en/docs/commerce-admin/stores-sales/site-store/store-views) for details.
 
-1. **commerce-customer-group:** Determines product discounts and tax classes. See [Customer groups](https://experienceleague.adobe.com/docs/commerce-admin/customers/customer-groups.html) and the [Create Customer Groups](https://experienceleague.adobe.com/docs/commerce-learn/tutorials/customers/customer-groups.html) video for details.
+1. **commerce-customer-group:** Determines product discounts and tax classes. See [Customer groups](https://experienceleague.adobe.com/en/docs/commerce-admin/customers/customer-groups) and the [Create Customer Groups](https://experienceleague.adobe.com/en/docs/commerce-learn/tutorials/customers/customer-groups) video for details.
 
-1. **commerce-x-api-key:** Provides access to SaaS storefront services (Catalog Service, Live Search, and Product Recommendations). See [Commerce Services Connector](https://experienceleague.adobe.com/docs/commerce-merchant-services/user-guides/integration-services/saas.html) for details.
+1. **commerce-x-api-key:** Provides access to SaaS storefront services (Catalog Service, Live Search, and Product Recommendations). See [Commerce Services Connector](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/user-guides/integration-services/saas) for details.
 
 </Callouts>
 

--- a/src/content/docs/get-started/requirements.mdx
+++ b/src/content/docs/get-started/requirements.mdx
@@ -12,7 +12,7 @@ import { Aside, CardGrid, Card, Tabs, TabItem } from '@astrojs/starlight/compone
 When connecting your storefront dropins to your own instance of Adobe Commerce, you must ensure that your Commmerce backend is configured with the services described here. These services are required for Commerce dropins to function properly.
 
 :::note[Adobe Commerce Services Guides]
-For a complete list of merchandising services available for your Adobe Commerce storefront, refer to the [Adobe Commerce Services Guides](https://experienceleague.adobe.com/docs/commerce-merchant-services/user-guides/home.html). Direct links to the required services are provided below.
+For a complete list of merchandising services available for your Adobe Commerce storefront, refer to the [Adobe Commerce Services Guides](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/user-guides/home). Direct links to the required services are provided below.
 :::
 
 <Tasks>
@@ -23,8 +23,8 @@ For a complete list of merchandising services available for your Adobe Commerce 
 
 The following links provide the requirements and installation procedures for your Adobe Commerce backend:
 
-- [System requirements for cloud infrastructure](https://experienceleague.adobe.com/docs/commerce-operations/installation-guide/system-requirements.html)
-- [Setup for Commerce on cloud infrastructure](https://experienceleague.adobe.com/docs/commerce-cloud-service/user-guide/overview.html)
+- [System requirements for cloud infrastructure](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements)
+- [Setup for Commerce on cloud infrastructure](https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/overview)
 
 </Task>
 
@@ -32,7 +32,7 @@ The following links provide the requirements and installation procedures for you
 
 ### Data Connection service
 
-The Data Connection extension connects your Adobe Commerce storefront to the Adobe Experience Platform and the Edge Network so that you can enrich and personalize the shopping experience for your customers. Refer to the [Data Connection Guide](https://experienceleague.adobe.com/docs/commerce-merchant-services/data-connection/overview.html) for details and installation instructions.
+The Data Connection extension connects your Adobe Commerce storefront to the Adobe Experience Platform and the Edge Network so that you can enrich and personalize the shopping experience for your customers. Refer to the [Data Connection Guide](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/data-connection/overview) for details and installation instructions.
 
 </Task>
 
@@ -54,21 +54,21 @@ The Catalog Sync service synchronizes Commerce catalog data with your Commerce s
 <Task>
 ### Catalog Service
 
-The Catalog Service module provides fast read-only access to Commerce catalog data. The Product Details dropin requires this service to render product data in the storefront. Refer to the [Catalog Service Guide](https://experienceleague.adobe.com/docs/commerce-merchant-services/catalog-service/guide-overview.html) for details and installation instructions.
+The Catalog Service module provides fast read-only access to Commerce catalog data. The Product Details dropin requires this service to render product data in the storefront. Refer to the [Catalog Service Guide](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/catalog-service/guide-overview) for details and installation instructions.
 
 </Task>
 
 <Task>
 ### Live Search
 
-The Live Search service replaces the default Commerce catalog search and installs the Product Listing Page (PLP) widget in your storefront. Refer to the [Live Search Guide](https://experienceleague.adobe.com/docs/commerce-merchant-services/live-search/guide-overview.html) for details and installation instructions.
+The Live Search service replaces the default Commerce catalog search and installs the Product Listing Page (PLP) widget in your storefront. Refer to the [Live Search Guide](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/live-search/overview) for details and installation instructions.
 
 </Task>
 
 <Task>
 ### Product Recommendations
 
-Product Recommendations uses artificial intelligence and machine-learning algorithms ([Adobe Sensei](https://business.adobe.com/products/sensei/adobe-sensei.html)) to create personalized storefront experiences. While not a strict requirement, we recommended it for Commerce storefronts. Refer to the [Product Recommendations Guide](https://experienceleague.adobe.com/docs/commerce-merchant-services/product-recommendations/guide-overview.html) for details and installation instructions.
+Product Recommendations uses artificial intelligence and machine-learning algorithms ([Adobe Sensei](https://business.adobe.com/products/sensei/adobe-sensei.html)) to create personalized storefront experiences. While not a strict requirement, we recommended it for Commerce storefronts. Refer to the [Product Recommendations Guide](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/product-recommendations/guide-overview) for details and installation instructions.
 
 </Task>
 </Tasks>

--- a/src/content/docs/get-started/storefront-structure.mdx
+++ b/src/content/docs/get-started/storefront-structure.mdx
@@ -122,11 +122,11 @@ Run your storefront locally using the `npm start` command and use the table belo
 
 :::note[Live Search components]
 The Gear page is rendered by the [Live Search Product Listing Page
-(PLP)](https://experienceleague.adobe.com/docs/commerce-merchant-services/live-search/live-search-storefront/plp-styling.html)
+(PLP)](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/live-search/live-search-storefront/plp-styling)
 and the Search box (🔍) is rendered by the [Live Search
-Popover](https://experienceleague.adobe.com/docs/commerce-merchant-services/live-search/live-search-storefront/storefront-popover.html).
+Popover](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/live-search/live-search-storefront/storefront-popover).
 To learn more about the Live Search service, visit [Introduction to Live
-Search](https://experienceleague.adobe.com/docs/commerce-merchant-services/live-search/overview.html#live-search-components).
+Search](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/live-search/overview#live-search-components).
 :::
 
 ### Relationship between the Commerce blocks and dropins


### PR DESCRIPTION
@larsroettig reported broken links in [Slack](https://magento.slack.com/archives/C034VBDRM6U/p1719508988509639).

The issue with all the broken links appears to be related to a hardcoded URL parameter that specifies the language. That URL parameter is no longer supported by ExL since they started using EDS for their backend.