### PR TITLE
Updates Cart version in initial storefront suite

### DIFF
--- a/src/content/docs/get-started/release.mdx
+++ b/src/content/docs/get-started/release.mdx
@@ -18,7 +18,7 @@ The following table shows the compatibility between all of the storefront releas
 | **Adobe Commerce** | 2.4.7 |
 | **Storefront compatibility package** | 4.7.0 |
 | **Drop-in SDK** | Tools: 0.38.0<br/>Build tools: 0.1.1 |
-| **Drop-in components** | Product Details: 1.0.0<br/>Cart: 1.0.0<br/>Checkout: 1.0.0<br/>User Auth: 1.0.0<br/>User Account: 1.0.0<br/>Orders: 1.0.0 |
+| **Drop-in components** | Product Details: 1.0.0<br/>Cart: 1.0.1<br/>Checkout: 1.0.0<br/>User Auth: 1.0.0<br/>User Account: 1.0.0<br/>Orders: 1.0.0 |
 
 ## Code changes
 


### PR DESCRIPTION
Unfortunately Cart version `1.0.0`  was published without a license attached and we had to release a version `1.0.1` to fix it.

Therefore, as weird as it looks, I think we should specify that Storefront suite `1.0` starts at Cart `1.0.1`.

We don't want to encourage anyone to use `1.0.0` that doesn't have the license.