### PR TITLE
USF-1052: Cart feature matrix

### DIFF
--- a/src/content/docs/dropins/cart/index.mdx
+++ b/src/content/docs/dropins/cart/index.mdx
@@ -6,7 +6,7 @@ sidebar:
   order: 1
 ---
 
-import Aside from '@components/Aside.astro';
+import { Badge } from '@astrojs/starlight/components';
 import OptionsTable from '@components/OptionsTable.astro';
 
 The Cart dropin provides a variety of fully-editabled controls to help you view, update, and merge the products in your cart and mini-cart, including image thumbnails, pricing, descriptions, quantities, estimated shipping and taxes, order summary, merging guest and authenticated cart, and more.
@@ -15,31 +15,28 @@ The Cart dropin provides a variety of fully-editabled controls to help you view,
 
 The following table provides an overview of the Adobe Commerce features that the Cart dropin supports:
 
-<OptionsTable
-  options={[
-    ['Feature', 'Status'],
-    ['All product types', 'Supported'],
-    ['Apply coupons', 'Roadmap'],
-    ['Apply gift card', 'API only'],
-    ['Apply reward points', 'API only'],
-    ['Cart rules', 'Supported'],
-    ['Cart slots for extensibility', 'Roadmap'],
-    ['Cart with 100+ products', 'Roadmap'],
-    ['Customer cart', 'Supported'],
-    ['Customer groups', 'Supported'],
-    ['Customer segments', 'Supported'],
-    ['Edit selected product configuration in cart', 'Supported'],
-    ['Estimate tax/shipping', 'Supported'],
-    ['Guest cart', 'Supported'],
-    ['Low product stock alert', 'Supported'],
-    ['Mini-cart', 'Supported'],
-    ['Out of stock/insufficient quantity products', 'Supported'],
-    ['Product line discounts (catalog rule, special price, tier price)', 'API only'],
-    ['Taxes: Fixed', 'API only'],
-    ['Taxes: Sales, VAT', 'Supported'],
-    ['Wishlist', 'Roadmap'],
-  ]}
-/>
+| Feature | Status |
+| --- | --- |
+| All product types | <Badge text="Supported" variant="success" /> |
+| Apply coupons | <Badge text="Roadmap" variant="note" /> |
+| Apply gift card | <Badge text="API only" variant="tip" /> |
+| Apply reward points | <Badge text="API only" variant="tip" /> |
+| Cart rules | <Badge text="Supported" variant="success" /> |
+| Cart slots for extensibility | <Badge text="Roadmap" variant="note" /> |
+| Cart with 100+ products | <Badge text="Roadmap" variant="note" /> |
+| Customer cart | <Badge text="Supported" variant="success" /> |
+| Customer groups | <Badge text="Supported" variant="success" /> |
+| Customer segments | <Badge text="Supported" variant="success" /> |
+| Edit selected product configuration in cart | <Badge text="Supported" variant="success" /> |
+| Estimate tax/shipping | <Badge text="Supported" variant="success" /> |
+| Guest cart | <Badge text="Supported" variant="success" /> |
+| Low product stock alert | <Badge text="Supported" variant="success" /> |
+| Mini-cart | <Badge text="Supported" variant="success" /> |
+| Out of stock/insufficient quantity products | <Badge text="Supported" variant="success" /> |
+| Product line discounts (catalog rule, special price, tier price) | <Badge text="API only" variant="tip" /> |
+| Taxes: Fixed | <Badge text="API only" variant="tip" /> |
+| Taxes: Sales, VAT | <Badge text="Supported" variant="success" /> |
+| Wishlist | <Badge text="Roadmap" variant="note" /> |
 
 ## Section topics
 

--- a/src/content/docs/dropins/cart/index.mdx
+++ b/src/content/docs/dropins/cart/index.mdx
@@ -11,7 +11,7 @@ import OptionsTable from '@components/OptionsTable.astro';
 
 The Cart dropin provides a variety of fully-editabled controls to help you view, update, and merge the products in your cart and mini-cart, including image thumbnails, pricing, descriptions, quantities, estimated shipping and taxes, order summary, merging guest and authenticated cart, and more.
 
-## Commerce features supported
+## Supported Commerce features
 
 The following table provides an overview of the Adobe Commerce features that the Cart dropin supports:
 

--- a/src/content/docs/dropins/cart/index.mdx
+++ b/src/content/docs/dropins/cart/index.mdx
@@ -11,6 +11,8 @@ import OptionsTable from '@components/OptionsTable.astro';
 
 The Cart dropin provides a variety of fully-editabled controls to help you view, update, and merge the products in your cart and mini-cart, including image thumbnails, pricing, descriptions, quantities, estimated shipping and taxes, order summary, merging guest and authenticated cart, and more.
 
+## Commerce features supported
+
 The following table provides an overview of the Adobe Commerce features that the Cart dropin supports:
 
 <OptionsTable

--- a/src/content/docs/dropins/cart/index.mdx
+++ b/src/content/docs/dropins/cart/index.mdx
@@ -7,12 +7,37 @@ sidebar:
 ---
 
 import Aside from '@components/Aside.astro';
+import OptionsTable from '@components/OptionsTable.astro';
 
 The Cart dropin provides a variety of fully-editabled controls to help you view, update, and merge the products in your cart and mini-cart, including image thumbnails, pricing, descriptions, quantities, estimated shipping and taxes, order summary, merging guest and authenticated cart, and more.
 
-<Aside type="wip" title="In Development">
-  The Cart dropin is in active development. Stay tuned for updates.
-</Aside>
+The following table provides an overview of the Adobe Commerce features that the Cart dropin supports:
+
+<OptionsTable
+  options={[
+    ['Feature', 'Status'],
+    ['All product types', 'Supported'],
+    ['Apply coupons', 'Roadmap'],
+    ['Apply gift card', 'API only'],
+    ['Apply reward points', 'API only'],
+    ['Cart rules', 'Supported'],
+    ['Cart slots for extensibility', 'Roadmap'],
+    ['Cart with 100+ products', 'Roadmap'],
+    ['Customer cart', 'Supported'],
+    ['Customer groups', 'Supported'],
+    ['Customer segments', 'Supported'],
+    ['Edit selected product configuration in cart', 'Supported'],
+    ['Estimate tax/shipping', 'Supported'],
+    ['Guest cart', 'Supported'],
+    ['Low product stock alert', 'Supported'],
+    ['Mini-cart', 'Supported'],
+    ['Out of stock/insufficient quantity products', 'Supported'],
+    ['Product line discounts (catalog rule, special price, tier price)', 'API only'],
+    ['Taxes: Fixed', 'API only'],
+    ['Taxes: Sales, VAT', 'Supported'],
+    ['Wishlist', 'Roadmap'],
+  ]}
+/>
 
 ## Section topics
 


### PR DESCRIPTION
This pull request (PR) adds a table showing which Adobe Commerce features that the cart dropin supports.

>[!NOTE]
>The `OptionsTable` component doesn't currently support image links. It would be nice to have icons/.svg files for each status similar to [this](https://developer.adobe.com/commerce/pwa-studio/integrations/adobe-commerce/features/).

I know that we're attempting to finalize the dropin doc template (#41), but since we'll have to refactor the cart docs after that anyway, it seems prudent to get this info out on production. It's unclear how long it will take to get the template finalized.