### PR TITLE
USF-1911: Adapted PaymentMethods container into the Checkout drop-in

### DIFF
--- a/src/content/docs/dropins/checkout/containers/payment-methods.mdx
+++ b/src/content/docs/dropins/checkout/containers/payment-methods.mdx
@@ -5,22 +5,73 @@ description: Configure the PaymentMethods container to manage and display availa
 
 import OptionsTable from '@components/OptionsTable.astro';
 
-The `PaymentMethods` container is designed to manage and display the available payment methods during the checkout process. You can configure it to handle the selection of payment methods, display the payment method handlers, and manage the main slot for the payment methods.
+The `PaymentMethods` container is designed to manage and display the available payment methods during the checkout process. You can configure it to decide whether the container should not set the payment method automatically when it is selected (for instance because it needs more information provided by the payment method during the place order action), provide specific handlers to the payment methods, and manage the main slot for the payment methods.
 
 ## PaymentMethods configurations
 
-The `PaymentMethods` container provides the following configuration options:
+The `PaymentMethods` container provides the following configuration options implementing the `PaymentMethodsProps` interface:
 
 <OptionsTable
   compact
   options={[
     ['Option', 'Type', 'Req?', 'Description'],
-    ['slots.Main', 'SlotProps<PaymentMethodsMainSlotContext>', 'No', 'The main slot for the payment methods.'],
-    ['slots.Handlers', 'PaymentMethodHandlerSlots', 'No', 'The handlers for different payment methods.']
+    ['setOnChange', 'object', 'No', 'Object with a list of "[key: string]: boolean". Only if a payment method is specifically set to false, the container will not set the payment method when selected. By default, the container takes an empty object.'],
+    ['slots', 'object', 'No', 'Object with a "Main" payment method or a list of "Handlers" for existing payment methods.'],
   ]}
 />
 
-## Example
+### PaymentMethodsProps interface
+
+The `PaymentMethods` container receives an object as parameter which implements the `PaymentMethodsProps` interface:
+
+```ts
+export interface PaymentMethodsProps extends HTMLAttributes<HTMLDivElement> {
+  setOnChange?: { [key: string]: boolean };
+  slots?: {
+    Main?: SlotProps<PaymentMethodsMainSlotContext>;
+    Handlers?: PaymentMethodHandlerSlots;
+  };
+}
+```
+
+The `slots` parameter is an object within the following fields:
+
+### Main field
+
+Function which provides a context and returns a Promise. It should be used if the merchant wants to configure just a main payment method.
+
+```ts
+export type SlotProps<T = any> = (
+  ctx: T & DefaultSlotContext<T>,
+  element: HTMLDivElement | null
+) => Promise<void> | void;
+
+export interface PaymentMethodsMainSlotContext {
+  replaceHTML: (domElement: HTMLElement) => void;
+}
+```
+
+### Handlers field
+
+List of payment method codes providing a handler to be executed when the payment method is selected.
+
+```ts
+export type SlotProps<T = any> = (
+  ctx: T & DefaultSlotContext<T>,
+  element: HTMLDivElement | null
+) => Promise<void> | void;
+
+export interface PaymentMethodHandlerSlotContext {
+  cartId: string;
+  replaceHTML: (domElement: HTMLElement) => void;
+}
+
+export interface PaymentMethodHandlerSlots {
+  [code: string]: SlotProps<PaymentMethodHandlerSlotContext>;
+}
+```
+
+## Example 1
 
 The following example renders the `PaymentMethods` container on a checkout page, displaying the available payment methods in the element with the class `checkout__payment-methods`:
 
@@ -29,8 +80,90 @@ import PaymentMethods from '@dropins/storefront-checkout/containers/PaymentMetho
 import { render as CheckoutProvider } from '@dropins/storefront-checkout/render.js';
 
 const $paymentMethods = checkoutFragment.querySelector(
-  '.checkout__payment-methods'
+  '.checkout__payment-methods',
 );
 
 CheckoutProvider.render(PaymentMethods)($paymentMethods),
+```
+
+## Example 2
+
+The following example renders the `PaymentMethods` container on a checkout page, displaying the available payment methods in the element with the class `checkout__payment-methods`, providing handlers for `checkmo` and `braintree` payment methods, and finally configuring `braintree` to not be set to the cart when selected:
+
+```ts
+import PaymentMethods from '@dropins/storefront-checkout/containers/PaymentMethods.js';
+import { render as CheckoutProvider } from '@dropins/storefront-checkout/render.js';
+
+const $paymentMethods = checkoutFragment.querySelector(
+  '.checkout__payment-methods',
+);
+
+CheckoutProvider.render(PaymentMethods, {
+  setOnChange: {
+    braintree: false,
+  },
+  slots: {
+    Handlers: {
+      checkmo: (_ctx) => {
+        const $content = document.createElement('div');
+
+        $content.innerText = 'Pay later with Checkmo';
+        _ctx.replaceHTML($content);
+      },
+      braintree: async (ctx) => {
+        const container = document.createElement('div');
+
+        window.braintree.dropin.create({
+          authorization: 'sandbox_cstz6tw9_sbj9bzvx2ngq77n4',
+          container,
+        }, (err, dropinInstance) => {
+          if (err) {
+            console.error(err);
+          }
+
+          braintreeInstance = dropinInstance;
+        });
+
+        ctx.replaceHTML(container);
+      },
+    },
+  },
+})($paymentMethods),
+```
+
+## Example 3
+
+The following example renders the `PaymentMethods` container on a checkout page, displaying a main payment method in the element with the class `checkout__payment-methods`:
+
+```ts
+import PaymentMethods from '@dropins/storefront-checkout/containers/PaymentMethods.js';
+import { render as CheckoutProvider } from '@dropins/storefront-checkout/render.js';
+
+import 'https://js.braintreegateway.com/web/dropin/1.43.0/js/dropin.min.js';
+
+const $paymentMethods = checkoutFragment.querySelector(
+  '.checkout__payment-methods',
+);
+
+// Define the modifier for the Payment Methods section
+const renderBraintreePayments = (ctx, element) => {
+  const container = document.createElement('div');
+
+  if (element) {
+    element.innerHTML = container.innerHTML;
+    window.braintree.dropin.create({
+      authorization: 'sandbox_cstz6tw9_sbj9bzvx2ngq77n4',
+      container,
+    });
+  }
+
+  ctx.replaceHTML(container);
+};
+
+// CheckoutProvider.render(PaymentMethods)($paymentMethods),
+CheckoutProvider.render(PaymentMethods, {
+  slots: {
+    Main: renderBraintreePayments,
+  },
+})($paymentMethods),
 ```

--- a/src/content/docs/dropins/checkout/containers/payment-methods.mdx
+++ b/src/content/docs/dropins/checkout/containers/payment-methods.mdx
@@ -88,15 +88,20 @@ CheckoutProvider.render(PaymentMethods)($paymentMethods),
 
 ## Example 2
 
-The following example renders the `PaymentMethods` container on a checkout page, displaying the available payment methods in the element with the class `checkout__payment-methods`, providing handlers for `checkmo` and `braintree` payment methods, and finally configuring `braintree` to not be set to the cart when selected:
+The following example renders the `PaymentMethods` container on a checkout page, displaying the available payment methods in the element with the class `checkout__payment-methods`, providing handlers for `PaymentServices` and `braintree` payment methods, and finally configuring `braintree` to not be set to the cart when selected:
 
 ```ts
 import PaymentMethods from '@dropins/storefront-checkout/containers/PaymentMethods.js';
 import { render as CheckoutProvider } from '@dropins/storefront-checkout/render.js';
 
+import CreditCard, { CREDIT_CARD_CODE } from '@dropins/payment-services/containers/CreditCard.js';
+import { render as paymentServicesProvider } from '@dropins/payment-services/render.js';
+
 const $paymentMethods = checkoutFragment.querySelector(
   '.checkout__payment-methods',
 );
+
+const apiUrl = await getConfigValue('commerce-core-endpoint');
 
 CheckoutProvider.render(PaymentMethods, {
   setOnChange: {
@@ -104,11 +109,24 @@ CheckoutProvider.render(PaymentMethods, {
   },
   slots: {
     Handlers: {
-      checkmo: (_ctx) => {
+      // Render Payment Services Dropin
+      [CREDIT_CARD_CODE]: (ctx) => {
         const $content = document.createElement('div');
 
-        $content.innerText = 'Pay later with Checkmo';
-        _ctx.replaceHTML($content);
+        $content.innerText = CREDIT_CARD_CODE;
+        ctx.replaceHTML($content);
+        placeOrder.setProps((props) => ({ ...props, disabled: true }));
+        paymentServicesProvider.render(CreditCard, {
+          apiUrl,
+          getCustomerToken: getUserTokenCookie,
+          getCartId: () => ctx.cartId,
+          onValidation: (isValid) => {
+            placeOrder.setProps((props) => ({ ...props, disabled: !isValid }));
+          },
+          onRender: (creditCard) => {
+            paymentServicesCreditCard = creditCard;
+          },
+        })($content);
       },
       braintree: async (ctx) => {
         const container = document.createElement('div');

--- a/src/content/docs/dropins/product-details/index.mdx
+++ b/src/content/docs/dropins/product-details/index.mdx
@@ -4,6 +4,7 @@ description: Learn about the purpose, features, and use cases of the product det
 ---
 
 import Aside from '@components/Aside.astro';
+import { Badge } from '@astrojs/starlight/components';
 import Callouts from '@components/Callouts.astro';
 import Diagram from '@components/Diagram.astro';
 import { Image } from 'astro:assets';

--- a/src/content/docs/dropins/product-details/index.mdx
+++ b/src/content/docs/dropins/product-details/index.mdx
@@ -26,6 +26,21 @@ The PDP component provides a variety of fully-customizable controls to showcase 
 - **Product Reviews**: Include user reviews and ratings to provide social proof and help users make informed purchasing decisions.
 - **Customization Options**: Customize the appearance and behavior of the drop-in component to align with your brand's design aesthetic and user experience goals.
 
+## Supported Commerce features
+
+The following table provides an overview of the Adobe Commerce features that the PdP drop-in component supports:
+
+| Feature                         | Status                                       |
+| ------------------------------- | -------------------------------------------- |
+| Bundle product type             | <Badge text="Supported" variant="success" /> |
+| Configurable product type       | <Badge text="Supported" variant="success" /> |
+| Image gallery                   | <Badge text="Supported" variant="success" /> |
+| Grouped products                | <Badge text="Roadmap" variant="note" />      |
+| Product details                 | <Badge text="Supported" variant="success" /> |
+| Simple product type             | <Badge text="Supported" variant="success" /> |
+| Virtual product type            | <Badge text="Roadmap" variant="note" />      |
+| Zoom                            | <Badge text="Supported" variant="success" /> |
+
 ## Render product types
 
 The PDP component supports rendering different product types configured in your Adobe Commerce instance by default using data provided by the [Catalog Service GraphQL API](https://developer.adobe.com/commerce/services/graphql/catalog-service/). Adobe Commerce supports seven product types, but the Catalog Service GraphQL API schema maps these to two types:


### PR DESCRIPTION
Adapted PaymentMethods container docs based on the last changes in Checkout dropin.
Updated the following sections:
- **PaymentMethods description**
- **PaymentMethods configurations**
1.  Added `setOnChange`param
2. Updated `slots`param
- Added interfaces used on the params
- Added **Example 1** (all payment methods available in Magento)
- Added **Example 2** (showing how to use setOnChange and slots.Handlers params)
- Added **Example 3** (showing how to use slots.Main param)
