### PR TITLE
DATA-5753: PDP use cases

### DIFF
--- a/src/content/docs/dropins/product-details/files/zoom.css
+++ b/src/content/docs/dropins/product-details/files/zoom.css
@@ -1,0 +1,71 @@
+/**
+ * ADOBE CONFIDENTIAL
+ * __________________
+ * Copyright 2024 Adobe
+ * All Rights Reserved.
+ * __________________
+ * NOTICE: All information contained herein is, and remains
+ * the property of Adobe and its suppliers, if any. The intellectual
+ * and technical concepts contained herein are proprietary to Adobe
+ * and its suppliers and are protected by all applicable intellectual
+ * property laws, including trade secret and copyright laws.
+ * Dissemination of this information or reproduction of this material
+ * is strictly forbidden unless prior written permission is obtained
+ * from Adobe.
+ */
+ .pdp-zoom {
+    cursor: zoom-in;
+    overflow: hidden;
+    margin: 0;
+    position: relative;
+  
+    img {
+      height: 100%;
+      max-width: 100%;
+      min-width: 100%;
+      object-fit: contain;
+      position: relative;
+      transition: transform .2s;
+      transform: var(--transform);
+      vertical-align: middle;
+      width: 100%;
+    }
+  
+    .pdp-zoom__close-button {
+      background-color: var(--color-neutral-50);
+      border-radius: 50%;
+      position: absolute;
+      right: var(--spacing-small);
+      top: var(--spacing-small);
+    }
+  }
+  
+  .pdp-zoom.pdp-zoom--zoomed {
+    cursor: zoom-out;
+  }
+  
+  .pdp-zoom.pdp-zoom--no-effects {
+    cursor: default;
+  }
+  
+  @media only screen and (max-width: 768px) {
+    .pdp-zoom img {
+      display: block;
+      width: 100%;
+      height: 100%;
+      transition: transform .2s;
+      transform: var(--transform);
+    }
+  }
+  
+  /* Medium (portrait tablets and large phones, 768px and up) */
+  /* @media only screen and (min-width: 768px) { } */
+  
+  /* Large (landscape tablets, 1024px and up) */
+  /* @media only screen and (min-width: 1024px) { } */
+  
+  /* XLarge (laptops/desktops, 1366px and up) */
+  /* @media only screen and (min-width: 1366px) { } */
+  
+  /* XXlarge (large laptops and desktops, 1920px and up) */
+  /* @media only screen and (min-width: 1920px) { } */

--- a/src/content/docs/dropins/product-details/index.mdx
+++ b/src/content/docs/dropins/product-details/index.mdx
@@ -10,15 +10,20 @@ import Aside from '@components/Aside.astro';
 import Callouts from '@components/Callouts.astro';
 import Diagram from '@components/Diagram.astro';
 import { Image } from 'astro:assets';
+import List from '@components/List.astro';
 import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 import Task from '@components/Task.astro';
 import Tasks from '@components/Tasks.astro';
 
 The Product Details Page (PDP) dropin provides a variety of fully-customizable controls to help you showcase your products, including image carousels, thumbnails, pricing, descriptions, and more.
 
+## Anatomy
+
+<Diagram caption="PDP slots">![PDP example](@images/slots/pdp-slots.webp)</Diagram>
+
 ## Use cases
 
-The Product Details Page allows you to showcase your products according to your brand's aesthetics and user experience goals. Use cases include:
+The PDP dropin allows you to showcase your products according to your brand's aesthetics and user experience goals. Use cases include:
 
 - **Image Carousel**: Display multiple product images in a carousel format, allowing users to view different angles and details of the product.
 - **Product Information**: Showcase detailed product information, including pricing, descriptions, and specifications.
@@ -26,237 +31,32 @@ The Product Details Page allows you to showcase your products according to your 
 - **Product Reviews**: Include user reviews and ratings to provide social proof and help users make informed purchasing decisions.
 - **Product Recommendations**: Suggest related products or accessories to encourage users to explore additional items.
 - **Customization Options**: Customize the appearance and behavior of the dropin to align with your brand's design aesthetic and user experience goals.
-- **Render different product types**: Render different product types, such as simple, configurable, and bundle products.
+- **Render product types**: Render simple or complex product types to enhance shopper experience.
 
-## Anatomy
+### Render product types
 
-<Diagram caption="PDP slots">![PDP example](@images/slots/pdp-slots.webp)</Diagram>
+The PDP dropin supports rendering different product types configured in your Adobe Commerce instance by default (for example, simple, configurable, and bundle) using data provided by the [Catalog Service GraphQL API](https://developer.adobe.com/commerce/services/graphql/catalog-service/).
 
-## Render product types
+The practical application of rendering different product types is to provide a consistent user experience across different products. For example, a simple product can be rendered with a single price and quantity, while a complex product can be rendered with multiple simple products and different prices. This flexibility allows you to showcase a wide range of products in a consistent and user-friendly manner. These product types allow you to cater to diverse customer needs, streamline operations, and enhance the shopping experience.
 
-The Product Details Page dropin supports rendering different product types, such as simple, configurable, and bundle products. You can customize the dropin to display the appropriate product information based on the product type.
+The following table describes the different product types, their definitions, use cases, and benefits:
 
-1. Follow the [installation](pdp-installation) instructions to get the latest version of the PDP dropin.
+| **Product type**       | **Definition**                                | **Use case**                                                                 | **Benefits**                                                                 |
+|------------------------|-----------------------------------------------|------------------------------------------------------------------------------|------------------------------------------------------------------------------|
+| [**Simple Products**](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/products/types/product-create-simple)    | Single items with no variations               | Ideal for straightforward products like books, electronics, or groceries     | Easy to manage, quick to set up, suitable for products with consistent attributes |
+| [**Configurable Products**](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/products/types/product-create-configurable) | Products with multiple variations (e.g., size, color) | Perfect for apparel, footwear, and accessories where customers need to choose specific attributes | Enhances customer experience by offering choices, reduces the need for multiple product listings, simplifies inventory management |
+| [**Bundle Products**](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/products/types/product-create-bundle)    | A combination of multiple products sold together | Common in promotions, gift sets, or kits (e.g., skincare sets, computer accessories) | Increases average order value, encourages the sale of complementary products, provides convenience to customers |
+| [**Grouped Products**](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/products/types/product-create-grouped)   | A collection of related products displayed together | Suitable for items that are often bought together, like furniture sets or toolkits | Simplifies the shopping process, promotes cross-selling, enhances the overall shopping experience |
+| [**Virtual Products**](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/products/types/product-create-virtual)   | Non-tangible items like services or digital downloads | Ideal for software, e-books, online courses, or subscriptions                | No inventory management, instant delivery, scalable sales                    |
+| [**Downloadable Products**](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/products/types/product-create-downloadable) | Digital products that customers can download | Suitable for music, videos, software, or e-books                             | Immediate access for customers, no shipping costs, easy to distribute        |
 
-1. Functions - is there where the graphql query goes?
+#### Simple and complex products
 
-    <Tabs>
-      <TabItem label="Simple product">
-        ```graphql
-        products(skus: [$sku]) {
-            externalId
-            sku
-            name
-            description
-            shortDescription
-            urlKey
-            inStock
-            metaTitle
-            metaKeyword
-            metaDescription
-            images(roles: []) {
-              url
-              label
-              roles
-            }
-            attributes(roles: []) {
-              name
-              label
-              value
-              roles
-            }
-            ... on SimpleProductView {
-              price {
-                ...priceFields
-              }
-            }
-            ... on ComplexProductView {
-              options {
-                id
-                title
-                required
-                values {
-                  id
-                  title
-                  inStock
-                  ... on ProductViewOptionValueSwatch {
-                    type
-                    value
-                  }
-                }
-              }
-              priceRange {
-                maximum {
-                  ...priceFields
-                }
-                minimum {
-                  ...priceFields
-                }
-              }
-            }
-          }
-          }
-          fragment priceFields on ProductViewPrice {
-          roles
-          regular {
-            amount {
-              currency
-              value
-            }
-          }
-          final {
-            amount {
-              currency
-              value
-            }
-          }
-          }
-        ```
-      </TabItem>
-      <TabItem label="Configurable product">
-        ```graphql
-        products(skus: [$sku]) {
-            externalId
-            sku
-            name
-            description
-            shortDescription
-            urlKey
-            inStock
-            metaTitle
-            metaKeyword
-            metaDescription
-            images(roles: []) {
-              url
-              label
-              roles
-            }
-            attributes(roles: []) {
-              name
-              label
-              value
-              roles
-            }
-            ... on SimpleProductView {
-              price {
-                ...priceFields
-              }
-            }
-            ... on ComplexProductView {
-              options {
-                id
-                title
-                required
-                values {
-                  id
-                  title
-                  inStock
-                  ... on ProductViewOptionValueSwatch {
-                    type
-                    value
-                  }
-                }
-              }
-              priceRange {
-                maximum {
-                  ...priceFields
-                }
-                minimum {
-                  ...priceFields
-                }
-              }
-            }
-          }
-          }
-          fragment priceFields on ProductViewPrice {
-          roles
-          regular {
-            amount {
-              currency
-              value
-            }
-          }
-          final {
-            amount {
-              currency
-              value
-            }
-          }
-          }
-        ```
-      </TabItem>
-      <TabItem label="Bundle product">
-        ```graphql
-        products(skus: [$sku]) {
-            externalId
-            sku
-            name
-            description
-            shortDescription
-            urlKey
-            inStock
-            metaTitle
-            metaKeyword
-            metaDescription
-            images(roles: []) {
-              url
-              label
-              roles
-            }
-            attributes(roles: []) {
-              name
-              label
-              value
-              roles
-            }
-            ... on SimpleProductView {
-              price {
-                ...priceFields
-              }
-            }
-            ... on ComplexProductView {
-              options {
-                id
-                title
-                required
-                values {
-                  id
-                  title
-                  inStock
-                  ... on ProductViewOptionValueSwatch {
-                    type
-                    value
-                  }
-                }
-              }
-              priceRange {
-                maximum {
-                  ...priceFields
-                }
-                minimum {
-                  ...priceFields
-                }
-              }
-            }
-          }
-          }
-          fragment priceFields on ProductViewPrice {
-          roles
-          regular {
-            amount {
-              currency
-              value
-            }
-          }
-          final {
-            amount {
-              currency
-              value
-            }
-          }
-          }
-        ```
-      </TabItem>
-    </Tabs>
-  
-1. Slots?
+The Catalog Service GraphQL API schema reduces the diversity of product types to two classes:
+
+- Simple products are products that are defined with a single price and quantity. Catalog Service maps the simple, virtual, downloadable, and gift card product types to [`simpleProductViews`](https://developer.adobe.com/commerce/services/graphql/catalog-service/products/#return-details-about-a-simple-product).
+- Complex products are comprised of multiple simple products. The component simple products can have different prices. A complex product can also be defined so that the shopper can specify the quantity of component simple products. Catalog Service maps the configurable, bundle, and grouped product types to [`complexProductViews`](https://developer.adobe.com/commerce/services/graphql/catalog-service/products/#return-details-about-a-complex-product).
+
+<Aside type="tip" title="Pro tip!">
+  Go to the [Commerce APIs Playground](https://experienceleague.adobe.com/developer/commerce/storefront/playgrounds/commerce-services/) and run the `product` query to see the product data structure for different product types.
+</Aside>

--- a/src/content/docs/dropins/product-details/index.mdx
+++ b/src/content/docs/dropins/product-details/index.mdx
@@ -17,7 +17,7 @@ import Tasks from '@components/Tasks.astro';
 
 The Product Details Page (PDP) dropin renders detailed information about your products, including descriptions, specifications, options, pricing, and images.
 
-The practical application of rendering different product types is to provide a consistent user experience across different products. For example, a simple product can be rendered with a single price and quantity, while a complex product can be rendered with multiple simple products and different prices. This flexibility allows you to showcase a wide range of products in a consistent and user-friendly manner. These product types allow you to cater to diverse customer needs, streamline operations, and enhance the shopping experience.
+The practical application of rendering different product types is to provide a consistent user experience across different products. For example, a simple product can be rendered with a single price and quantity, while a complex product can be rendered with multiple options; their combination resulting in product variants. This flexibility allows you to showcase a wide range of products in a consistent and user-friendly manner. These product types allow you to cater to diverse customer needs, streamline operations, and enhance the shopping experience.
 
 ## Use cases
 

--- a/src/content/docs/dropins/product-details/index.mdx
+++ b/src/content/docs/dropins/product-details/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: Product Details Page overview
-description: Learn about the parts and usages for the Product Details dropin.
+description: Learn about the parts and usages of the Product Details dropin.
 sidebar:
   label: PDP Overview
   order: 1
@@ -15,48 +15,31 @@ import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 import Task from '@components/Task.astro';
 import Tasks from '@components/Tasks.astro';
 
-The Product Details Page (PDP) dropin provides a variety of fully-customizable controls to help you showcase your products, including image carousels, thumbnails, pricing, descriptions, and more.
+The Product Details Page (PDP) dropin renders detailed information about your products, including descriptions, specifications, options, pricing, and images.
 
-## Anatomy
-
-<Diagram caption="PDP slots">![PDP example](@images/slots/pdp-slots.webp)</Diagram>
+The practical application of rendering different product types is to provide a consistent user experience across different products. For example, a simple product can be rendered with a single price and quantity, while a complex product can be rendered with multiple simple products and different prices. This flexibility allows you to showcase a wide range of products in a consistent and user-friendly manner. These product types allow you to cater to diverse customer needs, streamline operations, and enhance the shopping experience.
 
 ## Use cases
 
-The PDP dropin allows you to showcase your products according to your brand's aesthetics and user experience goals. Use cases include:
+The PDP dropin provides a variety of fully-customizable controls to showcase your products according to your brand's aesthetics and build interactive experiences that engage customers. Use cases include:
 
 - **Image Carousel**: Display multiple product images in a carousel format, allowing users to view different angles and details of the product.
 - **Product Information**: Showcase detailed product information, including pricing, descriptions, and specifications.
 - **Product Variants**: Display different product variants, such as colors, sizes, and styles, allowing users to select the option that best fits their needs.
 - **Product Reviews**: Include user reviews and ratings to provide social proof and help users make informed purchasing decisions.
-- **Product Recommendations**: Suggest related products or accessories to encourage users to explore additional items.
 - **Customization Options**: Customize the appearance and behavior of the dropin to align with your brand's design aesthetic and user experience goals.
-- **Render product types**: Render simple or complex product types to enhance shopper experience.
 
-### Render product types
+## Anatomy
 
-The PDP dropin supports rendering different product types configured in your Adobe Commerce instance by default (for example, simple, configurable, and bundle) using data provided by the [Catalog Service GraphQL API](https://developer.adobe.com/commerce/services/graphql/catalog-service/).
+<Diagram caption="PDP slots">![PDP example](@images/slots/pdp-slots.webp)</Diagram>
 
-The practical application of rendering different product types is to provide a consistent user experience across different products. For example, a simple product can be rendered with a single price and quantity, while a complex product can be rendered with multiple simple products and different prices. This flexibility allows you to showcase a wide range of products in a consistent and user-friendly manner. These product types allow you to cater to diverse customer needs, streamline operations, and enhance the shopping experience.
+## Render product types
 
-The following table describes the different product types, their definitions, use cases, and benefits:
+The PDP dropin supports rendering different product types configured in your Adobe Commerce instance by default using data provided by the [Catalog Service GraphQL API](https://developer.adobe.com/commerce/services/graphql/catalog-service/). Adobe Commerce supports seven product types, but the Catalog Service GraphQL API schema maps these to two types:
 
-| **Product type**       | **Definition**                                | **Use case**                                                                 | **Benefits**                                                                 |
-|------------------------|-----------------------------------------------|------------------------------------------------------------------------------|------------------------------------------------------------------------------|
-| [**Simple Products**](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/products/types/product-create-simple)    | Single items with no variations               | Ideal for straightforward products like books, electronics, or groceries     | Easy to manage, quick to set up, suitable for products with consistent attributes |
-| [**Configurable Products**](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/products/types/product-create-configurable) | Products with multiple variations (e.g., size, color) | Perfect for apparel, footwear, and accessories where customers need to choose specific attributes | Enhances customer experience by offering choices, reduces the need for multiple product listings, simplifies inventory management |
-| [**Bundle Products**](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/products/types/product-create-bundle)    | A combination of multiple products sold together | Common in promotions, gift sets, or kits (e.g., skincare sets, computer accessories) | Increases average order value, encourages the sale of complementary products, provides convenience to customers |
-| [**Grouped Products**](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/products/types/product-create-grouped)   | A collection of related products displayed together | Suitable for items that are often bought together, like furniture sets or toolkits | Simplifies the shopping process, promotes cross-selling, enhances the overall shopping experience |
-| [**Virtual Products**](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/products/types/product-create-virtual)   | Non-tangible items like services or digital downloads | Ideal for software, e-books, online courses, or subscriptions                | No inventory management, instant delivery, scalable sales                    |
-| [**Downloadable Products**](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/products/types/product-create-downloadable) | Digital products that customers can download | Suitable for music, videos, software, or e-books                             | Immediate access for customers, no shipping costs, easy to distribute        |
+- _Simple products_ are products that are defined with a single price and quantity. Catalog Service maps the simple, virtual, downloadable, and gift card product types to [`simpleProductViews`](https://developer.adobe.com/commerce/services/graphql/catalog-service/products/#return-details-about-a-simple-product).
+- _Complex products_ are comprised of multiple simple products. The component simple products can have different prices. A complex product can also be defined so that the shopper can specify the quantity of component simple products. Catalog Service maps the configurable, bundle, and grouped product types to [`complexProductViews`](https://developer.adobe.com/commerce/services/graphql/catalog-service/products/#return-details-about-a-complex-product).
 
-#### Simple and complex products
-
-The Catalog Service GraphQL API schema reduces the diversity of product types to two classes:
-
-- Simple products are products that are defined with a single price and quantity. Catalog Service maps the simple, virtual, downloadable, and gift card product types to [`simpleProductViews`](https://developer.adobe.com/commerce/services/graphql/catalog-service/products/#return-details-about-a-simple-product).
-- Complex products are comprised of multiple simple products. The component simple products can have different prices. A complex product can also be defined so that the shopper can specify the quantity of component simple products. Catalog Service maps the configurable, bundle, and grouped product types to [`complexProductViews`](https://developer.adobe.com/commerce/services/graphql/catalog-service/products/#return-details-about-a-complex-product).
-
-<Aside type="tip" title="Pro tip!">
-  Go to the [Commerce APIs Playground](https://experienceleague.adobe.com/developer/commerce/storefront/playgrounds/commerce-services/) and run the `product` query to see the product data structure for different product types.
-</Aside>
+  <Aside type="tip" title="Pro tip!">
+    Go to the [Commerce APIs Playground](https://experienceleague.adobe.com/developer/commerce/storefront/playgrounds/commerce-services/) and run the `product` query to see the product data structure for different product types.
+  </Aside>

--- a/src/content/docs/dropins/product-details/index.mdx
+++ b/src/content/docs/dropins/product-details/index.mdx
@@ -6,15 +6,19 @@ sidebar:
   order: 1
 ---
 
-import Diagram from '@components/Diagram.astro';
-import Callouts from '@components/Callouts.astro';
 import Aside from '@components/Aside.astro';
+import Callouts from '@components/Callouts.astro';
+import Diagram from '@components/Diagram.astro';
+import { Image } from 'astro:assets';
+import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
+import Task from '@components/Task.astro';
+import Tasks from '@components/Tasks.astro';
 
 The Product Details Page (PDP) dropin provides a variety of fully-customizable controls to help you showcase your products, including image carousels, thumbnails, pricing, descriptions, and more.
 
-## Features
+## Use cases
 
-The Product Details Page allows you to showcase your products according to your brand's aesthetics and user experience goals. Dropin features include:
+The Product Details Page allows you to showcase your products according to your brand's aesthetics and user experience goals. Use cases include:
 
 - **Image Carousel**: Display multiple product images in a carousel format, allowing users to view different angles and details of the product.
 - **Product Information**: Showcase detailed product information, including pricing, descriptions, and specifications.
@@ -22,13 +26,237 @@ The Product Details Page allows you to showcase your products according to your 
 - **Product Reviews**: Include user reviews and ratings to provide social proof and help users make informed purchasing decisions.
 - **Product Recommendations**: Suggest related products or accessories to encourage users to explore additional items.
 - **Customization Options**: Customize the appearance and behavior of the dropin to align with your brand's design aesthetic and user experience goals.
+- **Render different product types**: Render different product types, such as simple, configurable, and bundle products.
 
 ## Anatomy
 
-The Product Details Page consists of the following prerequisites and components:
-
-<Diagram>![PDP Anatomy](@images/placeholder.webp)</Diagram>
-
-## Examples
-
 <Diagram caption="PDP slots">![PDP example](@images/slots/pdp-slots.webp)</Diagram>
+
+## Render product types
+
+The Product Details Page dropin supports rendering different product types, such as simple, configurable, and bundle products. You can customize the dropin to display the appropriate product information based on the product type.
+
+1. Follow the [installation](pdp-installation) instructions to get the latest version of the PDP dropin.
+
+1. Functions - is there where the graphql query goes?
+
+    <Tabs>
+      <TabItem label="Simple product">
+        ```graphql
+        products(skus: [$sku]) {
+            externalId
+            sku
+            name
+            description
+            shortDescription
+            urlKey
+            inStock
+            metaTitle
+            metaKeyword
+            metaDescription
+            images(roles: []) {
+              url
+              label
+              roles
+            }
+            attributes(roles: []) {
+              name
+              label
+              value
+              roles
+            }
+            ... on SimpleProductView {
+              price {
+                ...priceFields
+              }
+            }
+            ... on ComplexProductView {
+              options {
+                id
+                title
+                required
+                values {
+                  id
+                  title
+                  inStock
+                  ... on ProductViewOptionValueSwatch {
+                    type
+                    value
+                  }
+                }
+              }
+              priceRange {
+                maximum {
+                  ...priceFields
+                }
+                minimum {
+                  ...priceFields
+                }
+              }
+            }
+          }
+          }
+          fragment priceFields on ProductViewPrice {
+          roles
+          regular {
+            amount {
+              currency
+              value
+            }
+          }
+          final {
+            amount {
+              currency
+              value
+            }
+          }
+          }
+        ```
+      </TabItem>
+      <TabItem label="Configurable product">
+        ```graphql
+        products(skus: [$sku]) {
+            externalId
+            sku
+            name
+            description
+            shortDescription
+            urlKey
+            inStock
+            metaTitle
+            metaKeyword
+            metaDescription
+            images(roles: []) {
+              url
+              label
+              roles
+            }
+            attributes(roles: []) {
+              name
+              label
+              value
+              roles
+            }
+            ... on SimpleProductView {
+              price {
+                ...priceFields
+              }
+            }
+            ... on ComplexProductView {
+              options {
+                id
+                title
+                required
+                values {
+                  id
+                  title
+                  inStock
+                  ... on ProductViewOptionValueSwatch {
+                    type
+                    value
+                  }
+                }
+              }
+              priceRange {
+                maximum {
+                  ...priceFields
+                }
+                minimum {
+                  ...priceFields
+                }
+              }
+            }
+          }
+          }
+          fragment priceFields on ProductViewPrice {
+          roles
+          regular {
+            amount {
+              currency
+              value
+            }
+          }
+          final {
+            amount {
+              currency
+              value
+            }
+          }
+          }
+        ```
+      </TabItem>
+      <TabItem label="Bundle product">
+        ```graphql
+        products(skus: [$sku]) {
+            externalId
+            sku
+            name
+            description
+            shortDescription
+            urlKey
+            inStock
+            metaTitle
+            metaKeyword
+            metaDescription
+            images(roles: []) {
+              url
+              label
+              roles
+            }
+            attributes(roles: []) {
+              name
+              label
+              value
+              roles
+            }
+            ... on SimpleProductView {
+              price {
+                ...priceFields
+              }
+            }
+            ... on ComplexProductView {
+              options {
+                id
+                title
+                required
+                values {
+                  id
+                  title
+                  inStock
+                  ... on ProductViewOptionValueSwatch {
+                    type
+                    value
+                  }
+                }
+              }
+              priceRange {
+                maximum {
+                  ...priceFields
+                }
+                minimum {
+                  ...priceFields
+                }
+              }
+            }
+          }
+          }
+          fragment priceFields on ProductViewPrice {
+          roles
+          regular {
+            amount {
+              currency
+              value
+            }
+          }
+          final {
+            amount {
+              currency
+              value
+            }
+          }
+          }
+        ```
+      </TabItem>
+    </Tabs>
+  
+1. Slots?

--- a/src/content/docs/dropins/product-details/pdp-containers.mdx
+++ b/src/content/docs/dropins/product-details/pdp-containers.mdx
@@ -28,7 +28,7 @@ The Product Details Page provides the following configuration options:
     ['hideDescription', 'boolean', 'No', 'Hides the description if set to true.'],
     ['hideAttributes', 'boolean', 'No', 'Hides the attributes if set to true.'],
     ['hideURLParams', 'boolean', 'No', 'Disables synchronization of options with URL parameters if true.'],
-    ['initialData', 'ProductModel', 'No', 'Optional initial product data to preload the component.'],
+    ['productData', 'ProductModel', 'No', 'Optional initial product data to preload the component.'],
     ['slots', 'object', 'No', 'An object containing slot overrides for customizing various parts of the component display.'],
     ['carousel', 'CarouselConfig', 'No', 'Configuration for the product image carousel display.'],
     ['onAddToCart', 'function', 'No', 'Callback function triggered upon adding the product to the cart.'],
@@ -45,9 +45,9 @@ The `sku` property is the only required configuration. It's a string that unique
 
 The hide options (`hideSku`, `hideQuantity`, and the others) let you hide the parts of the Product Details UI that are not relevant for your storefront. These properties are optional and default to `false`.
 
-## initalData
+## Product Data
 
-The `initialData` property is an optional object that contains the initial product data to preload the component. The object should follow the `ProductModel` interface:
+The `productData` property is an optional object that contains the initial product data to preload the component. The object should follow the `ProductModel` interface:
 
 ```ts
 interface ProductModel {
@@ -133,11 +133,11 @@ onAddToCart: (values) => void;
 This property can take one of two string values: `zoom` or `overlay`. It is used to enhance product image viewing by providing zoom or overlay functionality:
 
 - `overlay` (_default_): Provides a larger, distraction-free view of a product image. The clicked image is opened in full screen.
-- `zoom`: Provides a close-up view of the product's image in the carousel. The clicked image is not opened in full screen.
+- `zoom`: Provides a close-up view of the product's image in the gallery. The clicked image is not opened in full screen.
 
 ## closeButton
 
-This property is a boolean that controls the visibility of a close button on modals and overlays. It can only be used in combination with `zoomType`. The default value is `false`. If `true`, the close button is shown; if `false` or not provided, the close button is not shown.
+This property is a boolean that can only be used in combination with the `zoomType` property. The default value is `false`. If `true`, the close button is shown; if `false` or not provided, the close button is not shown.
 
 ## Example configuration
 

--- a/src/content/docs/dropins/product-details/pdp-containers.mdx
+++ b/src/content/docs/dropins/product-details/pdp-containers.mdx
@@ -28,7 +28,7 @@ The Product Details Page provides the following configuration options:
     ['hideDescription', 'boolean', 'No', 'Hides the description if set to true.'],
     ['hideAttributes', 'boolean', 'No', 'Hides the attributes if set to true.'],
     ['hideURLParams', 'boolean', 'No', 'Disables synchronization of options with URL parameters if true.'],
-    ['productData', 'ProductModel', 'No', 'Optional initial product data to preload the component.'],
+    ['initialData', 'ProductModel', 'No', 'Optional initial product data to preload the component.'],
     ['slots', 'object', 'No', 'An object containing slot overrides for customizing various parts of the component display.'],
     ['carousel', 'CarouselConfig', 'No', 'Configuration for the product image carousel display.'],
     ['onAddToCart', 'function', 'No', 'Callback function triggered upon adding the product to the cart.'],
@@ -45,9 +45,9 @@ The `sku` property is the only required configuration. It's a string that unique
 
 The hide options (`hideSku`, `hideQuantity`, and the others) let you hide the parts of the Product Details UI that are not relevant for your storefront. These properties are optional and default to `false`.
 
-## ProductData
+## initalData
 
-The `productData` property is an optional object that contains the initial product data to preload the component. The object should follow the `ProductModel` interface:
+The `initialData` property is an optional object that contains the initial product data to preload the component. The object should follow the `ProductModel` interface:
 
 ```ts
 interface ProductModel {
@@ -132,12 +132,12 @@ onAddToCart: (values) => void;
 
 This property can take one of two string values: `zoom` or `overlay`. It is used to enhance product image viewing by providing zoom or overlay functionality:
 
-- `zoom`: Provides a close-up view of product details.
-- `overlay`: Provides a larger, distraction-free view of a product image.
+- `overlay` (_default_): Provides a larger, distraction-free view of a product image. The clicked image is opened in full screen.
+- `zoom`: Provides a close-up view of the product's image in the carousel. The clicked image is not opened in full screen.
 
 ## closeButton
 
-This property is a boolean that controls the visibility of a close button on modals and overlays. If `true`, the close button is shown; if `false` or not provided, the close button is not shown.
+This property is a boolean that controls the visibility of a close button on modals and overlays. It can only be used in combination with `zoomType`. The default value is `false`. If `true`, the close button is shown; if `false` or not provided, the close button is not shown.
 
 ## Example configuration
 
@@ -147,7 +147,7 @@ The following example demonstrates how to configure the Product Details containe
 return productRenderer.render(ProductDetails, {
   sku: yourGetSkuFetchFunction(),
   hideSku: false,
-  productData: {
+  initialData: {
     name: 'Product Name',
     sku: '12345',
     addToCartAllowed: false;

--- a/src/content/docs/dropins/product-details/pdp-containers.mdx
+++ b/src/content/docs/dropins/product-details/pdp-containers.mdx
@@ -23,35 +23,17 @@ The Product Details Page provides the following configuration options:
     ['sku', 'string', 'Yes', 'The unique identifier for the product.'],
     ['hideSku', 'boolean', 'No', 'Optional boolean to hide the SKU display.'],
     ['hideQuantity', 'boolean', 'No', 'Hides the quantity selector if set to true.'],
-    ['hideSelectedOptionValue', 'boolean', 'Hides the selected values of the option.'],
+    ['hideSelectedOptionValue', 'boolean', 'No', 'Hides the selected values of the option.'],
     ['hideShortDescription', 'boolean', 'No', 'Hides the short description if set to true.'],
     ['hideDescription', 'boolean', 'No', 'Hides the description if set to true.'],
     ['hideAttributes', 'boolean', 'No', 'Hides the attributes if set to true.'],
-    [
-      'hideURLParams',
-      'boolean',
-      'No',
-      'Disables synchronization of options with URL parameters if true.',
-    ],
-    [
-      'productData',
-      'ProductModel',
-      'No',
-      'Optional initial product data to preload the component.',
-    ],
-    [
-      'slots',
-      'object',
-      'No',
-      'An object containing slot overrides for customizing various parts of the component display.',
-    ],
+    ['hideURLParams', 'boolean', 'No', 'Disables synchronization of options with URL parameters if true.'],
+    ['productData', 'ProductModel', 'No', 'Optional initial product data to preload the component.'],
+    ['slots', 'object', 'No', 'An object containing slot overrides for customizing various parts of the component display.'],
     ['carousel', 'CarouselConfig', 'No', 'Configuration for the product image carousel display.'],
-    [
-      'onAddToCart',
-      'function',
-      'No',
-      'Callback function triggered upon adding the product to the cart.',
-    ],
+    ['onAddToCart', 'function', 'No', 'Callback function triggered upon adding the product to the cart.'],
+    ['zoomType', 'string', 'No', 'Specifies the type of zoom functionality for a product image. Options: "zoom" or "overlay".'],
+    ['closeButton', 'boolean', 'No', 'Indicates whether a close button should be displayed.'],
   ]}
 />
 
@@ -74,6 +56,9 @@ interface ProductModel {
   addToCartAllowed: boolean;
   inStock: boolean | null;
   shortDescription?: string;
+  metaDescription?: string;
+  metaKeyword?: string;
+  metaTitle?: string;
   description?: string;
   images?: Image[];
   prices: Prices;
@@ -83,6 +68,8 @@ interface ProductModel {
   url?: string;
   urlKey?: string;
   externalId?: string;
+  externalParentId?: string;
+  variantSku?: string;
 }
 ```
 
@@ -132,7 +119,7 @@ interface CarouselConfig {
 
 The [Example configuration](#example-configuration) section shows a usage example for `carousel`.
 
-### onAddToCart
+## onAddToCart
 
 Triggered when the Add to Cart button is clicked. Receives an object with `sku`, `quantity`, and optionally `optionsUIDs` reflecting the user's selection.
 
@@ -140,6 +127,17 @@ Triggered when the Add to Cart button is clicked. Receives an object with `sku`,
 // values: Values { sku: string, quantity: number, optionsUIDs: string[] }
 onAddToCart: (values) => void;
 ```
+
+## zoomType
+
+This property can take one of two string values: `zoom` or `overlay`. It is used to enhance product image viewing by providing zoom or overlay functionality:
+
+- `zoom`: Provides a close-up view of product details.
+- `overlay`: Provides a larger, distraction-free view on a product image.
+
+## closeButton
+
+This property is a boolean that controls the visibility of a close button on modals and overlays. If `true`, the close button is shown; if `false` or not provided, the close button is not shown.
 
 ## Example configuration
 

--- a/src/content/docs/dropins/product-details/pdp-containers.mdx
+++ b/src/content/docs/dropins/product-details/pdp-containers.mdx
@@ -133,7 +133,7 @@ onAddToCart: (values) => void;
 This property can take one of two string values: `zoom` or `overlay`. It is used to enhance product image viewing by providing zoom or overlay functionality:
 
 - `zoom`: Provides a close-up view of product details.
-- `overlay`: Provides a larger, distraction-free view on a product image.
+- `overlay`: Provides a larger, distraction-free view of a product image.
 
 ## closeButton
 
@@ -179,6 +179,8 @@ return productRenderer.render(ProductDetails, {
     imageParams: ResolveImageUrlOptions,
     thumbnailParams: ResolveImageUrlOptions,
   },
+  zoomType: 'zoom',
+  closeButton: true,
   slots: {
     // See all PDP slots in the next section
     Title: { },

--- a/src/content/docs/dropins/product-details/pdp-functions.mdx
+++ b/src/content/docs/dropins/product-details/pdp-functions.mdx
@@ -21,12 +21,12 @@ getProductData(sku: string);
 
 ## getRefinedProduct
 
-A function that returns refined product's data. It takes `sku` and `optionUIDs` as parameters.
+A function that returns refined product's data. It takes `sku`, `optionUIDs`, and `isBundle?` as parameters.
 
 ```js
 import { getRefinedProduct } from '@/pdp/api/getRefinedProduct';
 
-getRefinedProduct(sku: string, optionUIDs: string[]);
+getRefinedProduct(sku: string, optionUIDs: string, isBundle?: boolean[]);
 ```
 
 ## Example usage

--- a/src/content/docs/dropins/product-details/pdp-styles.mdx
+++ b/src/content/docs/dropins/product-details/pdp-styles.mdx
@@ -11,6 +11,7 @@ import overlay from './files/overlay.css?raw';
 import priceRange from './files/price-range.css?raw';
 import product from './files/product.css?raw';
 import swatches from './files/swatches.css?raw';
+import zoom from './files/zoom.css?raw';
 
 import CodeImport from '@components/CodeImport.astro';
 import Diagram from '@components/Diagram.astro';
@@ -28,6 +29,7 @@ Product Details (like most other dropins) contains several components that provi
 @import 'price-range.css';
 @import 'product.css';
 @import 'swatches.css';
+@import 'zoom.css';
 ```
 
 :::
@@ -81,6 +83,8 @@ The CSS classes for each PDP Component are provided here.
 <CodeImport code={priceRange} title="PriceRange.css" lang="css" frame="none" />
 
 <CodeImport code={swatches} title="Swatches.css" lang="css" frame="none" />
+
+<CodeImport code={zoom} title="Zoom.css" lang="css" frame="none" />
 
 ## Summary
 


### PR DESCRIPTION
This pull request (PR) adds the following as described in DATA-5753:

- New `zoomType` and `closeButton` PDP container configuration options (DATA-5317)
- New CSS file for zoom functionality
- New use cases section with practical application of rendering product types

It also updates the `ProductModel` interface to match the latest from the code.

## Preview

https://commerce-docs.github.io/microsite-commerce-storefront/dropins/product-details/#use-cases