### PR TITLE
fix: correct find-replace typos of dropin-in

### DIFF
--- a/_dropin-templates/SidebarConfiguration.mjs
+++ b/_dropin-templates/SidebarConfiguration.mjs
@@ -6,7 +6,7 @@
   items: [
     { label: 'DROPIN_NAME anatomy', link: '/dropins/blueprint/dropin-anatomy/' },
     { label: 'DROPIN_NAME prerequisites', link: '/dropins/blueprint/dropin-prerequisites/' },
-    { label: 'DROPIN_NAME initialization', link: '/dropins/blueprint/drop-initialization/' },
+    { label: 'DROPIN_NAME initialization', link: '/dropins/blueprint/dropin-initialization/' },
     { label: 'DROPIN_NAME containers', link: '/dropins/blueprint/dropin-containers/' },
     { label: 'DROPIN_NAME styles', link: '/dropins/blueprint/dropin-styles/' },
     { label: 'DROPIN_NAME slots', link: '/dropins/blueprint/dropin-slots/' },

--- a/_dropin-templates/SidebarConfiguration.mjs
+++ b/_dropin-templates/SidebarConfiguration.mjs
@@ -6,11 +6,11 @@
   items: [
     { label: 'DROPIN_NAME anatomy', link: '/dropins/blueprint/dropin-anatomy/' },
     { label: 'DROPIN_NAME prerequisites', link: '/dropins/blueprint/dropin-prerequisites/' },
-    { label: 'DROPIN_NAME initialization', link: '/dropins/blueprint/dropin-initialization/' },
+    { label: 'DROPIN_NAME initialization', link: '/dropins/blueprint/drop-initialization/' },
     { label: 'DROPIN_NAME containers', link: '/dropins/blueprint/dropin-containers/' },
     { label: 'DROPIN_NAME styles', link: '/dropins/blueprint/dropin-styles/' },
     { label: 'DROPIN_NAME slots', link: '/dropins/blueprint/dropin-slots/' },
     { label: 'DROPIN_NAME functions', link: '/dropins/blueprint/dropin-functions/' },
     { label: 'DROPIN_NAME data events', link: '/dropins/blueprint/dropin-data-events/' },
-  ]
+  ];
 }

--- a/_dropin-templates/dropin-labels.mdx
+++ b/_dropin-templates/dropin-labels.mdx
@@ -33,7 +33,7 @@ This topic provides examples for how to override the labels in the DROPIN_NAME d
 
 ## Changing labels
 
-To change the labels in the DROPIN_NAME dropin-in component, you can override the following file(s) in your project:
+To change the labels in the DROPIN_NAME drop-in component, you can override the following file(s) in your project:
 
 ````json
 

--- a/_dropin-templates/dropin-prerequisites.mdx
+++ b/_dropin-templates/dropin-prerequisites.mdx
@@ -27,7 +27,7 @@ To support the DROPIN_NAME drop-in component in your storefront, ensure that you
 
 ## Installing the prerequisites
 
-To install the prerequisites for the DROPIN_NAME dropin-in component, follow these steps:
+To install the prerequisites for the DROPIN_NAME drop-in component, follow these steps:
 
 <Steps>
 
@@ -38,7 +38,7 @@ To install the prerequisites for the DROPIN_NAME dropin-in component, follow the
 
 ## Configuring the prerequisites
 
-To configure the prerequisites for the DROPIN_NAME dropin-in component, follow these steps:
+To configure the prerequisites for the DROPIN_NAME drop-in component, follow these steps:
 
 <Steps>
 

--- a/src/content/docs/discovery/data-export-validation.mdx
+++ b/src/content/docs/discovery/data-export-validation.mdx
@@ -3,7 +3,7 @@ title: Data export validation
 description: Learn how to validate data exports from your Adobe Commerce backend to your storefront.
 ---
 
-Data export synchronizes data between an Adobe Commerce instance and connected [storefront services](/discovery/architecture/#storefront-services). Storefront services are required for dropin-in components to work correctly.
+Data export synchronizes data between an Adobe Commerce instance and connected [storefront services](/discovery/architecture/#storefront-services). Storefront services are required for drop-in components to work correctly.
 
 Validating the data export is crucial to ensure that the data is correctly synchronized and available for the storefront. You can use the [Data Management Dashboard](https://experienceleague.adobe.com/en/docs/commerce-admin/systems/data-transfer/data-dashboard) to monitor the data sync progress for each service.
 

--- a/src/content/docs/discovery/luma-bridge.mdx
+++ b/src/content/docs/discovery/luma-bridge.mdx
@@ -25,7 +25,7 @@ Luma Bridge is a session management mechanism between two storefronts:
 
 It allows you to reuse complex transactional parts of your storefront (such as, cart, checkout, and account) instead of rebuilding them. This approach provides a path for Adobe customers currently using Luma to migrate to a highly performant shopping experience. It focuses on converting the top of the funnel while keeping the last mile of the funnel in Luma. This allows you to benefit from Adobe innovations while preserving your investments in the existing storefront.
 
-If the previous discovery steps led to the conclusion that dropin-in components can be used for cart, checkout, and account experiences, Luma Bridge is not necessary or can be reduced to parts that are not covered by dropin-in components (for example, complex customizations). If existing headless implementations for cart, checkout, and account ([PWA Studio](https://github.com/magento/pwa-studio), [Vue Storefront](https://vuestorefront.io/)) are available, Luma Bridge is not necessary.
+If the previous discovery steps led to the conclusion that drop-in components can be used for cart, checkout, and account experiences, Luma Bridge is not necessary or can be reduced to parts that are not covered by drop-in components (for example, complex customizations). If existing headless implementations for cart, checkout, and account ([PWA Studio](https://github.com/magento/pwa-studio), [Vue Storefront](https://vuestorefront.io/)) are available, Luma Bridge is not necessary.
 
 ## Where can I get it?
 

--- a/src/content/docs/dropins/all/branding.mdx
+++ b/src/content/docs/dropins/all/branding.mdx
@@ -28,10 +28,10 @@ Branding with design tokens is the quickest way to customize your storefront. Th
 
 ## Big picture
 
-The following diagram shows a small branding change. When we override the default value of a single shape token, we override the default border-radius of the `Button` library component, which changes the look and feel of dropin-in components that use it.
+The following diagram shows a small branding change. When we override the default value of a single shape token, we override the default border-radius of the `Button` library component, which changes the look and feel of drop-in components that use it.
 
 <Diagram caption="How to override the drop-in-design tokens.">
-  ![Diagram for how to brand dropin-in components](@images/brand/howtobrand.svg)
+  ![Diagram for how to brand drop-in components](@images/brand/howtobrand.svg)
 </Diagram>
 
 ## Vocabulary
@@ -40,17 +40,17 @@ The following diagram shows a small branding change. When we override the defaul
 
 ### design tokens
 
-CSS variables with default values. Our design tokens provide a standard set of CSS properties and default values for colors, typography, spacing, shapes, and layout grids. We use them in all of our component CSS classes to avoid hard-coded values that cannot be easily changed. With this strategy, you can restyle our dropin-in components to match your brand simply by changing the default token values.
+CSS variables with default values. Our design tokens provide a standard set of CSS properties and default values for colors, typography, spacing, shapes, and layout grids. We use them in all of our component CSS classes to avoid hard-coded values that cannot be easily changed. With this strategy, you can restyle our drop-in components to match your brand simply by changing the default token values.
 
 <CodeImport code={base} title="All default design tokens" lang="css" frame="none" />
 
 ### library components
 
-Basic components (like `Button`, `Checkbox`, and `Carousel`) used to build dropin-in components. Design tokens are embedded in the CSS classes of these components to ensure fast, flexible styling to match your brand.
+Basic components (like `Button`, `Checkbox`, and `Carousel`) used to build drop-in components. Design tokens are embedded in the CSS classes of these components to ensure fast, flexible styling to match your brand.
 
 ### Adobe Commerce design system
 
-The collection of design tokens, library components, and conventions we use to style our dropin-in components.
+The collection of design tokens, library components, and conventions we use to style our drop-in components.
 
 ### brand
 
@@ -89,7 +89,7 @@ For example, start with **typography**, then move on to **spacing**, **shapes**,
 From the root of your project, open the `styles/styles.css` file.
 
 <FileTree>
- 
+
 - scripts/
 - **styles/** _CSS files for drop-in component design tokens, fonts, deferred styles_
   - fonts.css _-- Default font styles_
@@ -175,4 +175,4 @@ Use the same process for overriding the spacing, shapes, grids, and color token 
 
 ## Summary
 
-The process of branding dropin-in components is typically fast and easy. Focus on one brand category at a time and work with your designers to solve the less obvious brand-to-token overrides.
+The process of branding drop-in components is typically fast and easy. Focus on one brand category at a time and work with your designers to solve the less obvious brand-to-token overrides.

--- a/src/content/docs/dropins/all/eventbus.mdx
+++ b/src/content/docs/dropins/all/eventbus.mdx
@@ -1,6 +1,6 @@
 ---
 title: Event bus
-description: Learn what dropin-in components are and how to use them.
+description: Learn what drop-in components are and how to use them.
 ---
 
 import CodeImport from '@components/CodeImport.astro';

--- a/src/content/docs/dropins/all/extending.mdx
+++ b/src/content/docs/dropins/all/extending.mdx
@@ -1,6 +1,6 @@
 ---
-title: Extending dropin-in components
-description: Learn about different methods to extend dropin-in components.
+title: Extending drop-in components
+description: Learn about different methods to extend drop-in components.
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';

--- a/src/content/docs/dropins/all/installing.mdx
+++ b/src/content/docs/dropins/all/installing.mdx
@@ -1,6 +1,6 @@
 ---
-title: Installing dropin-in components
-description: Learn about installing and initializing dropin-in components for your site.
+title: Installing drop-in components
+description: Learn about installing and initializing drop-in components for your site.
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
@@ -11,11 +11,11 @@ import Diagram from '@components/Diagram.astro';
 
 Drop-in components are designed for the browser's JavaScript run-time without the need for a bundler. But they can also be installed and executed in a build-time environment with bundlers like Webpack and Vite. The installation steps for both run-time and build-time environments are the same after the initial drop-in component package imports.
 
-## Why install dropin-in components?
+## Why install drop-in components?
 
-Installing dropin-in components is essential for customizing and enhancing your Adobe Commerce storefront, especially if you choose not to start with the [boilerplate template](/get-started/#boilerplate-template). It is a strategic choice for businesses looking to customize, optimize, and scale their Adobe Commerce storefronts effectively. This approach provides the flexibility and modularity needed to create a unique and high-performing online shopping experience.
+Installing drop-in components is essential for customizing and enhancing your Adobe Commerce storefront, especially if you choose not to start with the [boilerplate template](/get-started/#boilerplate-template). It is a strategic choice for businesses looking to customize, optimize, and scale their Adobe Commerce storefronts effectively. This approach provides the flexibility and modularity needed to create a unique and high-performing online shopping experience.
 
-If you have an existing storefront project and are not starting with the boilerplate template, you can install dropin-in components individually to add the specific features that you need.
+If you have an existing storefront project and are not starting with the boilerplate template, you can install drop-in components individually to add the specific features that you need.
 
 ## Workflow
 
@@ -23,7 +23,7 @@ The following diagram provides an overview of the steps necessary for installing
 
 <Diagram>![PDP Installation](@images/pdp/pdp-installation.svg)</Diagram>
 
-The installation of all dropin-in components follows the same pattern described in the workflow diagram above. Refer to the following resources for step-by-step instructions to install specific dropin-in components:
+The installation of all drop-in components follows the same pattern described in the workflow diagram above. Refer to the following resources for step-by-step instructions to install specific drop-in components:
 
 - [Product details page (PDP)](/dropins/product-details/installation)
 - [Cart](/dropins/cart/installation)

--- a/src/content/docs/dropins/all/introduction.mdx
+++ b/src/content/docs/dropins/all/introduction.mdx
@@ -1,6 +1,6 @@
 ---
-title: Introduction to dropin-in components
-description: Learn what dropin-in components are and how to use them.
+title: Introduction to drop-in components
+description: Learn what drop-in components are and how to use them.
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
@@ -12,9 +12,9 @@ import { Badge } from '@astrojs/starlight/components';
 
 Drop-in components (with Commerce services) make up the entire storefront experience. They are equivalent to small apps that you can mix and match to create a storefront that fits your needs.
 
-## What are dropin-in components?
+## What are drop-in components?
 
-Drop-in components are full-featured shopping components. They are not primitive components like Carousels and Galleries. dropin-in components _define_ the storefront shopping experience. Our dropin-in components include product details, carts, checkout, user authentication, user accounts, with more on the way. This section introduces these dropin-in components and provides links to their details.
+Drop-in components are full-featured shopping components. They are not primitive components like Carousels and Galleries. drop-in components _define_ the storefront shopping experience. Our drop-in components include product details, carts, checkout, user authentication, user accounts, with more on the way. This section introduces these drop-in components and provides links to their details.
 
 ### Product details
 
@@ -56,9 +56,9 @@ The [user account](/dropins/user-account/) drop-in component
 provides users with a personalized experience, allowing them to view their order history, manage
 their account settings, and access other account-related features.
 
-## How can I customize dropin-in components?
+## How can I customize drop-in components?
 
-All dropin-in components can be customized in five ways: design tokens, CSS classes, slots, content enrichment, and localization. In this section, you'll learn how to use each approach.
+All drop-in components can be customized in five ways: design tokens, CSS classes, slots, content enrichment, and localization. In this section, you'll learn how to use each approach.
 
 ### Design tokens
 
@@ -66,7 +66,7 @@ All dropin-in components can be customized in five ways: design tokens, CSS clas
 
 ### CSS classes
 
-[CSS classes](/dropins/all/styling/) provide deeper style changes for dropin-in components than design tokens. Overriding or adding new CSS classes allows you to restyle specific areas of the drop-in component. You'll find best practices for styling here.
+[CSS classes](/dropins/all/styling/) provide deeper style changes for drop-in components than design tokens. Overriding or adding new CSS classes allows you to restyle specific areas of the drop-in component. You'll find best practices for styling here.
 
 ### Slots
 
@@ -78,4 +78,4 @@ All dropin-in components can be customized in five ways: design tokens, CSS clas
 
 ### Localization
 
-[Localization](/dropins/all/labeling/) is one of the easiest ways to customize dropin-in components for a region. This topic shows you how to add and use a second language file in your dropin-in components.
+[Localization](/dropins/all/labeling/) is one of the easiest ways to customize drop-in components for a region. This topic shows you how to add and use a second language file in your drop-in components.

--- a/src/content/docs/dropins/all/slots.mdx
+++ b/src/content/docs/dropins/all/slots.mdx
@@ -1,6 +1,6 @@
 ---
 title: Understanding slots
-description: Learn about slots and how to use them to customize dropin-in components.
+description: Learn about slots and how to use them to customize drop-in components.
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';

--- a/src/content/docs/dropins/all/styling.mdx
+++ b/src/content/docs/dropins/all/styling.mdx
@@ -1,6 +1,6 @@
 ---
-title: Styling dropin-in components
-description: Learn how to style dropin-in components more deeply with CSS classes.
+title: Styling drop-in components
+description: Learn how to style drop-in components more deeply with CSS classes.
 sidebar:
   label: CSS classes
   order: 2
@@ -8,7 +8,7 @@ sidebar:
 
 import Aside from '@components/Aside.astro';
 
-Overriding and adding CSS classes for drop-in components provides the next level of customizing your storefront dropin-in components. By modifying a drop-in component's built-in CSS classes and adding additional classes, you can quickly change the built-in classes to meet your specifications. You'll find best-practices for styling here.
+Overriding and adding CSS classes for drop-in components provides the next level of customizing your storefront drop-in components. By modifying a drop-in component's built-in CSS classes and adding additional classes, you can quickly change the built-in classes to meet your specifications. You'll find best-practices for styling here.
 
 import CodeImport from '@components/CodeImport.astro';
 import Diagram from '@components/Diagram.astro';
@@ -17,7 +17,7 @@ import Callouts from '@components/Callouts.astro';
 The CSS classes for each UI component that provides the product details drop-in component with its UI are provided here. Override these classes and add new classes to customize the look and feel of your PDP drop-in component to match your specific style requirements.
 
 :::tip[CSS Tip!]
-Drop-in components contain several components that provide its UI. If you plan to make several CSS changes to the dropin-in component, we suggest creating individual CSS files for each component in your drop-in component and import those into an aggregate `drop-in.css` file as shown below. This practice makes it easier to maintain and update your CSS as your changes accumulate.
+Drop-in components contain several components that provide its UI. If you plan to make several CSS changes to the drop-in component, we suggest creating individual CSS files for each component in your drop-in component and import those into an aggregate `drop-in.css` file as shown below. This practice makes it easier to maintain and update your CSS as your changes accumulate.
 
 This example shows how to import several CSS files into a single `drop-in.css` file:
 

--- a/src/content/docs/dropins/cart/installation.mdx
+++ b/src/content/docs/dropins/cart/installation.mdx
@@ -13,7 +13,7 @@ import Callouts from '@components/Callouts.astro';
 import Diagram from '@components/Diagram.astro';
 import Vocabulary from '@components/Vocabulary.astro';
 
-The cart drop-in component, like our other drop-in components, are designed for the browser's JavaScript runtime without the need for a bundler. You can also install and execute dropin-in components in a build-time environment with bundlers like Vite. The installation steps for both runtime and build-time environments are the same after the initial drop-in component package imports.
+The cart drop-in component, like our other drop-in components, are designed for the browser's JavaScript runtime without the need for a bundler. You can also install and execute drop-in components in a build-time environment with bundlers like Vite. The installation steps for both runtime and build-time environments are the same after the initial drop-in component package imports.
 
 ## Step-by-step
 
@@ -56,7 +56,7 @@ Use a CDN or NPM (recommended for performance) to install the drop-in component 
 </Tabs>
 
 :::note[Install @dropins/tools]
-All dropin-in components require the `@dropins/tools` package. This package contains the libraries that dropin-in components need to initialize and communicate, including `fetch-graphql`, `event-bus`, and `initializer` utilities.
+All drop-in components require the `@dropins/tools` package. This package contains the libraries that drop-in components need to initialize and communicate, including `fetch-graphql`, `event-bus`, and `initializer` utilities.
 :::
 
 </Task>
@@ -69,7 +69,7 @@ In the `<head>` tag of your `index.html` or `head.html` file, use an `importmap`
 <Tabs>
 <TabItem label="node_modules" icon="seti:npm">
     This example shows an `importmap` added to a `head.html` The `importmap` points both packages to the local `node_modules` directory that contains your installed drop-in component files from the drop-in component tools (@dropins/tools) and the cart (@dropins/storefront-cart):
-  
+
   ```html title="head.html"
   <script type="importmap">
     {
@@ -126,7 +126,7 @@ With the `importmap` defined for both runtime and build-time environments, you c
 <Task>
 ### Import the required files
 
-Import the required files from the dropin-in components tools (`@dropins/tools/fetch-graphql.js'`, `@dropin/tools/initializers.js`) and the cart (`@dropins/storefront-cart`) into a JavaScript file for your cart block. The example here shows the imports added to a `cart.js` file. These imports constitute the minimum imports you need to create a fully functioning cart for your site:
+Import the required files from the drop-in components tools (`@dropins/tools/fetch-graphql.js'`, `@dropin/tools/initializers.js`) and the cart (`@dropins/storefront-cart`) into a JavaScript file for your cart block. The example here shows the imports added to a `cart.js` file. These imports constitute the minimum imports you need to create a fully functioning cart for your site:
 
 ```js title="cart.js"
 // GraphQL Client
@@ -184,7 +184,7 @@ mesh.setEndpoint('https://<graphql-service-endpoint>/graphql');
 
 #### Request headers
 
-The cart does not need additional headers set for basic installation. But if you're looking to enable features for your dropin-in component, the GraphQL request accepts additional headers. The below example shows how you could set the `Commerce-Auth` header with the customer token for the Authorization header, and how to set the store code header for store specific features. Replace the header values with the actual values from your Commerce backend services:
+The cart does not need additional headers set for basic installation. But if you're looking to enable features for your drop-in component, the GraphQL request accepts additional headers. The below example shows how you could set the `Commerce-Auth` header with the customer token for the Authorization header, and how to set the store code header for store specific features. Replace the header values with the actual values from your Commerce backend services:
 
 ```js title="cart.js"
 // Set the customer token. This method is specific to @dropins/storefront-cart package.
@@ -229,7 +229,7 @@ The code below shows how to register the cart, load it (mount), and enable the l
 <Task>
 ### Render the drop-in
 
-Render the cart on the page. The example below provides the minimal configuration options required to render the default Cart dropin-in component, along with an example to render Mini-Cart.
+Render the cart on the page. The example below provides the minimal configuration options required to render the default Cart drop-in component, along with an example to render Mini-Cart.
 
 ```js title="cart.js"
 // Render Cart
@@ -260,4 +260,4 @@ Test the cart by viewing your cart page in a browser, or running your local dev 
 
 ## Summary
 
-The installation of all dropin-in components follow the same pattern demonstrated by installing the cart: Install, Map, Import, Connect, Register, and Render.
+The installation of all drop-in components follow the same pattern demonstrated by installing the cart: Install, Map, Import, Connect, Register, and Render.

--- a/src/content/docs/dropins/cart/styles.mdx
+++ b/src/content/docs/dropins/cart/styles.mdx
@@ -16,7 +16,7 @@ import Callouts from '@components/Callouts.astro';
 The CSS classes for each UI component that provides the cart drop-in component with its UI are provided here. Override these classes and add new classes to customize the look and feel of your cart to match your specific style requirements.
 
 :::tip[Boilerplate CSS Tip!]
-The cart contains several components that provide its UI. If you plan to make several CSS changes to the dropin-in component, we suggest creating CSS files for each drop-in component (in the `cart` directory) and importing those into the `cart.css` file as shown below. This practice makes it easier to maintain and update your CSS in the future.
+The cart contains several components that provide its UI. If you plan to make several CSS changes to the drop-in component, we suggest creating CSS files for each drop-in component (in the `cart` directory) and importing those into the `cart.css` file as shown below. This practice makes it easier to maintain and update your CSS in the future.
 
 ```css title="cart.css"
 @import 'cart.css';

--- a/src/content/docs/dropins/order/files/return-order-product-list.css
+++ b/src/content/docs/dropins/order/files/return-order-product-list.css
@@ -50,11 +50,11 @@
 
 .order-create-return
   .dropin-cart-item__footer
-  .dropin-incrementer.dropin-incrementer--medium {
+  .drop-incrementer.drop-incrementer--medium {
   max-width: 160px;
 }
 
-.order-return-order-product-list .dropin-incrementer__button-container {
+.order-return-order-product-list .drop-incrementer__button-container {
   margin: 0;
 }
 

--- a/src/content/docs/dropins/order/files/return-reason-form.css
+++ b/src/content/docs/dropins/order/files/return-reason-form.css
@@ -50,11 +50,11 @@
 
 .order-create-return
   .dropin-cart-item__footer
-  .dropin-incrementer.dropin-incrementer--medium {
+  .drop-incrementer.drop-incrementer--medium {
   max-width: 160px;
 }
 
-.order-return-order-product-list .dropin-incrementer__button-container {
+.order-return-order-product-list .drop-incrementer__button-container {
   margin: 0;
 }
 

--- a/src/content/docs/dropins/order/styles.mdx
+++ b/src/content/docs/dropins/order/styles.mdx
@@ -28,7 +28,7 @@ import shippingStatusCard from './files/shipping-status-card.css?raw';
 The CSS classes for each UI component that provides the order drop-in component with its UI are provided here. Override these classes and add new classes to customize the look and feel of your cart to match your specific style requirements.
 
 :::tip[Boilerplate CSS Tip!]
-The drop-in component contains multiple components that provide its UI. If you plan to make several CSS changes to the dropin-in, we suggest creating CSS files for each drop-in component and importing those into a custom `order.css` file as shown below. This practice makes it easier to maintain and update your CSS in the future.
+The drop-in component contains multiple components that provide its UI. If you plan to make several CSS changes to the drop-in, we suggest creating CSS files for each drop-in component and importing those into a custom `order.css` file as shown below. This practice makes it easier to maintain and update your CSS in the future.
 
 ```css title="order.css"
 @import 'commerce-order-returns.css';
@@ -38,7 +38,7 @@ The drop-in component contains multiple components that provide its UI. If you p
 
 :::
 
-[Styling dropin-in components](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/all/styling/) describes how to inspect the drop-in component in your browser's developer tools to discover the BEM class names to be extended.
+[Styling drop-in components](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/all/styling/) describes how to inspect the drop-in component in your browser's developer tools to discover the BEM class names to be extended.
 
 ## Example CSS overrides
 

--- a/src/content/docs/dropins/product-details/installation.mdx
+++ b/src/content/docs/dropins/product-details/installation.mdx
@@ -13,7 +13,7 @@ import Task from '@components/Task.astro';
 import Callouts from '@components/Callouts.astro';
 import Diagram from '@components/Diagram.astro';
 
-Our dropin-in components are designed for the browser's JavaScript run-time without the need for a bundler. But they can also be installed and executed in a build-time environment with bundlers like Webpack and Vite. The installation steps for both run-time and build-time environments are the same after the initial drop-in component package imports.
+Our drop-in components are designed for the browser's JavaScript run-time without the need for a bundler. But they can also be installed and executed in a build-time environment with bundlers like Webpack and Vite. The installation steps for both run-time and build-time environments are the same after the initial drop-in component package imports.
 
 ## Prerequisites
 
@@ -62,7 +62,7 @@ Use a CDN or NPM (recommended for performance) to install the drop-in component 
 </Tabs>
 
 :::note[Install @dropins/tools]
-All dropin-in components require the `@dropins/tools` package. This package contains the libraries that dropin-in components need to initialize and communicate, including `fetch-graphql`, `event-bus`, and `initializer` utilities.
+All drop-in components require the `@dropins/tools` package. This package contains the libraries that drop-in components need to initialize and communicate, including `fetch-graphql`, `event-bus`, and `initializer` utilities.
 :::
 
 </Task>
@@ -75,7 +75,7 @@ In the `<head>` tag of your `index.html` or `head.html` file, use an `importmap`
 <Tabs>
 <TabItem label="node_modules" icon="seti:npm">
     This example shows an `importmap` added to a `head.html` The `importmap` points both packages to the local `node_modules` directory that contains your installed drop-in component files from the drop-in component tools (@dropins/tools) and the PDP drop-in component (@dropins/storefront-pdp):
-  
+
   ```html title="head.html"
   <script type="importmap">
     {
@@ -132,7 +132,7 @@ With the `importmap` defined for both run-time and build-time environments, you 
 <Task>
 ### Import the required files
 
-Import the required files from the dropin-in components tools (`@dropin/tools/initializers.js`) and the product details component (`@dropins/storefront-pdp`) into a JavaScript file for your PDP drop-in. The example here shows the imports added to a `product-details.js` file. These imports constitute the minimum imports you need to create a fully functioning product details component for your site:
+Import the required files from the drop-in components tools (`@dropin/tools/initializers.js`) and the product details component (`@dropins/storefront-pdp`) into a JavaScript file for your PDP drop-in. The example here shows the imports added to a `product-details.js` file. These imports constitute the minimum imports you need to create a fully functioning product details component for your site:
 
 ```js title="product-details.js"
 // Drop-in component tools
@@ -221,4 +221,4 @@ Test the product details component by viewing your PDP page in a browser, or run
 
 ## Summary
 
-The installation of all dropin-in components follows the same pattern demonstrated by installing the PDP drop-in: Install, Map, Import, Connect, Register, and Render. We like to call the process `iMICRR` for short, pronounced `eye-mike-er`. Actually, we don't call it that, but if it helps...Enjoy!
+The installation of all drop-in components follows the same pattern demonstrated by installing the PDP drop-in: Install, Map, Import, Connect, Register, and Render. We like to call the process `iMICRR` for short, pronounced `eye-mike-er`. Actually, we don't call it that, but if it helps...Enjoy!

--- a/src/content/docs/dropins/product-details/styles.mdx
+++ b/src/content/docs/dropins/product-details/styles.mdx
@@ -20,7 +20,7 @@ import Callouts from '@components/Callouts.astro';
 The CSS classes for each UI component that provides the product details page (PDP) drop-in component with its UI are provided here. Override these classes and add new classes to customize the look and feel of your PDP drop-in component to match your specific style requirements.
 
 :::tip[Boilerplate CSS Tip!]
-Product details (like most other dropin-in components) contains several components that provide its UI. If you plan to make several CSS changes to the dropin-in component, we suggest creating CSS files for each drop-in component (in the `product-details` directory) and importing those into the `product-details.css` file as shown below. This practice makes it easier to maintain and update your CSS in the future.
+Product details (like most other drop-in components) contains several components that provide its UI. If you plan to make several CSS changes to the drop-in component, we suggest creating CSS files for each drop-in component (in the `product-details` directory) and importing those into the `product-details.css` file as shown below. This practice makes it easier to maintain and update your CSS in the future.
 
 ```css title="product-details.css"
 @import 'carousel.css';

--- a/src/content/docs/dropins/user-account/initialization.mdx
+++ b/src/content/docs/dropins/user-account/initialization.mdx
@@ -5,7 +5,7 @@ description: Learn how to configure initializer for the user account drop-in com
 
 import OptionsTable from '@components/OptionsTable.astro';
 
-The user account drop-in component does not require any special data or specific parameters to be initialized. To initialize the dropin-in component, you must import [`/scripts/initializers/account.js`](https://github.com/hlxsites/aem-boilerplate-commerce/blob/develop/scripts/initializers/account.js) into the appropriate file.
+The user account drop-in component does not require any special data or specific parameters to be initialized. To initialize the drop-in component, you must import [`/scripts/initializers/account.js`](https://github.com/hlxsites/aem-boilerplate-commerce/blob/develop/scripts/initializers/account.js) into the appropriate file.
 
 ```js
 import { initializers } from '@dropins/tools/initializer.js';

--- a/src/content/docs/dropins/user-auth/auth-functions.mdx
+++ b/src/content/docs/dropins/user-auth/auth-functions.mdx
@@ -251,7 +251,7 @@ The `getCustomerToken` function handles the sign-in operation. It requires `user
 
 1. Emits an “authenticated” event.
 
-You can use the `getCustomerToken` function to build a custom authentication flow that remains fully integrated with other dropin-in components.
+You can use the `getCustomerToken` function to build a custom authentication flow that remains fully integrated with other drop-in components.
 
 The function calls the [`generateCustomerToken` mutation](https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/generate-token/).
 
@@ -419,7 +419,7 @@ resetPassword(
 
 The `revokeCustomerToken` function revokes the customer's token and clears cookie. It then publishes an ACDL event and emits an "authenticated" event.
 
-This API can also be used to build a custom sign-out flow that stays fully integrated with other dropin-in components.
+This API can also be used to build a custom sign-out flow that stays fully integrated with other drop-in components.
 
 The function calls the [`revokeCustomerToken` mutation](https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/revoke-token/).
 

--- a/src/content/docs/get-started/_storefront-blocks.mdx
+++ b/src/content/docs/get-started/_storefront-blocks.mdx
@@ -10,7 +10,7 @@ import Vocabulary from '@components/Vocabulary.astro';
 import Diagram from '@components/Diagram.astro';
 import Icon from '@components/overrides/Icon.astro';
 
-Blocks are Edge Delivery components divided into content blocks and commerce blocks. Content blocks are UI components like buttons and text fields. Commerce blocks are the Edge Delivery integrations of Commerce dropin-in components and services. This section introduces blocks and and describes their role in Commerce storefronts.
+Blocks are Edge Delivery components divided into content blocks and commerce blocks. Content blocks are UI components like buttons and text fields. Commerce blocks are the Edge Delivery integrations of Commerce drop-in components and services. This section introduces blocks and and describes their role in Commerce storefronts.
 
 <Diagram caption="Overview of Commerce Drop-in components.">
   ![Temporary placeholder](../assets/placeholder.webp)

--- a/src/content/docs/get-started/index.mdx
+++ b/src/content/docs/get-started/index.mdx
@@ -263,7 +263,7 @@ Now let's create and set up the content side of your storefront. We'll create a 
     </Callouts>
 
   </TabItem>
-  
+
   <TabItem label="SharePoint">
 
     Follow these steps to create and share your **SharePoint folder**.
@@ -432,7 +432,7 @@ You can now use Sidekick to **Preview**, **Publish**, and **Edit** all your file
 
 <Aside type="tip" title="Congrats!">
   You now have a Commerce storefront project on GitHub and a local development environment to learn
-  how to customize dropin-in components to develop the boilerplate into a production storefront.
+  how to customize drop-in components to develop the boilerplate into a production storefront.
 </Aside>
 
 </Tasks>

--- a/src/content/docs/get-started/storefront-structure.mdx
+++ b/src/content/docs/get-started/storefront-structure.mdx
@@ -11,7 +11,7 @@ import Diagram from '@components/Diagram.astro';
 import FileTree from '@components/FileTree.astro';
 import OptionsTable from '@components/OptionsTable.astro';
 
-The storefront project is a collection of **blocks** (Content components, widgets, and dropin-in components), **scripts**, and **styles** designed for amazing performance, easy customizations, and rapid content development.
+The storefront project is a collection of **blocks** (Content components, widgets, and drop-in components), **scripts**, and **styles** designed for amazing performance, easy customizations, and rapid content development.
 
 ## Big picture
 
@@ -69,7 +69,7 @@ The file structure of the storefront boilerplate is shown here. Detailed descrip
   - caret-down-fill.svg
   - more...
 - scripts/ _-- JavaScript files that provide core site functions and connections to Commerce backend services_
-  - \_\_dropins\_\_ _-- Imported dropin-in components_
+  - \_\_dropins\_\_ _-- Imported drop-in components_
     - storefront-cart/ _-- minified/optimized drop-in code_
     - storefront-checkout/ _-- minified/optimized drop-in code_
     - storefront-order-confirmation/ _-- minified/optimized drop-in code_
@@ -94,7 +94,7 @@ The file structure of the storefront boilerplate is shown here. Detailed descrip
 - fstab.yaml _-- Connects the code to the content using the URL and ID to your Google Drive or SharePoint folder_
 - head.html _-- Includes @dropin importmap, aem.js, scripts.js, and styles.css_
 - helix-query.yaml _-- Defines the path and properties for your enrichment blocks_
-- package.json _-- Includes aem-cli, @dropins/tools, and the currently integrated dropin-in components_
+- package.json _-- Includes aem-cli, @dropins/tools, and the currently integrated drop-in components_
 
 </FileTree>
 
@@ -102,13 +102,13 @@ The file structure of the storefront boilerplate is shown here. Detailed descrip
 
 <Vocabulary>
 
-### Commerce dropin-in components
+### Commerce drop-in components
 
-Full-featured shopping components that turn websites into storefronts. [Drop-in components](/discovery/architecture/#dropin-in components-and-widgets) are not primitive components, like Carousels and Galleries. They provide the entire storefront shopping experience for a website using pages and other commerce features.
+Full-featured shopping components that turn websites into storefronts. [Drop-in components](/discovery/architecture/#drop-in components-and-widgets) are not primitive components, like Carousels and Galleries. They provide the entire storefront shopping experience for a website using pages and other commerce features.
 
 ### Commerce blocks
 
-The integration of Commerce dropin-in components into the Edge Delivery Services architecture of JavaScript blocks and document-based authoring. [Commerce blocks](/discovery/architecture/#commerce-blocks) are the components that provide the content and layout for commerce pages in the storefront.
+The integration of Commerce drop-in components into the Edge Delivery Services architecture of JavaScript blocks and document-based authoring. [Commerce blocks](/discovery/architecture/#commerce-blocks) are the components that provide the content and layout for commerce pages in the storefront.
 
 ### Content blocks
 
@@ -129,7 +129,7 @@ To learn more about the Live Search service, visit [Introduction to Live
 Search](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/live-search/overview#live-search-components).
 :::
 
-### Relationship between the Commerce blocks and dropin-in components
+### Relationship between the Commerce blocks and drop-in components
 
 In the following table, the first column of **links won't resolve unless you have your storefront running locally on port 3000**. The second column links to the Commerce block code in the boilerplate repository, and the third column links to the drop-in/widget code that powers the block.
 

--- a/src/content/docs/seo/indexing.mdx
+++ b/src/content/docs/seo/indexing.mdx
@@ -50,7 +50,7 @@ For multi-store setups or stores supporting multiple locales:
 - Verify that the store code is part of the URL for every Catalog Service or Live Search request. This is required because Google caches Catalog Service responses without considering headers. Not adding the store code to the URL might lead to Google indexing the wrong data.
 
   :::tip
-  You can ensure this by [proxying the Catalog Service endpoint](/setup/content-delivery-network/) through Fastly. Alternatively, you can add a query parameter, but this method is incompatible with dropin-in components.
+  You can ensure this by [proxying the Catalog Service endpoint](/setup/content-delivery-network/) through Fastly. Alternatively, you can add a query parameter, but this method is incompatible with drop-in components.
   :::
 
 ### Redirects

--- a/src/content/docs/troubleshooting/faq.mdx
+++ b/src/content/docs/troubleshooting/faq.mdx
@@ -7,7 +7,7 @@ tableOfContents:
 
 ## Where can I find technical documentation?
 
-- [Storefront dropin-in components](https://experienceleague.adobe.com/developer/commerce/storefront/)
+- [Storefront drop-in components](https://experienceleague.adobe.com/developer/commerce/storefront/)
 - [Catalog Service](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/catalog-service/guide-overview)
 - [Live Search](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/live-search/overview)
 - [[AEM Gems] Building Storefronts on Edge Delivery Services with Adobe Commerce](https://experienceleaguecommunities.adobe.com/t5/adobe-experience-manager/aem-gems-building-storefronts-on-edge-delivery-services-with/m-p/652692)

--- a/src/content/docs/troubleshooting/pagespeed-issues.mdx
+++ b/src/content/docs/troubleshooting/pagespeed-issues.mdx
@@ -11,7 +11,7 @@ Common issues for PageSpeed Insights errors and how to resolve them.
 ## Status code 404
 
 <Diagram caption="PageSpeed 404 error">
-  ![Diagram for how to brand dropin-in components](@images/troubleshoot/pagespeed-404.webp)
+  ![Diagram for how to brand drop-in components](@images/troubleshoot/pagespeed-404.webp)
 </Diagram>
 
 ### If This

--- a/src/content/integrations/integrate-react.mdx
+++ b/src/content/integrations/integrate-react.mdx
@@ -1,4 +1,4 @@
 ---
 title: React
-description: How to integrate dropin-in components with React.
+description: How to integrate drop-in components with React.
 ---

--- a/src/content/integrations/integrate-vue.mdx
+++ b/src/content/integrations/integrate-vue.mdx
@@ -1,4 +1,4 @@
 ---
 title: Vue
-description: How to integrate dropin-in components with Vue
+description: How to integrate drop-in components with Vue
 ---

--- a/src/content/integrations/overview.mdx
+++ b/src/content/integrations/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Integrations overview
-description: Overview of integrating dropin-in components into different frontend frameworks.
+description: Overview of integrating drop-in components into different frontend frameworks.
 ---
 
-Overview of integrating dropin-in components into different frontend frameworks.
+Overview of integrating drop-in components into different frontend frameworks.

--- a/src/pages/playgrounds/index.astro
+++ b/src/pages/playgrounds/index.astro
@@ -30,6 +30,6 @@ import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
 
   <p>
     Welcome to the Commerce Playgrounds, where you can get hands-on experience with Commerce
-    services, storefronts, and dropin-in components. Select a playground to get started.
+    services, storefronts, and drop-in components. Select a playground to get started.
   </p>
 </StarlightPage>

--- a/src/pages/videos/customize-pdp.astro
+++ b/src/pages/videos/customize-pdp.astro
@@ -39,7 +39,7 @@ import Aside from '@components/Aside.astro';
   <div style="max-width: 700px;">
     <Aside type="tip" title="Roadmap">
       This will be the first video in a series of videos that will teach you how to customize the
-      commerce boilerplate dropin-in components to create a polished, production-ready storefront. Check back
+      commerce boilerplate drop-in components to create a polished, production-ready storefront. Check back
       later for updates!
     </Aside>
   </div>

--- a/src/pages/videos/index.astro
+++ b/src/pages/videos/index.astro
@@ -6,7 +6,7 @@ import Aside from '@components/Aside.astro';
 <StarlightPage
   frontmatter={{
     title: 'Commerce Training Videos',
-    description: 'Learn about how to build your storefront with dropin-in components and customizations.',
+    description: 'Learn about how to build your storefront with drop-in components and customizations.',
     tableOfContents: false,
     editUrl:
       'https://github.com/commerce-docs/microsite-commerce-storefront/blob/api-playground/src/pages/videos/index.astro',


### PR DESCRIPTION
This PR fixes all the find-replace typos associated with the spelling correction of dropin to drop-in.