### PR TITLE
fix: correct Sidekick preview and publish instructions

### DIFF
--- a/src/content/docs/get-started/index.mdx
+++ b/src/content/docs/get-started/index.mdx
@@ -378,7 +378,7 @@ For this task, we'll use the **Sidekick Configurator** to install Sidekick and c
 1. Install Sidekick from the Chrome Web Store or use the bookmarklet. If you're using the bookmarklet, drag it to your browser's bookmarks bar. If installing the extension, Pin the Sidekick extension to your browser's toolbar.
 1. Select the browser's back button to return to the Sidekick Configurator page. You should now see a message stating "Your Sidekick is not configured for this project yet" and an **Add project** button.
 1. Select the **Add project** button to complete your Sidekick setup. You should see a message stating: "Your Sidekick is configured for this project."
-1. Return to your folder, select all your Google docs or Word.docx files, select the **Sidekick** extension, and click the **Preview** button. Repeat this for all files in each folder. Select all the files again, but select the **Publish** button for each docs/docx file. These actions add your content to the internal (preview) and production (publish) Edge Delivery CDNs, where it can be downloaded and displayed on your browser for local development.
+1. Return to your folder, select **ALL files** (including `.json` config files), select the **Sidekick** extension, and click the **Preview** button. Repeat this for all files in each folder. Select all the files again, but select the **Publish** button to publish these files to the CDN. These actions add your content to the internal (preview) and production (publish) Edge Delivery CDNs, where they can be downloaded and displayed in your browser for local development.
 
 </Callouts>
 
@@ -444,26 +444,24 @@ To access the `develop` branch of the boilerplate repo, follow these steps:
 
 1. Add the upstream boilerplate repo as a new remote:
 
-    ```bash frame="none"
-    git remote add upstream https://github.com/hlxsites/aem-boilerplate-commerce.git
-    ```
+   ```bash frame="none"
+   git remote add upstream https://github.com/hlxsites/aem-boilerplate-commerce.git
+   ```
 
 1. Fetch the upstream boilerplate repo:
 
-    ```bash frame="none"
-    git fetch upstream
-    ```
+   ```bash frame="none"
+   git fetch upstream
+   ```
 
 1. Checkout the `develop` branch of the upstream boilerplate repo:
 
-    ```bash frame="none"
-    git checkout develop
-    ```
+   ```bash frame="none"
+   git checkout develop
+   ```
 
 </Steps>
 
 </Task>
 
 </Tasks>
-
-


### PR DESCRIPTION
This PR fixes the incomplete instructions for previewing and publishing the files in the storefront content folders using the Sidekick extension. 