### PR TITLE
fix: remove errant quote breaking launch script

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -62,7 +62,7 @@ export default defineConfig({
       head: [{
         tag: 'script',
         attrs: {
-          src: 'https://assets.adobedtm.com/d4d114c60e50/9f881954c8dc/launch-7a902c4895c3.min.js" async'
+          src: 'https://assets.adobedtm.com/d4d114c60e50/9f881954c8dc/launch-7a902c4895c3.min.js'
         }
       }, {
         tag: 'meta',


### PR DESCRIPTION
Analytics for the site haven't been working. I'm pretty sure it's because of the quote character introduced in #58. I also don't know if we really need the `async` parameter either.

Got to the production site and open Chrome dev tools. You'll see the following error in the console:

```
Refused to execute script from 'https://assets.adobedtm.com/d4d114c60e50/9f881954c8dc/launch-7a902c4895c3.min.js%22%20async' because its MIME type ('') is not executable, and strict MIME type checking is enabled.
```

After removing the quote and checking the console on a local build, the error is gone. 