### PR TITLE
SCP beta 24 updates

### DIFF
--- a/src/content/docs/setup/storefront-compatibility.mdx
+++ b/src/content/docs/setup/storefront-compatibility.mdx
@@ -35,9 +35,23 @@ This package defines the following queries and mutations:
 
 ## Release information
 
-**Latest version:** 4.7.0-beta23
+**Latest version:** 4.7.0-beta24
 
-**Release date:** October 30, 2024
+**Release date:** November 11, 2024
+
+### 4.7.0-beta24
+
+* The `setShippingAddressesOnCart` mutation no longer throws an error when specifying the `pickup_location_code` field.
+
+* `customer` queries using the `items_eligible_for_return` field do not return both parent and child products for configurable products.
+
+* Added the `quantity_return_requested` and `eligible_for_return` fields to `OrderItemInterface`.
+
+* Added the `items_eligible_for_return` field to the `CustomerOrder` type.
+
+* The `eligible_for_return` field no longer returns true on items that have been returned.
+
+* Updated WebAPI tests on shared catalogs.
 
 ### 4.7.0-beta23
 


### PR DESCRIPTION
Updates the mini release notes for the beta-24 release of the SCP.