### PR TITLE
USF-1911: Remove the slot.Main config in PaymentMethods container

### DIFF
--- a/src/content/docs/dropins/checkout/containers/payment-methods.mdx
+++ b/src/content/docs/dropins/checkout/containers/payment-methods.mdx
@@ -5,7 +5,7 @@ description: Configure the PaymentMethods container to manage and display availa
 
 import OptionsTable from '@components/OptionsTable.astro';
 
-The `PaymentMethods` container is designed to manage and display the available payment methods during the checkout process. You can configure it to decide whether the container should not set the payment method automatically when it is selected (for instance because it needs more information provided by the payment method during the place order action), provide specific handlers to the payment methods, and manage the main slot for the payment methods.
+The `PaymentMethods` container is designed to manage and display the available payment methods during the checkout process. You can configure it to decide whether the container should not set the payment method automatically when it is selected (for instance because it needs more information provided by the payment method during the place order action) and provide specific handlers to the payment methods.
 
 ## PaymentMethods configurations
 
@@ -15,8 +15,8 @@ The `PaymentMethods` container provides the following configuration options impl
   compact
   options={[
     ['Option', 'Type', 'Req?', 'Description'],
-    ['setOnChange', 'object', 'No', 'Object with a list of "[key: string]: boolean". Only if a payment method is specifically set to false, the container will not set the payment method when selected. By default, the container takes an empty object.'],
-    ['slots', 'object', 'No', 'Object with a "Main" payment method or a list of "Handlers" for existing payment methods.'],
+    ['setOnChange', 'object', 'No', 'Object with a list of "[key: string]: boolean". Only if a payment method is specifically set to false, the container will not automatically set the payment method to the cart when selected. By default, the container takes an empty object.'],
+    ['slots', 'object', 'No', 'Object with a list of "Handlers" for existing payment methods.'],
   ]}
 />
 
@@ -28,28 +28,12 @@ The `PaymentMethods` container receives an object as parameter which implements 
 export interface PaymentMethodsProps extends HTMLAttributes<HTMLDivElement> {
   setOnChange?: { [key: string]: boolean };
   slots?: {
-    Main?: SlotProps<PaymentMethodsMainSlotContext>;
     Handlers?: PaymentMethodHandlerSlots;
   };
 }
 ```
 
 The `slots` parameter is an object within the following fields:
-
-### Main field
-
-Function which provides a context and returns a Promise. It should be used if the merchant wants to configure just a main payment method.
-
-```ts
-export type SlotProps<T = any> = (
-  ctx: T & DefaultSlotContext<T>,
-  element: HTMLDivElement | null
-) => Promise<void> | void;
-
-export interface PaymentMethodsMainSlotContext {
-  replaceHTML: (domElement: HTMLElement) => void;
-}
-```
 
 ### Handlers field
 
@@ -71,7 +55,7 @@ export interface PaymentMethodHandlerSlots {
 }
 ```
 
-## Example 1
+## Example 1: Available payment methods without customization
 
 The following example renders the `PaymentMethods` container on a checkout page, displaying the available payment methods in the element with the class `checkout__payment-methods`:
 
@@ -86,22 +70,21 @@ const $paymentMethods = checkoutFragment.querySelector(
 CheckoutProvider.render(PaymentMethods)($paymentMethods),
 ```
 
-## Example 2
+## Example 2: How to use the `setOnChange` configuration
 
-The following example renders the `PaymentMethods` container on a checkout page, displaying the available payment methods in the element with the class `checkout__payment-methods`, providing handlers for `PaymentServices` and `braintree` payment methods, and finally configuring `braintree` to not be set to the cart when selected:
+The following example renders the `PaymentMethods` container on a checkout page, displaying the available payment methods in the element with the class `checkout__payment-methods`, providing a specific handler for `braintree` payment method indicating it cannot be set to the cart when selected:
 
 ```ts
 import PaymentMethods from '@dropins/storefront-checkout/containers/PaymentMethods.js';
 import { render as CheckoutProvider } from '@dropins/storefront-checkout/render.js';
 
-import CreditCard, { CREDIT_CARD_CODE } from '@dropins/payment-services/containers/CreditCard.js';
-import { render as paymentServicesProvider } from '@dropins/payment-services/render.js';
+import 'https://js.braintreegateway.com/web/dropin/1.43.0/js/dropin.min.js';
 
 const $paymentMethods = checkoutFragment.querySelector(
   '.checkout__payment-methods',
 );
 
-const apiUrl = await getConfigValue('commerce-core-endpoint');
+let braintreeInstance;
 
 CheckoutProvider.render(PaymentMethods, {
   setOnChange: {
@@ -109,25 +92,6 @@ CheckoutProvider.render(PaymentMethods, {
   },
   slots: {
     Handlers: {
-      // Render Payment Services Dropin
-      [CREDIT_CARD_CODE]: (ctx) => {
-        const $content = document.createElement('div');
-
-        $content.innerText = CREDIT_CARD_CODE;
-        ctx.replaceHTML($content);
-        placeOrder.setProps((props) => ({ ...props, disabled: true }));
-        paymentServicesProvider.render(CreditCard, {
-          apiUrl,
-          getCustomerToken: getUserTokenCookie,
-          getCartId: () => ctx.cartId,
-          onValidation: (isValid) => {
-            placeOrder.setProps((props) => ({ ...props, disabled: !isValid }));
-          },
-          onRender: (creditCard) => {
-            paymentServicesCreditCard = creditCard;
-          },
-        })($content);
-      },
       braintree: async (ctx) => {
         const container = document.createElement('div');
 
@@ -149,39 +113,46 @@ CheckoutProvider.render(PaymentMethods, {
 })($paymentMethods),
 ```
 
-## Example 3
+## Example 3: How to customize a payment method using the `slots.Handlers` configuration
 
-The following example renders the `PaymentMethods` container on a checkout page, displaying a main payment method in the element with the class `checkout__payment-methods`:
+The following example renders the `PaymentMethods` container on a checkout page, displaying the available payment methods in the element with the class `checkout__payment-methods`, providing a specific handler for `PaymentServices` payment method:
 
 ```ts
 import PaymentMethods from '@dropins/storefront-checkout/containers/PaymentMethods.js';
 import { render as CheckoutProvider } from '@dropins/storefront-checkout/render.js';
 
-import 'https://js.braintreegateway.com/web/dropin/1.43.0/js/dropin.min.js';
+import CreditCard, { CREDIT_CARD_CODE } from '@dropins/payment-services/containers/CreditCard.js';
+import { render as paymentServicesProvider } from '@dropins/payment-services/render.js';
 
 const $paymentMethods = checkoutFragment.querySelector(
   '.checkout__payment-methods',
 );
 
-// Define the modifier for the Payment Methods section
-const renderBraintreePayments = (ctx, element) => {
-  const container = document.createElement('div');
+const apiUrl = await getConfigValue('commerce-core-endpoint');
 
-  if (element) {
-    element.innerHTML = container.innerHTML;
-    window.braintree.dropin.create({
-      authorization: 'sandbox_cstz6tw9_sbj9bzvx2ngq77n4',
-      container,
-    });
-  }
-
-  ctx.replaceHTML(container);
-};
-
-// CheckoutProvider.render(PaymentMethods)($paymentMethods),
 CheckoutProvider.render(PaymentMethods, {
   slots: {
-    Main: renderBraintreePayments,
+    Handlers: {
+      // Render Payment Services Dropin
+      [CREDIT_CARD_CODE]: (ctx) => {
+        const $content = document.createElement('div');
+
+        $content.innerText = CREDIT_CARD_CODE;
+        ctx.replaceHTML($content);
+        placeOrder.setProps((props) => ({ ...props, disabled: true }));
+        paymentServicesProvider.render(CreditCard, {
+          apiUrl,
+          getCustomerToken: getUserTokenCookie,
+          getCartId: () => ctx.cartId,
+          onValidation: (isValid) => {
+            placeOrder.setProps((props) => ({ ...props, disabled: !isValid }));
+          },
+          onRender: (creditCard) => {
+            paymentServicesCreditCard = creditCard;
+          },
+        })($content);
+      },
+    },
   },
 })($paymentMethods),
 ```


### PR DESCRIPTION
## Description
As the current `slots.Main`configuration is not really needed and taking into account it is going to be deprecated on the next Checkout drop-in release, the team has decided to remove it directly instead of deprecate it because no clients are using the configuration yet.
