### PR TITLE
docs: rewrite generic dropin install

### DIFF
--- a/src/content/docs/dropins/all/branding.mdx
+++ b/src/content/docs/dropins/all/branding.mdx
@@ -173,10 +173,6 @@ Use the same process for overriding the spacing, shapes, grids, and color token 
 </Task>
 </Tasks>
 
-## Video
-
-## Playground
-
 ## Summary
 
 The process of branding dropins is typically fast and easy. Focus on one brand category at a time and work with your designers to solve the less obvious brand-to-token overrides.

--- a/src/content/docs/dropins/all/extending.mdx
+++ b/src/content/docs/dropins/all/extending.mdx
@@ -44,6 +44,3 @@ Component that provides placeholders to add other components. You can use a drop
 Overloaded term in web development. Everything is a component. It's components all the way down. This is why we need to be specific about what kind of component we are talking about. For example, from top-to-bottom, big-to-small, a **dropin component** can contain multiple **container components** that can contain multiple **slot components** that can contain multiple **UI components**.
 
 </Vocabulary>
-
-## Examples
-

--- a/src/content/docs/dropins/all/installing.mdx
+++ b/src/content/docs/dropins/all/installing.mdx
@@ -1,10 +1,6 @@
 ---
 title: Installing dropins
-description: Learn how to install the Product Details dropin into your site.
-sidebar:
-  order: 2
-
-base: /developer/commerce/storefront
+description: Learn about installing and initializing dropins for your site.
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
@@ -13,212 +9,21 @@ import Task from '@components/Task.astro';
 import Callouts from '@components/Callouts.astro';
 import Diagram from '@components/Diagram.astro';
 
-Our dropins are designed for the browser's JavaScript run-time without the need for a bundler. But they can also be installed and executed in a build-time environment with bundlers like Webpack and Vite. The installation steps for both run-time and build-time environments are the same after the initial dropin package imports.
+Dropins are designed for the browser's JavaScript run-time without the need for a bundler. But they can also be installed and executed in a build-time environment with bundlers like Webpack and Vite. The installation steps for both run-time and build-time environments are the same after the initial dropin package imports.
 
-## Prerequisites
+## Why install dropins?
 
-Before you install the Product Details dropin, ensure you have the following prerequisites:
+Installing dropins is essential for customizing and enhancing your Adobe Commerce storefront, especially if you choose not to start with the [boilerplate template](/get-started/#boilerplate-template). It is a strategic choice for businesses looking to customize, optimize, and scale their Adobe Commerce storefronts effectively. This approach provides the flexibility and modularity needed to create a unique and high-performing online shopping experience.
+
+If you have an existing storefront project and are not starting with the boilerplate template, you can install dropins individually to add the specific features that you need.
 
 ## Workflow
 
-The steps for installing the Product Details dropin are as follows:
+The following diagram provides an overview of the steps necessary for installing a dropin:
 
 <Diagram>![PDP Installation](@images/pdp/pdp-installation.svg)</Diagram>
 
-## Step-by-step
+The installation of all dropins follows the same pattern described in the workflow diagram above. Refer to the following resources for step-by-step instructions to install specific dropins:
 
-The following steps show how to install the Product Details dropin into your site.
-
-<Tasks>
-
-<Task>
-
-### Install the packages
-
-Use a CDN or NPM (recommended for performance) to install the dropin tools (`@dropins/tools`) and Product Details (`@dropins/storefront-pdp`) packages.
-
-<Tabs>
-  <TabItem label="NPM" icon="seti:npm">
-
-    ```bash frame="none"
-    npm install @dropins/tools @dropins/storefront-pdp
-    ```
-
-  </TabItem>
-  <TabItem label="CDN" icon="external">
-
-    ```html title="index.html" del={"Replace with actual URLs":5-7}
-    <head>
-      <meta charset="UTF-8">
-      <meta name="viewport" content="width=device-width, initial-scale=1.0">
-      <title>Your Storefront</title>
-
-      <script src="https://cdn.jsdelivr.net/npm/@dropins/tools@latest"></script>
-      <script src="https://cdn.jsdelivr.net/npm/@dropins/storefront-pdp@latest"></script>
-    </head>
-    ```
-
-  </TabItem>
-</Tabs>
-
-:::note[Install @dropins/tools]
-All dropins require the `@dropins/tools` package. This package contains the libraries that dropins need to initialize and communicate, including `fetch-graphql`, `event-bus`, and `initializer` utilities.
-:::
-
-</Task>
-
-<Task>
-### Map the packages
-
-In the `<head>` tag of your `index.html` or `head.html` file, use an `importmap` pointed to the `node_modules` directory, a **custom local directory**, or **CDN** (for run-time environments).
-
-<Tabs>
-<TabItem label="node_modules" icon="seti:npm">
-    This example shows an `importmap` added to a `head.html` The `importmap` points both packages to the local `node_modules` directory that contains your installed dropin files from the dropin tools (@dropins/tools) and the PDP dropin (@dropins/storefront-pdp):
-  
-  ```html title="head.html"
-  <script type="importmap">
-    {
-      "imports": {
-        "@dropins/tools/": "/node_modules/@dropins/tools/",
-        "@dropins/storefront-pdp/": "/node_modules/@dropins/storefront-pdp/",
-      }
-    }
-  </script>
-  <script src="/scripts/scripts.js" type="module"></script>
-    ```
-  </TabItem>
-    <TabItem label="custom" icon="seti:folder">
-    This example shows an `importmap` added to a `head.html` The `importmap` points both packages to local directories that contain all the optimized/minified files from the dropin tools (@dropins/tools) and the Product Details dropin (@dropins/storefront-pdp):
-
-    ```html title="head.html"
-    <script type="importmap">
-      {
-        "imports": {
-          "@dropins/tools/": "/scripts/__dropins__/tools/",
-          "@dropins/storefront-pdp/": "/scripts/__dropins__/storefront-pdp/",
-        }
-      }
-    </script>
-    <script src="/scripts/scripts.js" type="module"></script>
-    ```
-
-  </TabItem>
-  <TabItem label="CDN" icon="external">
-    This example shows an `importmap` pointing both packages to a CDN for the dropin tools (@dropins/tools) and the Product Details dropin (@dropins/storefront-pdp):
-
-    ```html title="index.html" {"Replace CDN URLs with correct URLs":5-7} del='https://cdn.jsdelivr.net/npm/'
-    <head>
-      <script type="importmap">
-        {
-          "imports": {
-
-            "@dropins/tools/": "https://cdn.jsdelivr.net/npm/@dropins/tools@latest",
-            "@dropins/storefront-pdp/": "https://cdn.jsdelivr.net/npm/@dropins/storefront-pdp@latest",
-          }
-        }
-      </script>
-    </head>
-    ```
-
-  </TabItem>
-
-</Tabs>
-
-With the `importmap` defined for both run-time and build-time environments, you can now **import the required files** from these packages into your PDP dropin JavaScript file as described in the next step.
-
-</Task>
-
-<Task>
-### Import the required files
-
-Import the required files from the dropins tools (`@dropin/tools/initializers.js`) and the Product Details dropin (`@dropins/storefront-pdp`) into a JavaScript file for your PDP dropin. The example here shows the imports added to a `product-details.js` file. These imports constitute the minimum imports you need to create a fully functioning Product Details dropin for your site:
-
-```js title="product-details.js"
-// Dropin Tools
-import { initializers } from '@dropins/tools/initializer.js';
-
-// Dropin Functions
-import * as product from '@dropins/storefront-pdp/api.js';
-
-// Dropin Provider
-import { render as productRenderer } from '@dropins/storefront-pdp/render.js';
-
-// Dropin Container
-import ProductDetails from '@dropins/storefront-pdp/containers/ProductDetails.js';
-```
-
-</Task>
-
-<Task>
-### Connect to the endpoint
-
-Connect your Product Details dropin to the Catalog Service GraphQL endpoint and set the required headers as shown in the example below. Replace the endpoint URL and header placeholder values with the actual values from your Commerce backend services:
-
-```js title="product-details.js"
-// Set endpoint configuration
-product.setEndpoint('https://<catalog-service-endpoint>/graphql');
-
-product.setFetchGraphQlHeaders({
-  // Environment required headers
-  'Magento-Environment-Id': 'your-environment-id',
-  'Magento-Store-View-Code': 'your-store-view-code',
-  'Magento-Website-Code': 'your-website-code',
-  'x-api-key': 'your-api-key',
-  'Magento-Store-Code': 'main_website_store',
-  'Magento-Customer-Group': 'your-customer-group',
-  'Content-Type': 'application/json',
-});
-```
-
-</Task>
-
-<Task>
-### Register and load the dropin
-
-The code below shows how to register the Product Details dropin, load it (mount), and enable the logger for debugging purposes. You can add these functions within a `<script>` tag in your Product Details HTML page as shown here:
-
-```html title="index.html" ins={"1":5} ins={"2":8}
-<script type="module">
-  // more code above...
-
-  // Register and load the Product Details dropin
-  initializers.register(pdp.initialize);
-
-  // Mount Initializers (must be called after all initializers are registered)
-  window.addEventListener('load', initializers.mount);
-</script>
-```
-
-<Callouts square color="var(--sl-color-green)">
-
-1. This function registers the Product Details dropin to be loaded on the page by the `initializers.mount` function.
-1. This event handler triggers the initializers.mount function to load the Product Details dropin after the page has loaded.
-
-</Callouts>
-
-</Task>
-
-<Task>
-### Render the dropin
-
-Render the Product Details dropin on the page. The example below provides the minimal configuration options required to render the default Product Details dropin:
-
-```js title="product-details.js"
-// Render Product Details
-productRenderer(ProductDetails, {
-  sku: 'SKU-001',
-  // other configuration options
-  // slots for adding custom elements, components, and functions
-})(document.getElementById('your-pdp-element'));
-```
-
-Test the Product Details dropin by viewing your PDP page in a browser, or running your local dev or build server. If you see the Product Details dropin rendered in the browser, congrats!, you have a successful installation. If not, check the console for any errors and verify that you have followed all the steps correctly.
-
-</Task>
-
-</Tasks>
-
-## Summary
-
-The installation of all dropins follows the same pattern demonstrated by installing the PDP dropin: Install, Map, Import, Connect, Register, and Render. We like to call the process `iMICRR` for short, pronounced `eye-mike-er`. Actually, we don't call it that, but if it helps...Enjoy!
+- [Product Details Page (PDP)](/dropins/product-details/pdp-installation)
+- [Cart](/dropins/cart/cart-installation)


### PR DESCRIPTION
This pull request (PR) revises the [generic dropin installation page](rewrite-dropin-install) to provide a high-level overview of why someone should install dropins and the general process for doing so.

>[!NOTE]
>It also removes empty sections.

This eliminates duplication of the [PDP install page](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/product-details/pdp-installation/) and provides a scalable path forward as we document the installation of other dropins (checkout, user account, user auth).

In future docs, we'll need to consider whether to provide examples for customizing dropins based on the boilerplate or non-boilerplate use case. I don't think we necessarily need both unless it's trivial effort to do so. 