### PR TITLE
fix: resolve link validation errors in LinkCard component

### DIFF
--- a/src/components/LinkCard.astro
+++ b/src/components/LinkCard.astro
@@ -14,7 +14,7 @@ interface Props extends Omit<HTMLAttributes<'a'>, 'title'> {
   noborder?: boolean;
 }
 
-const { title, description, image, icon, rightIcon, noborder, href, ...attributes } = Astro.props;
+const { title, description, image, icon, rightIcon, noborder, link, ...attributes } = Astro.props;
 
 const iconClass = noborder ? '' : 'icon';
 const iconSize = noborder ? '1.5rem' : '2rem';
@@ -30,7 +30,7 @@ const iconSize = noborder ? '1.5rem' : '2rem';
   }
   {icon && <Icon name={icon} class={iconClass} size={iconSize} />}
   <div class="sl-flex stack">
-    <a href={href?.toString().startsWith('https://') ? href : setBasePath(href)} {...attributes}></a>
+    <a href={link?.toString().startsWith('https://') ? link : setBasePath(link)} {...attributes}></a>
       <span class="title" set:html={title} />
     </a>
     {description && <span class="description" set:html={description} />}

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -34,30 +34,30 @@ import Callouts from '@components/Callouts.astro';
     icon="commerce"
     title="Create your Storefront"
     description="Give us 20 minutes, we'll give you the foundation for your next storefront."
-    href="/get-started/"
+    link="/get-started/"
   />
   <LinkCard
     icon="seti:graphql"
     title="Explore the Commerce API"
     description="Use our GraphQL playground to explore our Commerce API with predefined and custom queries."
-    href="/playgrounds/commerce-services/"
+    link="/playgrounds/commerce-services/"
   />
   <LinkCard
     icon="seti:code-search"
     title="Product Details dropin"
     description="Discover how flexible our Commerce components are with our Product Details dropin."
-    href="/dropins/product-details/pdp-anatomy/"
+    link="/dropins/product-details/pdp-anatomy/"
   />
   <LinkCard
     icon="seti:code-search"
     title="Cart dropin"
     description="Learn about the Cart dropin."
-    href="/dropins/cart/"
+    link="/dropins/cart/"
   />
   <LinkCard
     icon="seti:code-search"
     title="Checkout dropin"
     description="Learn about the Checkout dropin."
-    href="/dropins/checkout/"
+    link="/dropins/checkout/"
   />
 </CardGrid>


### PR DESCRIPTION
This pull request (PR) fixes the following link validation errors for builds:

```
validating links 
17:36:57 [ERROR] ✗ Found 5 invalid links in 1 file.
17:36:57 ▶ developer/commerce/storefront/
17:36:57   ├─ /get-started/ - invalid link
17:36:57   ├─ /playgrounds/commerce-services/ - invalid link
17:36:57   ├─ /dropins/product-details/pdp-anatomy/ - invalid link
17:36:57   ├─ /dropins/cart/ - invalid link
17:36:57   └─ /dropins/checkout/ - invalid link

[AstroUserError] Links validation failed.
```

I only tested with the `build:gh-pages` script. We should also test `build:prod`.