### PR TITLE
Fix the pipeline name after recent renaming in the shared lib

### DIFF
--- a/.jenkins/deliver-build.groovy
+++ b/.jenkins/deliver-build.groovy
@@ -11,7 +11,7 @@
 
 @Library('jenkins-shared-libs') _
 
-micrositeBuildDeliver(
+micrositeBuildDeliverPipeline(
     repoName: 'microsite-commerce-storefront',
     runBuildScript: 'node --version && corepack enable && corepack prepare pnpm@latest-9 --activate && pnpm version && pnpm install && pnpm run build:prod',
     deliverBuildScript: 'cp -r dist/* storefront',


### PR DESCRIPTION
This is a CICD fix which does not affect the project's codebase.