### PR TITLE
Replace cartID in cart query

### DIFF
--- a/src/components/Graphiql/queries/queryVariables.js
+++ b/src/components/Graphiql/queries/queryVariables.js
@@ -1,5 +1,5 @@
 export const VARIABLES = {
-  Cart: JSON.stringify({ cartId: 'Y8HrBP9pLdVhiWJ6gNyM5WmxjR97S7ra' }, null, 2),
+  Cart: JSON.stringify({ cartId: 'cdKuDrc2cd9AnyWycSuMPIYN4UqWlK85' }, null, 2),
   Products: JSON.stringify({ sku: '24-WG080' }, null, 2),
   Recommendations: JSON.stringify(
     {


### PR DESCRIPTION
By default, a cart (quote) ID is valid for 30 days. The cart query was failing because the cart ID had expired. This PR replaces the cart ID. To prevent this from recurring every month, I had the owner of the Commerce instance change the value of Stores > Configuration > Sales  > Checkout > Shopping Cart > Quote Lifetime (Days) to 1000 days. Maybe in the future the playground will have better cart management and we can change the value back.

Staging build: https://special-adventure-vywvyqo.pages.github.io/playgrounds/commerce-services/

To verify this fix, click **Cart**, then the pink run button. The query returns valid data, instead of an error message.