### PR TITLE
docs: align PDP overview with template

### DIFF
--- a/src/content/docs/dropins/product-details/index.mdx
+++ b/src/content/docs/dropins/product-details/index.mdx
@@ -1,9 +1,6 @@
 ---
 title: Product Details Page overview
-description: Learn about the parts and usages of the Product Details dropin.
-sidebar:
-  label: PDP Overview
-  order: 1
+description: Learn about the purpose, features, and use cases of the Product Details Page dropin.
 ---
 
 import Aside from '@components/Aside.astro';
@@ -28,10 +25,6 @@ The PDP dropin provides a variety of fully-customizable controls to showcase you
 - **Product Variants**: Display different product variants, such as colors, sizes, and styles, allowing users to select the option that best fits their needs.
 - **Product Reviews**: Include user reviews and ratings to provide social proof and help users make informed purchasing decisions.
 - **Customization Options**: Customize the appearance and behavior of the dropin to align with your brand's design aesthetic and user experience goals.
-
-## Anatomy
-
-<Diagram caption="PDP slots">![PDP example](@images/slots/pdp-slots.webp)</Diagram>
 
 ## Render product types
 


### PR DESCRIPTION
This pull request aligns the PDP dropin [overview](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/product-details/) with the new [template](https://github.com/commerce-docs/microsite-commerce-storefront/blob/develop/_dropin-templates/dropin-overview.mdx).