### PR TITLE
PAY-5922: Refactor Payment Services payment method codes

### DIFF
--- a/src/content/docs/dropins/checkout/containers/payment-methods.mdx
+++ b/src/content/docs/dropins/checkout/containers/payment-methods.mdx
@@ -9,6 +9,8 @@ The `PaymentMethods` container is designed to manage and display the available p
 
 ## PaymentMethods configurations
 
+🚧 TODO: Update to take into account changes to API made in https://git.corp.adobe.com/Commerce-Storefront/storefront-checkout/pull/963 (with new `slots: {Methods: []}` structure) 🚧
+
 The `PaymentMethods` container provides the following configuration options implementing the `PaymentMethodsProps` interface:
 
 <OptionsTable
@@ -33,7 +35,7 @@ export interface PaymentMethodsProps extends HTMLAttributes<HTMLDivElement> {
 }
 ```
 
-The `slots` parameter is an object within the following fields:
+The `slots` parameter is an object with the following fields:
 
 ### Handlers field
 
@@ -113,39 +115,38 @@ CheckoutProvider.render(PaymentMethods, {
 })($paymentMethods),
 ```
 
-## Example 3: How to customize a payment method using the `slots.Handlers` configuration
+## Example 3: How to customize a payment method using the `slots.Methods` configuration
 
-The following example renders the `PaymentMethods` container on a checkout page, displaying the available payment methods in the element with the class `checkout__payment-methods`, providing a specific handler for `PaymentServices` payment method:
+The following example renders the `PaymentMethods` container on a checkout page, displaying the available payment methods in the element with the class `checkout__payment-methods`, providing a specific handler for Payment Services' `CREDIT_CARD` payment method:
 
 ```ts
 import PaymentMethods from '@dropins/storefront-checkout/containers/PaymentMethods.js';
-import CreditCard, { CREDIT_CARD_CODE } from '@dropins/payment-services/containers/CreditCard.js';
-import { getConfigValue } from '../../scripts/configs.js';
+import CreditCard from '@dropins/storefront-payment-services/containers/CreditCard.js';
+import { render as PaymentServices } from '@dropins/storefront-payment-services/render.js';
+import { PaymentMethodCode } from '@dropins/storefront-payment-services/api.js';
 import { getUserTokenCookie } from '../../scripts/initializers/index.js';
-import { render as CheckoutProvider } from '@dropins/storefront-checkout/render.js';
-import { render as PaymentServices } from '@dropins/payment-services/render.js';
+import { getConfigValue } from '../../scripts/configs.js';
 
 const $paymentMethods = checkoutFragment.querySelector(
   '.checkout__payment-methods',
 );
 
 const commerceCoreEndpoint = await getConfigValue('commerce-core-endpoint');
-const creditCardFormRef = { current: null }; // Use this to validate and submit the form
 
 CheckoutProvider.render(PaymentMethods, {
   slots: {
-    Handlers: {
-      // Render Payment Services Dropin
-      [CREDIT_CARD_CODE]: (ctx) => {
+    Methods: {
+      [PaymentMethodCode.CREDIT_CARD]: (ctx) => {
         const $content = document.createElement('div');
-        ctx.replaceHTML($content);
 
-        paymentServicesProvider.render(CreditCard, {
+        PaymentServices.render(CreditCard, {
           apiUrl: commerceCoreEndpoint,
           getCustomerToken: getUserTokenCookie,
+          creditCardFormRef: { current: null },
           getCartId: () => ctx.cartId,
-          creditCardFormRef,
         })($content);
+
+        ctx.replaceHTML($content);
       },
     },
   },

--- a/src/content/docs/dropins/checkout/containers/payment-methods.mdx
+++ b/src/content/docs/dropins/checkout/containers/payment-methods.mdx
@@ -116,7 +116,7 @@ CheckoutProvider.render(PaymentMethods, {
 
 ## Example 3: How to customize a payment method using the `slots.Methods` configuration
 
-The following example renders the `PaymentMethods` container on a checkout page, displaying the available payment methods in the element with the class `checkout__payment-methods`, providing a specific handler for the Payment Services `CreditCard` payment method:
+The following example renders the `PaymentMethods` container on a checkout page, displaying the available payment methods in the element with the class `checkout__payment-methods`, providing a specific handler for the Payment Services [PaymentMethodCode.CREDIT_CARD]:
 
 ```ts
 import PaymentMethods from '@dropins/storefront-checkout/containers/PaymentMethods.js';

--- a/src/content/docs/dropins/checkout/containers/payment-methods.mdx
+++ b/src/content/docs/dropins/checkout/containers/payment-methods.mdx
@@ -9,7 +9,6 @@ The `PaymentMethods` container is designed to manage and display the available p
 
 ## PaymentMethods configurations
 
-🚧 TODO: Update to take into account changes to API made in https://git.corp.adobe.com/Commerce-Storefront/storefront-checkout/pull/963 (with new `slots: {Methods: []}` structure) 🚧
 
 The `PaymentMethods` container provides the following configuration options implementing the `PaymentMethodsProps` interface:
 

--- a/src/content/docs/dropins/checkout/containers/payment-methods.mdx
+++ b/src/content/docs/dropins/checkout/containers/payment-methods.mdx
@@ -117,7 +117,7 @@ CheckoutProvider.render(PaymentMethods, {
 
 ## Example 3: How to customize a payment method using the `slots.Methods` configuration
 
-The following example renders the `PaymentMethods` container on a checkout page, displaying the available payment methods in the element with the class `checkout__payment-methods`, providing a specific handler for Payment Services' `CREDIT_CARD` payment method:
+The following example renders the `PaymentMethods` container on a checkout page, displaying the available payment methods in the element with the class `checkout__payment-methods`, providing a specific handler for the Payment Services `CreditCard` payment method:
 
 ```ts
 import PaymentMethods from '@dropins/storefront-checkout/containers/PaymentMethods.js';

--- a/src/content/docs/dropins/checkout/containers/place-order.mdx
+++ b/src/content/docs/dropins/checkout/containers/place-order.mdx
@@ -66,17 +66,22 @@ CheckoutProvider.render(PlaceOrder, {
       success = billingFormRef.current.handleValidationSubmit(false);
     }
 
-    if (success && creditCardFormRef.current) {
-      success = creditCardFormRef.current.validate();
-    }
-
     return success;
   },
   handlePlaceOrder: async ({ code, cartId }) => {
     await displayOverlaySpinner();
     try {
-      if (code === CREDIT_CARD_CODE) {
-        // Submit payment services credit card form
+      // Payment Services credit card
+      if (code === PaymentMethodCode.CREDIT_CARD) {
+        if (!creditCardFormRef.current) {
+          console.error('Credit card form not rendered.');
+          return;
+        }
+        if (!creditCardFormRef.current.validate()) {
+          // Credit card form invalid; abort order placement
+          return;
+        }
+        // Submit Payment Services credit card form
         await creditCardFormRef.current.submit();
       }
       // Place order

--- a/src/content/docs/dropins/payment-services/containers/credit-card.mdx
+++ b/src/content/docs/dropins/payment-services/containers/credit-card.mdx
@@ -26,27 +26,32 @@ The `CreditCard` container provides the following configuration options:
 
 ## Example
 
-The following example renders the `CreditCard` container to handle and display the available credit card fields as a payment method.
+The fllowing example shows how to render and submit a credit card form.
 
 ```js
-import CreditCard, { CREDIT_CARD_CODE } from '@dropins/payment-services/containers/CreditCard.js';
-import { render as PaymentServicesProvider } from '@dropins/payment-services/render.js';
-import { getConfigValue } from '../../scripts/configs.js';
+import CreditCard from '@dropins/storefront-payment-services/containers/CreditCard.js';
+import { render as PaymentServices } from '@dropins/storefront-payment-services/render.js';
 import { getUserTokenCookie } from '../../scripts/initializers/index.js';
+import { getConfigValue } from '../../scripts/configs.js';
 
-const apiUrl = await getConfigValue('commerce-core-endpoint');
-const container = document.createElement('div');
+const commerceCoreEndpoint = await getConfigValue('commerce-core-endpoint');
+const $content = document.createElement('div');
+const creditCardFormRef = { current: null };
 const placeOrderButton = document.getElementById('place-order');
-const getCartId = () => 'ozGi7uLI74etDYyMijoI2cla5CmGIBch';
 
-PaymentServicesProvider.render(CreditCard, {
-  apiUrl: apiUrl,
+PaymentServices.render(CreditCard, {
+  apiUrl: commerceCoreEndpoint,
   getCustomerToken: getUserTokenCookie,
-  getCartId: getCartId,
-  onRender: (creditCardForm) => {
-    placeOrderButton.onclick = async () => {
-      await creditCardForm.submit();
-    };
-  },
-})(container);
+  getCartId: () => 'ozGi7uLI74etDYyMijoI2cla5CmGIBch',
+  creditCardFormRef: creditCardFormRef,
+})($content);
+
+placeOrderButton.onclick = () => {
+  if (creditCardFormRef.current) {
+    if (creditCardFormRef.current.validate() {
+      const future = creditCardFormRef.current.submit()
+      future.catch(console.error)
+    }
+  }
+}
 ```

--- a/src/content/docs/dropins/payment-services/containers/credit-card.mdx
+++ b/src/content/docs/dropins/payment-services/containers/credit-card.mdx
@@ -26,7 +26,7 @@ The `CreditCard` container provides the following configuration options:
 
 ## Example
 
-The fllowing example shows how to render and submit a credit card form.
+The following example shows how to render and submit a credit card form.
 
 ```js
 import CreditCard from '@dropins/storefront-payment-services/containers/CreditCard.js';


### PR DESCRIPTION
Update code examples:

- Update Payment Services payment method codes after refactoring how we expose them in the Payment Services drop-in in https://git.corp.adobe.com/magento-payments/storefront-payment-services/pull/38

- Add a TODO to update checkout drop-in code examples after updating slots API in https://git.corp.adobe.com/Commerce-Storefront/storefront-checkout/pull/963

- Update checkout drop-in "place order" code example after refactoring form validation in https://git.corp.adobe.com/Commerce-Storefront/storefront-checkout/pull/993