### PR TITLE
USF-1298-Cart-Container

### DIFF
--- a/src/content/docs/dropins/cart/cart-containers.mdx
+++ b/src/content/docs/dropins/cart/cart-containers.mdx
@@ -36,10 +36,11 @@ The following configuration options are available for the Cart and MiniCart cont
 <OptionsTable
   compact
   options={[
+    ['Option', 'Type', 'Req?', 'Description'],
     ['routeProduct', 'function', 'Yes', 'Callback function that returns a product.'],
     ['routeEmptyCartCTA', 'function', 'Yes', 'Callback function that returns an empty cart.'],
     ['routecart', 'function', 'Yes', 'Callback function that navigates to cart.'],
-    [('routeCheckout', 'function', 'Yes', 'Callback function that navigates cart to checkout.')],
+    ['routeCheckout', 'function', 'Yes', 'Callback function that navigates cart to checkout.'],
   ]}
 />
 


### PR DESCRIPTION
https://jira.corp.adobe.com/browse/USF-1298

Goal

As a storefront developer I want to be able to consult documentation and learn about the different Containers that the Cart dropin provides so that I understand my options on how to lay out my site.

Preconditions

None

Acceptance criteria
The docs site has an "Containers" page in the Cart dropin that closely mirrors the "Container" page in the PDP dropin
Note that the Cart dropin has more than one "Container" so it is plural