### PR TITLE
DATA-6181: PDP dropin initializer configuration

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -146,10 +146,11 @@ export default defineConfig({
           // },
           {
             label: 'Product Details Page',
-            collapsed: false,
+            collapsed: true,
             items: [
               { label: 'Overview', link: '/dropins/product-details/' },
               { label: 'PDP Installation', link: '/dropins/product-details/pdp-installation/' },
+              { label: 'PDP Initialization', link: '/dropins/product-details/pdp-initialization/' },
               { label: 'PDP Styles', link: '/dropins/product-details/pdp-styles/' },
               { label: 'PDP Containers', link: '/dropins/product-details/pdp-containers/' },
               { label: 'PDP Slots', link: '/dropins/product-details/pdp-slots/' },

--- a/src/content/docs/dropins/product-details/pdp-initialization.mdx
+++ b/src/content/docs/dropins/product-details/pdp-initialization.mdx
@@ -13,7 +13,7 @@ Customizing the PDP dropin initializers can help you meet your project requireme
 
 ## Configuration options
 
-The PDP dropin initializers allows you to define the language definitions, default locale, and models that your project will use.
+The PDP dropin initializers allow you to define the language definitions, default locale, and models that your project will use.
 
 <OptionsTable
   options={[
@@ -30,7 +30,7 @@ Models are used to define the data structure and initial data for the PDP dropin
 
 ## Example
 
-The following code shows the default implementation of the PDP dropin initializer in this Commerce boilerplate:
+The following code shows the default implementation of the PDP dropin initializer in the Commerce boilerplate:
 
 ```typescript
 // Define the models object with a ProductDetails property

--- a/src/content/docs/dropins/product-details/pdp-initialization.mdx
+++ b/src/content/docs/dropins/product-details/pdp-initialization.mdx
@@ -53,7 +53,7 @@ When a user navigates to the product detail page (PDP) on your site, you can set
 
 Default option selection is _not_ supported out-of-the-box for complex products. Instead, you must use [product attributes](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/product-attributes/product-attributes) and customize the PDP dropin initializers to define which attribute and value is used by default.
 
-If no option is defined as default in the Admin for the dropdown input type, the first listed option will be preselected by default. You can opt out of the preselection in the dropdown by providing a placeholder (for example, "Choose an option").
+If no option is defined as default in the Admin for the dropdown [input type](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/product-attributes/attributes-input-types), the first listed option will be preselected by default. You can opt out of the preselection in the dropdown by providing a placeholder (for example, "Choose an option").
 
 <Steps>
 
@@ -61,7 +61,11 @@ If no option is defined as default in the Admin for the dropdown input type, the
 
 1. Create a custom attribute (`default_options`) to define default options for each product.
 
-1. Ensure that the `default_options` attribute has been [exported](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/saas-data-export/overview) to the Catalog Service.
+   :::note
+   Be sure to set **Visible on Catalog Pages on Storefront** to _Yes_.
+   :::
+
+1. Ensure that the `default_options` attribute has been [exported](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/saas-data-export/overview) to the Catalog Service _and_ that the attribute's `roles` field includes `visible_in_pdp`. See the [`ProductViewAttribute`](https://developer.adobe.com/commerce/services/graphql/catalog-service/products/#productviewattribute-type) type documentation for details.
 
 1. Use the [`products`](https://developer.adobe.com/commerce/services/graphql/catalog-service/products/#return-details-about-a-complex-product) query to find the `id` of the `default_options` attribute for each product.
 

--- a/src/content/docs/dropins/product-details/pdp-initialization.mdx
+++ b/src/content/docs/dropins/product-details/pdp-initialization.mdx
@@ -9,11 +9,11 @@ import OptionsTable from '@components/OptionsTable.astro';
 import Aside from '@components/Aside.astro';
 import { Steps } from '@astrojs/starlight/components';
 
-Customizing the PDP dropin initializer can help you meet your project requirements and use cases.
+Customizing the PDP dropin initializers can help you meet your project requirements and use cases.
 
 ## Configuration options
 
-The PDP dropin initializer allows you to define the language definitions, default locale, and models that your project will use.
+The PDP dropin initializers allows you to define the language definitions, default locale, and models that your project will use.
 
 <OptionsTable
   options={[
@@ -49,13 +49,11 @@ initializers.register(productApi.initialize, {
 
 ## Set default product options
 
-When a user navigates to the product detail page (PDP) on your site, you can set certain options as preselected defaults. This use case allows merchandisers to set default options through the Adobe Commerce Admin, which provides a more customized and streamlined shopping experience.
+When a user navigates to the product detail page (PDP) on your site, you can set certain options as preselected defaults for complex products. This use case allows merchandisers to set default options through the Adobe Commerce Admin, which provides a more customized and streamlined shopping experience.
 
-* **Simple products**—Default option selection is supported out-of-the-box through the Admin (`isDefault`). No additional PDP dropin customization is required.
+Default option selection is _not_ supported out-of-the-box for complex products. Instead, you must use [product attributes](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/product-attributes/product-attributes) and customize the PDP dropin initializers to define which attribute and value is used by default.
 
-* **Complex products**—Default option selection is _not_ supported out-of-the-box. Instead, you must use [product attributes](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/product-attributes/product-attributes) and customize the PDP dropin initializers to define which attribute and value is used by default. If no option is defined as default, the first listed option will be preselected by default.
-
-This approach allows merchants to set different default selections for complex products in the Admin. Developers can then customize the PDP dropin to show the default or preselected options.
+If no option is defined as default in the Admin for the dropdown input type, the first listed option will be preselected by default. You can opt out of the preselection in the dropdown by providing a placeholder (for example, "Choose an option").
 
 <Steps>
 

--- a/src/content/docs/dropins/product-details/pdp-initialization.mdx
+++ b/src/content/docs/dropins/product-details/pdp-initialization.mdx
@@ -53,8 +53,6 @@ When a user navigates to the product detail page (PDP) on your site, you can set
 
 Default option selection is _not_ supported out-of-the-box for complex products. Instead, you must use [product attributes](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/product-attributes/product-attributes) and customize the PDP dropin initializers to define which attribute and value is used by default.
 
-If no option is defined as default in the Admin for the dropdown [input type](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/product-attributes/attributes-input-types), the first listed option will be preselected by default. You can opt out of the preselection in the dropdown by providing a placeholder (for example, "Choose an option").
-
 <Steps>
 
 1. Log in to the Adobe Commerce Admin.

--- a/src/content/docs/dropins/product-details/pdp-initialization.mdx
+++ b/src/content/docs/dropins/product-details/pdp-initialization.mdx
@@ -1,0 +1,96 @@
+---
+title: PDP dropin initialization
+description: Learn about the configuration options for the PDP initializer.
+---
+
+import Diagram from '@components/Diagram.astro';
+import Callouts from '@components/Callouts.astro';
+import OptionsTable from '@components/OptionsTable.astro';
+import Aside from '@components/Aside.astro';
+import { Steps } from '@astrojs/starlight/components';
+
+Customizing the PDP dropin initializer can help you meet your project requirements and use cases.
+
+## Configuration options
+
+The PDP dropin initializer allows you to define the language definitions, default locale, and models that your project will use.
+
+<OptionsTable
+  options={[
+    ['Option', 'Type', 'Req?', 'Description'],
+    ['langDefinitions', 'object', 'No', 'Provides language definitions for internationalization (i18n).'],
+    ['defaultLocale', 'string', 'No', 'Specifies the default locale. If not provided, defaults to en-US.'],
+    ['models', 'object', 'No', 'Defines the data structure and initial data. Options include initialData, transform, and fallBackData.'],
+  ]}
+/>
+
+:::note
+Models are used to define the data structure and initial data for the PDP dropin. The `initialData` object contains product details, options, and attributes.
+:::
+
+## Example
+
+The following code shows the default implementation of the PDP dropin initializer in this Commerce boilerplate:
+
+```typescript
+// Define the models object with a ProductDetails property
+const models = {
+ProductDetails: {
+  initialData: { ...product },
+  },
+};
+
+// Initialize Dropins
+initializers.register(productApi.initialize, {
+  langDefinitions,
+  models,
+});
+```
+
+## Set default product options
+
+When a user navigates to the product detail page (PDP) on your site, you can set certain options as preselected defaults. This use case allows merchandisers to set default options through the Adobe Commerce Admin, which provides a more customized and streamlined shopping experience.
+
+* **Simple products**—Default option selection is supported out-of-the-box through the Admin (`isDefault`). No additional PDP dropin customization is required.
+
+* **Complex products**—Default option selection is _not_ supported out-of-the-box. Instead, you must use [product attributes](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/product-attributes/product-attributes) and customize the PDP dropin initializers to define which attribute and value is used by default. If no option is defined as default, the first listed option will be preselected by default.
+
+This approach allows merchants to set different default selections for complex products in the Admin. Developers can then customize the PDP dropin to show the default or preselected options.
+
+<Steps>
+
+1. Log in to the Adobe Commerce Admin.
+
+1. Create a custom attribute (`default_options`) to define default options for each product.
+
+1. Ensure that the `default_options` attribute has been [exported](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/saas-data-export/overview) to the Catalog Service.
+
+1. Use the [`products`](https://developer.adobe.com/commerce/services/graphql/catalog-service/products/#return-details-about-a-complex-product) query to find the `id` of the `default_options` attribute for each product.
+
+1. Add the `id` of the `default_options` attribute to the `initialData` object for each complex product.
+
+1. Use the `id` to set the `optionsUIDs` in the `initialData` object.
+
+   ```ts
+   // Define the models object with a ProductDetails property
+   const models = {
+     ProductDetails: {
+       initialData: {
+         ...initialData,
+         // Set the optionsUIDs for each product
+         optionsUIDs: [
+          '<id>', // Use the id of the default_options attribute for product 1
+          '<id>', // Use the id of the default_options attribute for product 2
+        ],
+       },
+     },
+   };
+
+   // Register Initializers
+   initializers.register(api.initialize, {
+     langDefinitions,
+     models,
+   });
+   ```
+
+</Steps>

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -44,7 +44,7 @@ import Callouts from '@components/Callouts.astro';
   />
   <LinkCard
     icon="seti:code-search"
-    title="Product Details dropin"
+    title="Product Details Page dropin"
     description="Discover how flexible our Commerce components are with our Product Details dropin."
     link="/dropins/product-details/"
   />


### PR DESCRIPTION
This pull request (PR) adds a new topic that describes the initializer configuration options for the PDP dropin.

It also provides a detailed use case for setting default options on complex products using `models` and `initialData` as scoped in DATA-6181.

It does not provide detailed use cases for any other configuration options, but if a reviewer wants to suggest them, I'm happy to include 😃. I don't think it should block this PR though.

>[!NOTE]
>This topic deviates from the [dropin_Initialization.mdx](https://github.com/commerce-docs/microsite-commerce-storefront/blob/develop/_dropin-templates/dropin-initialization.mdx) template a little. I didn't understand how to include a "big picture" diagram. I also thought that replacing the "step-by-step" section with an actual use case made more sense. My assumption is that we can add new H2 sections for additional use cases in the future if necessary.