### PR TITLE
Reference correct npm package for cart dropin in docs

### DIFF
--- a/src/content/docs/dropins/cart/cart-installation.mdx
+++ b/src/content/docs/dropins/cart/cart-installation.mdx
@@ -35,13 +35,13 @@ These steps are specific for EDS projects, and may not necessarily be the same f
 
 ### Install the packages
 
-Use a CDN or NPM (recommended for performance) to install the dropin tools (`@dropins/tools`) and Cart (`@dropins/cart`) packages.
+Use a CDN or NPM (recommended for performance) to install the dropin tools (`@dropins/tools`) and Cart (`@dropins/storefront-cart`) packages.
 
 <Tabs>
   <TabItem label="NPM" icon="seti:npm">
 
     ```bash frame="none"
-    npm install @dropins/tools @dropins/cart
+    npm install @dropins/tools @dropins/storefront-cart
     ```
 
   </TabItem>
@@ -54,7 +54,7 @@ Use a CDN or NPM (recommended for performance) to install the dropin tools (`@dr
       <title>Your Storefront</title>
 
       <script src="https://cdn.jsdelivr.net/npm/@dropins/tools@latest"></script>
-      <script src="https://cdn.jsdelivr.net/npm/@dropins/cart@latest"></script>
+      <script src="https://cdn.jsdelivr.net/npm/@dropins/storefront-cart@latest"></script>
     </head>
     ```
 
@@ -74,14 +74,14 @@ In the `<head>` tag of your `index.html` or `head.html` file, use an `importmap`
 
 <Tabs>
 <TabItem label="node_modules" icon="seti:npm">
-    This example shows an `importmap` added to a `head.html` The `importmap` points both packages to the local `node_modules` directory that contains your installed dropin files from the dropin tools (@dropins/tools) and the Cart dropin (@dropins/cart):
+    This example shows an `importmap` added to a `head.html` The `importmap` points both packages to the local `node_modules` directory that contains your installed dropin files from the dropin tools (@dropins/tools) and the Cart dropin (@dropins/storefront-cart):
   
   ```html title="head.html"
   <script type="importmap">
     {
       "imports": {
         "@dropins/tools/": "/node_modules/@dropins/tools/",
-        "@dropins/cart/": "/node_modules/@dropins/cart/",
+        "@dropins/storefront-cart/": "/node_modules/@dropins/storefront-cart/",
       }
     }
   </script>
@@ -89,14 +89,14 @@ In the `<head>` tag of your `index.html` or `head.html` file, use an `importmap`
     ```
   </TabItem>
     <TabItem label="custom" icon="seti:folder">
-    This example shows an `importmap` added to a `head.html` The `importmap` points both packages to local directories that contain all the optimized/minified files from the dropin tools (@dropins/tools) and the Cart dropin (@dropins/cart):
+    This example shows an `importmap` added to a `head.html` The `importmap` points both packages to local directories that contain all the optimized/minified files from the dropin tools (@dropins/tools) and the Cart dropin (@dropins/storefront-cart):
 
     ```html title="head.html"
     <script type="importmap">
       {
         "imports": {
           "@dropins/tools/": "/scripts/__dropins__/tools/",
-          "@dropins/cart/": "/scripts/__dropins__/storefront-cart/",
+          "@dropins/storefront-cart/": "/scripts/__dropins__/storefront-cart/",
         }
       }
     </script>
@@ -114,7 +114,7 @@ In the `<head>` tag of your `index.html` or `head.html` file, use an `importmap`
           "imports": {
 
             "@dropins/tools/": "https://cdn.jsdelivr.net/npm/@dropins/tools@latest",
-            "@dropins/cart/": "https://cdn.jsdelivr.net/npm/@dropins/cart@latest",
+            "@dropins/storefront-cart/": "https://cdn.jsdelivr.net/npm/@dropins/storefront-cart@latest",
           }
         }
       </script>
@@ -132,7 +132,7 @@ With the `importmap` defined for both runtime and build-time environments, you c
 <Task>
 ### Import the required files
 
-Import the required files from the dropins tools (`@dropins/tools/fetch-graphql.js'`, `@dropin/tools/initializers.js`) and the Cart dropin (`@dropins/cart`) into a JavaScript file for your Cart dropin. The example here shows the imports added to a `cart.js` file. These imports constitute the minimum imports you need to create a fully functioning Cart dropin for your site:
+Import the required files from the dropins tools (`@dropins/tools/fetch-graphql.js'`, `@dropin/tools/initializers.js`) and the Cart dropin (`@dropins/storefront-cart`) into a JavaScript file for your Cart dropin. The example here shows the imports added to a `cart.js` file. These imports constitute the minimum imports you need to create a fully functioning Cart dropin for your site:
 
 ```js title="cart.js"
 // GraphQL Client
@@ -142,14 +142,14 @@ import * as mesh from '@dropins/tools/fetch-graphql.js';
 import { initializers } from '@dropins/tools/initializer.js';
 
 // Dropin Functions
-import * as pkg from '@dropins/cart/api.js';
+import * as pkg from '@dropins/storefront-cart/api.js';
 
 // Dropin Provider
-import { render as provider } from '@dropins/cart/render.js';
+import { render as provider } from '@dropins/storefront-cart/render.js';
 
 // Dropin Containers
-import Cart from '@dropins/cart/containers/Cart.js';
-import MiniCart from '@dropins/cart/containers/MiniCart.js';
+import Cart from '@dropins/storefront-cart/containers/Cart.js';
+import MiniCart from '@dropins/storefront-cart/containers/MiniCart.js';
 ```
 
 <Vocabulary>
@@ -193,7 +193,7 @@ mesh.setEndpoint('https://<graphql-service-endpoint>/graphql');
 The Cart dropin does not need additional headers set for basic installation. But if you're looking to enable features for your dropin, the GraphQL request accepts additional headers. The below example shows how you could set the `Commerce-Auth` header with the customer token for the Authorization header, and how to set the store code header for store specific features. Replace the header values with the actual values from your Commerce backend services:
 
 ```js title="cart.js"
-// Set the customer token. This method is specific to @dropins/cart package.
+// Set the customer token. This method is specific to @dropins/storefront-cart package.
 pkg.setFetchGraphQlHeader('commerce-auth', '<token>');
 
 // Set store code header. This method is specific to the @dropins/tools package.


### PR DESCRIPTION
I was getting the following error when I tried to install the cart dropin

```
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@dropins%2fcart - Not found
npm error 404
npm error 404  '@dropins/cart@*' is not in this registry.
npm error 404
npm error 404 Note that you can also install from a
npm error 404 tarball, folder, http url, or git url.
```

When looking at npm this seem to the correct package:

https://www.npmjs.com/package/@dropins/storefront-cart

So i fixed all the references.