### PR TITLE
Update Carousel code samples for PDP dropin v0.3.0

### DIFF
--- a/src/content/docs/dropins/product-details/pdp-containers.mdx
+++ b/src/content/docs/dropins/product-details/pdp-containers.mdx
@@ -123,7 +123,7 @@ interface CarouselConfig {
     ['loopable', 'boolean', 'No', 'Whether the carousel should loop continously or stop at the end.'],
     ['peak', 'object', 'No', 'Whether to show part of the next image on mobile and desktop.'],
     ['gap', 'string', 'No', 'The space between the image and the next one.'],
-    ['thumbnailsLoadingMode', 'string', 'No', 'The loading mode for the thumbnails, lazy or eager.'],
+    ['thumbnailsLoadingMode', 'string', 'No', 'The loading mode for the thumbnails: lazy or eager.'],
     ['imageParams', 'object', 'No', 'Can be used to set the width, height, auto, quality, crop, and fit properties of carousel images.'],
     ['thumbnailParams', 'object', 'No', 'Can be used to the set width, height, auto, quality, crop, and fit properties of the carousel thumbnails.']
   ]}


### PR DESCRIPTION
## Slack request from @alandana on 7/10/2024:

One request from my side - if you could please update the **[CarouselConfig](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/product-details/pdp-containers/#carousel)** info. Starting with PDP v0.3.0 this has been updated.

On the PDP Containers → Carousel the controls field on the interface should be:

```js
controls?: {
  desktop?: 'thumbnailsRow' | 'thumbnailsColumn' | 'dots' | null;
  mobile?: 'dots' | 'thumbnailsRow' | null;
};
```

This is what we defined in the source code:

```js
export type CarouselConfig = {
  controls?: {
    desktop?: 'thumbnailsRow' | 'thumbnailsColumn' | 'dots' | null,
    mobile?: 'dots' | 'thumbnailsRow' | null,
  },
  arrowsOnMainImage?: boolean;
  loopable?: boolean;
  peak?: {
    desktop: boolean,
    mobile: boolean,
  }
  gap?: 'small' | 'medium' | 'large' | null;
  thumbnailsLoadingMode?: 'lazy' | 'eager';
  imageParams?: ResolveImageUrlOptions,
  thumbnailParams?: ResolveImageUrlOptions
};
```

Updates to table describing options:

- **gap** - string - not required - the space between the an image and the next one
- **imageParams** - object - not required - can be used to set width, height, auto, quality, crop, fit properties of the carousel - images
- **thumbnailParams** - object - not required - can be used to set width, height, auto, quality, crop, fit properties of the carousel thumbnails
- **arrowsOnMainImage** - boolean - not required - used to display the carousel arrows on the main image