### PR TITLE
PAY-5872: Update CreditCard examples and props after updating API

### DIFF
--- a/src/content/docs/dropins/checkout/containers/payment-methods.mdx
+++ b/src/content/docs/dropins/checkout/containers/payment-methods.mdx
@@ -119,16 +119,18 @@ The following example renders the `PaymentMethods` container on a checkout page,
 
 ```ts
 import PaymentMethods from '@dropins/storefront-checkout/containers/PaymentMethods.js';
-import { render as CheckoutProvider } from '@dropins/storefront-checkout/render.js';
-
 import CreditCard, { CREDIT_CARD_CODE } from '@dropins/payment-services/containers/CreditCard.js';
-import { render as paymentServicesProvider } from '@dropins/payment-services/render.js';
+import { getConfigValue } from '../../scripts/configs.js';
+import { getUserTokenCookie } from '../../scripts/initializers/index.js';
+import { render as CheckoutProvider } from '@dropins/storefront-checkout/render.js';
+import { render as PaymentServices } from '@dropins/payment-services/render.js';
 
 const $paymentMethods = checkoutFragment.querySelector(
   '.checkout__payment-methods',
 );
 
-const apiUrl = await getConfigValue('commerce-core-endpoint');
+const commerceCoreEndpoint = await getConfigValue('commerce-core-endpoint');
+const creditCardFormRef = { current: null }; // Use this to validate and submit the form
 
 CheckoutProvider.render(PaymentMethods, {
   slots: {
@@ -136,20 +138,13 @@ CheckoutProvider.render(PaymentMethods, {
       // Render Payment Services Dropin
       [CREDIT_CARD_CODE]: (ctx) => {
         const $content = document.createElement('div');
-
-        $content.innerText = CREDIT_CARD_CODE;
         ctx.replaceHTML($content);
-        placeOrder.setProps((props) => ({ ...props, disabled: true }));
+
         paymentServicesProvider.render(CreditCard, {
-          apiUrl,
+          apiUrl: commerceCoreEndpoint,
           getCustomerToken: getUserTokenCookie,
           getCartId: () => ctx.cartId,
-          onValidation: (isValid) => {
-            placeOrder.setProps((props) => ({ ...props, disabled: !isValid }));
-          },
-          onRender: (creditCard) => {
-            paymentServicesCreditCard = creditCard;
-          },
+          creditCardFormRef,
         })($content);
       },
     },

--- a/src/content/docs/dropins/checkout/containers/place-order.mdx
+++ b/src/content/docs/dropins/checkout/containers/place-order.mdx
@@ -66,14 +66,18 @@ CheckoutProvider.render(PlaceOrder, {
       success = billingFormRef.current.handleValidationSubmit(false);
     }
 
+    if (success && creditCardFormRef.current) {
+      success = creditCardFormRef.current.validate();
+    }
+
     return success;
   },
   handlePlaceOrder: async ({ code, cartId }) => {
     await displayOverlaySpinner();
     try {
-      // Submit Payment Services credit card form
       if (code === CREDIT_CARD_CODE) {
-        await paymentServicesCreditCard.submit();
+        // Submit payment services credit card form
+        await creditCardFormRef.current.submit();
       }
       // Place order
       await orderApi.placeOrder(cartId);

--- a/src/content/docs/dropins/payment-services/containers/credit-card.mdx
+++ b/src/content/docs/dropins/payment-services/containers/credit-card.mdx
@@ -17,11 +17,10 @@ The `CreditCard` container provides the following configuration options:
     ['Option', 'Type', 'Req?', 'Description'],
     ['apiUrl', 'string', 'Yes', 'The URL to the Adobe Commerce GraphQL endpoint, such as "https://example.com/graphql".'],
     ['getCartId', 'function', 'Yes', 'Should return a promise that resolves to the shopper`s cart ID.'],
-    ['getCustomerToken', 'function', 'No', 'The credit card container may send GraphQL requests on behalf of the shopper. This requires GraphQL authorization, which can be performed using authorization tokens or session cookies. For token-based authorization, the "getCustomerToken" function should return a customer token as a string, or null for guest checkouts. The "getCustomerToken" function should not be provided for session-based authorization.'],
+    ['getCustomerToken', 'function', 'Yes', 'The credit card container may send GraphQL requests on behalf of the shopper. This requires GraphQL authorization, which can be performed using authorization tokens or session cookies. For token-based authorization, the "getCustomerToken" function should return a customer token as a string or null for guest checkouts. For session-based authorization, the "getCustomerToken" property must explicitly be set to "null".'],
+    ['creditCardFormRef', 'object', 'Yes', 'Credit card form reference. Initially, { current: null } should be passed. Once rendered, the credit card container will set the "current" property to an { validate: () => boolean; submit: () => Promise<void> } object, which parent containers can use to (programmatically) validate and submit the credit card form.'],
     ['onSuccess', 'function', 'No', 'Called when payment flow finishes successfully. This function is not passed any arguments.'],
     ['onError', 'function', 'No', 'Called when the payment flow was aborted due to an error. The function receives a single argument, {message: string}, containing the reason of error.'],
-    ['onRender', 'function', 'No', 'Called when the credit card fields render successfully. The function receives the credit card instance as its single argument, which has a submit() method to be used to start the payment flow.'],
-    ['onValidation', 'function', 'No', 'Called when the credit card form validity changes. Use this to disable/enable a "Place order" button.'],
   ]}
 />
 


### PR DESCRIPTION
Update examples and component props documentation after updating CreditCard container API in https://git.corp.adobe.com/magento-payments/storefront-payment-services/pull/34.