### PR TITLE
chore: update launch script for analytics

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -37,7 +37,7 @@ export default defineConfig({
       head: [{
         tag: 'script',
         attrs: {
-          src: 'https://assets.adobedtm.com/a7d65461e54e/6e9802a06173/launch-43baf8381f4b.min.js'
+          src: 'https://assets.adobedtm.com/d4d114c60e50/9f881954c8dc/launch-7a902c4895c3.min.js" async'
         }
       }, {
         tag: 'meta',


### PR DESCRIPTION
The ExL team changed the script for analytics recently. This should resolve the discrepancy in data we're seeing across the AMC and Adobe Corp org report suites.

See UGP-11309 for an example of how this was applied to the QPT microsite about a month ago.