### PR TITLE
fix: apply consistent styling to badges

### DIFF
--- a/src/styles/badge.css
+++ b/src/styles/badge.css
@@ -30,9 +30,10 @@
   color: var(--sl-color-accent);
 }
 
-.note {
-  --sl-color-bg-badge: var(--sl-color-blue-low);
-  --sl-color-border-badge: var(--sl-color-blue);
+.note.note {
+  --sl-color-bg-badge: transparent;
+  --sl-color-border-badge: var(--sl-color-blue-high);
+  color: var(--sl-color-blue-high);
 }
 
 .danger.danger {
@@ -42,18 +43,21 @@
 }
 
 .success.success {
-  --sl-color-bg-badge: var(--sl-color-green-low);
+  --sl-color-bg-badge: transparent;
   --sl-color-border-badge: var(--sl-color-green-high);
+  color: var(--sl-color-green-high);
 }
 
-.caution {
-  --sl-color-bg-badge: var(--sl-color-orange-low);
-  --sl-color-border-badge: var(--sl-color-orange);
+.caution.caution {
+  --sl-color-bg-badge: transparent;
+  --sl-color-border-badge: var(--sl-color-orange-high);
+  color: var(--sl-color-orange-high);
 }
 
-.tip {
-  --sl-color-bg-badge: var(--sl-color-purple-low);
-  --sl-color-border-badge: var(--sl-color-purple);
+.tip.tip {
+  --sl-color-bg-badge: transparent;
+  --sl-color-border-badge: var(--sl-color-purple-high);
+  color: var(--sl-color-purple-high);
 }
 
 :global([data-theme='light']) .default {


### PR DESCRIPTION
This pull request (PR) fixes custom CSS for the Badge component variants to align with the `danger` variant, which is already on production and presumably the preferred format for badges.

This is necessary to fix unexpected style rendering introduced by #45 before we deploy to production.

**Format of `danger` variant on production (before we merged #45):**

![Screenshot 2024-09-04 at 4 07 42 PM](https://github.com/user-attachments/assets/c55cc0ea-a595-44c4-b650-b14e95222bbd)

**Format of remaining variants based on local gh-pages and production builds (after merging #45, but not deployed to production. we don't want this on production):**

![Screenshot 2024-09-04 at 4 10 40 PM](https://github.com/user-attachments/assets/79162074-b425-473e-800c-65f37e7c2bae)

**Format of remaining variants based on this PR (consistent with `danger` variant. this is what we want on production):**

![Screenshot 2024-09-04 at 4 04 50 PM](https://github.com/user-attachments/assets/2fb19654-d8cb-415f-8b56-ed8c47e9f5f4)




