### PR TITLE
Add Commerce as a prereq

### DIFF
--- a/src/content/docs/get-started/index.mdx
+++ b/src/content/docs/get-started/index.mdx
@@ -101,7 +101,7 @@ Before you begin, take a moment to set up these required tools and accounts as n
   icon="commerce"
   title="Adobe Commerce 2.4.7+"
   description="Adobe Commerce system requirements."
-  href="https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements"
+  href="https://experienceleague.adobe.com/developer/commerce/storefront/get-started/requirements/"
   rightIcon="external"
   target="_blank"
   rel="noopener noreferrer"


### PR DESCRIPTION
This PR adds a card for Adobe Commerce to the prerequisites section of the main installation page.