### PR TITLE
Fixed typo in the checkout installation page

### DIFF
--- a/src/content/docs/dropins/checkout/installation.mdx
+++ b/src/content/docs/dropins/checkout/installation.mdx
@@ -5,7 +5,7 @@ description: Learn how to install the checkout drop-in component on your site.
 
 import OptionsTable from '@components/OptionsTable.astro';
 
-The checkout drop-in component provides a customizable UI for the checkout process. The checkout compoennt is designed to be integrated into a your storefront and provides a seamless checkout experience for customers.
+The checkout drop-in component provides a customizable UI for the checkout process. The checkout component is designed to be integrated into your storefront and provides a seamless checkout experience for customers.
 
 ## Installation
 


### PR DESCRIPTION
Encountered a typo in the checkout installation page while preparing the docs for Payment Services, this PR fixes a couple of typos