### PR TITLE
USF-1284: Add demo videos

### DIFF
--- a/src/components/LinkCard.astro
+++ b/src/components/LinkCard.astro
@@ -11,6 +11,7 @@ interface Props extends Omit<HTMLAttributes<'a'>, 'title'> {
   image?: string | ImageMetadata | Promise<{ default: ImageMetadata }> | undefined;
   icon?: keyof typeof Icons;
   rightIcon?: keyof typeof Icons;
+  link: string;
   noborder?: boolean;
 }
 

--- a/src/pages/videos/add-product-lines-to-cart-summary.astro
+++ b/src/pages/videos/add-product-lines-to-cart-summary.astro
@@ -1,0 +1,86 @@
+---
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+import Aside from '@components/Aside.astro';
+---
+
+<StarlightPage
+  frontmatter={{
+    title: 'Add custom product lines to the cart summary',
+    description: 'Learn how to add custom lines related to products in the cart summary.',
+    tableOfContents: false,
+    editUrl:
+      'https://github.com/commerce-docs/microsite-commerce-storefront/blob/api-playground/src/pages/videos/customize-cart.astro',
+  }}
+  sidebar={[
+    {
+      label: 'Training Videos',
+      items: [
+        { label: 'Overview', link: '/videos/' },
+        { label: 'Add custom product lines to cart summary', link: '/videos/add-product-lines-to-cart-summary/' },
+        { label: 'Buy online, pickup in store', link: '/videos/buy-online-pickup-in-store/' },
+        { label: 'Customize address form layout and address lookup', link: '/videos/customize-address-form-layout/' },
+        { label: 'Customize cart summary', link: '/videos/customize-cart-summary/' },
+        { label: 'Customize order summary lines', link: '/videos/customize-order-summary-lines/' },
+        { label: 'Multi-step guest checkout', link: '/videos/multi-step-checkout/' },
+      ],
+    },
+  ]}
+>
+  <style is:global>
+    .sl-container.sl-container {
+      max-width: 100%;
+    }
+    .meta.sl-flex {
+      margin-top: 0;
+      margin-bottom: 1rem;
+      padding-top: 0;
+    }
+  </style>
+
+  <h2>What you'll learn</h2>
+
+  <p>In this video, you will learn how to customize and extend the cart drop-in component to achieve the following:</p>
+
+  <ul>
+    <li>Display delivery timelines for back-order products</li>
+    <li>Show returnable and final sale notices</li>
+    <li>Apply a 25% discount for carts with a subtotal of $75 or more</li>
+  </ul>
+    
+  <p>By leveraging product attributes and slots, adding these features into the shopping cart enhances the overall user experience.</p>
+
+  <h2>Who is this video for?</h2>
+
+  <p>Roles that would benefit from reading this transcript include:</p>
+
+  <ul>
+    <li>E-commerce businesses looking to enhance the shopping cart with delivery timelines, sale information, and discounts.</li>
+    <li>Developers who need to learn how to implement these customizations for cart items.</li>
+    <li>Merchandisers to understand what options are available using native features to enhance the customer experience.</li>
+  </ul>
+
+  <h2>Video content</h2>
+
+  <ul>
+    <li>Customization of product detail and display customized delivery timelines for back-order products in the shopping cart.</li>
+    <li>Returnable and Final Sale Information examples using out of the box functionality for the cart items.</li>
+    <li>Coupon discount displayed using cart rules and footer slots to display this information effectively.</li>
+    <li>Using product attributes and Slots to extend and customize the shopping cart functionality, ensuring that all project requirements are met.</li>
+  </ul>
+
+  <div>
+    <iframe
+    width="760"
+    height="430"
+    src="https://video.tv.adobe.com/v/3441114?learn=on"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen
+    ></iframe>
+  </div>
+
+  <div style="max-width: 760px;">
+    <Aside type="note" title="Looking for the documentation?">
+      See the <a href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/cart/tutorials/add-product-lines-to-cart-summary/">text-based</a> version of this video tutorial for step-by-step instructions and code samples.
+    </Aside>
+
+</StarlightPage>

--- a/src/pages/videos/add-product-lines-to-cart-summary.astro
+++ b/src/pages/videos/add-product-lines-to-cart-summary.astro
@@ -16,9 +16,15 @@ import Aside from '@components/Aside.astro';
       label: 'Training Videos',
       items: [
         { label: 'Overview', link: '/videos/' },
-        { label: 'Add custom product lines to cart summary', link: '/videos/add-product-lines-to-cart-summary/' },
+        {
+          label: 'Add custom product lines to cart summary',
+          link: '/videos/add-product-lines-to-cart-summary/',
+        },
         { label: 'Buy online, pickup in store', link: '/videos/buy-online-pickup-in-store/' },
-        { label: 'Customize address form layout and address lookup', link: '/videos/customize-address-form-layout/' },
+        {
+          label: 'Customize address form layout and address lookup',
+          link: '/videos/customize-address-form-layout/',
+        },
         { label: 'Customize cart summary', link: '/videos/customize-cart-summary/' },
         { label: 'Customize order summary lines', link: '/videos/customize-order-summary-lines/' },
         { label: 'Multi-step guest checkout', link: '/videos/multi-step-checkout/' },
@@ -39,48 +45,74 @@ import Aside from '@components/Aside.astro';
 
   <h2>What you'll learn</h2>
 
-  <p>In this video, you will learn how to customize and extend the cart drop-in component to achieve the following:</p>
+  <p>
+    In this video, you will learn how to customize and extend the cart drop-in component to achieve
+    the following:
+  </p>
 
   <ul>
-    <li>Display delivery timelines for back-order products</li>
+    <li>Display delivery timelines for back-ordered products</li>
     <li>Show returnable and final sale notices</li>
-    <li>Apply a 25% discount for carts with a subtotal of $75 or more</li>
+    <li>Apply a 25% discount to carts with a subtotal of $75 or more</li>
   </ul>
-    
-  <p>By leveraging product attributes and slots, adding these features into the shopping cart enhances the overall user experience.</p>
+
+  <p>
+    By leveraging product attributes and slots, these features enhance the overall shopping cart
+    experience.
+  </p>
 
   <h2>Who is this video for?</h2>
 
-  <p>Roles that would benefit from reading this transcript include:</p>
+  <p>This video is beneficial for:</p>
 
   <ul>
-    <li>E-commerce businesses looking to enhance the shopping cart with delivery timelines, sale information, and discounts.</li>
-    <li>Developers who need to learn how to implement these customizations for cart items.</li>
-    <li>Merchandisers to understand what options are available using native features to enhance the customer experience.</li>
+    <li>
+      <strong>E-commerce businesses</strong> looking to enhance the shopping cart with delivery timelines,
+      sale information, and discounts.
+    </li>
+    <li><strong>Developers</strong> who need to implement these customizations for cart items.</li>
+    <li>
+      <strong>Merchandisers</strong> who want to understand the available native features to enhance
+      the customer experience.
+    </li>
   </ul>
 
   <h2>Video content</h2>
 
   <ul>
-    <li>Customization of product detail and display customized delivery timelines for back-order products in the shopping cart.</li>
-    <li>Returnable and Final Sale Information examples using out of the box functionality for the cart items.</li>
-    <li>Coupon discount displayed using cart rules and footer slots to display this information effectively.</li>
-    <li>Using product attributes and Slots to extend and customize the shopping cart functionality, ensuring that all project requirements are met.</li>
+    <li>
+      Customizing product details and displaying delivery timelines for back-ordered products in the
+      shopping cart.
+    </li>
+    <li>
+      Using out-of-the-box functionality to show returnable and final sale information for cart
+      items.
+    </li>
+    <li>
+      Applying coupon discounts using cart rules and footer slots to display discount details
+      effectively.
+    </li>
+    <li>
+      Extending and customizing shopping cart functionality using product attributes and slots to
+      meet project requirements.
+    </li>
   </ul>
 
   <div>
     <iframe
-    width="760"
-    height="430"
-    src="https://video.tv.adobe.com/v/3441114?learn=on"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowfullscreen
-    ></iframe>
+      width="760"
+      height="430"
+      src="https://video.tv.adobe.com/v/3441114?learn=on"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowfullscreen></iframe>
   </div>
 
   <div style="max-width: 760px;">
     <Aside type="note" title="Looking for the documentation?">
-      See the <a href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/cart/tutorials/add-product-lines-to-cart-summary/">text-based</a> version of this video tutorial for step-by-step instructions and code samples.
+      See the <a
+        href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/cart/tutorials/add-product-lines-to-cart-summary/"
+        >text-based</a
+      > version of this video tutorial for step-by-step instructions and code samples.
     </Aside>
-
+  </div>
 </StarlightPage>

--- a/src/pages/videos/buy-online-pickup-in-store.astro
+++ b/src/pages/videos/buy-online-pickup-in-store.astro
@@ -1,0 +1,76 @@
+---
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+import Aside from '@components/Aside.astro';
+---
+
+<StarlightPage
+  frontmatter={{
+    title: 'Buy online, pickup in store',
+    description: 'Learn how to implement a buy online, pickup in store checkout flow with the checkout drop-in components',
+    tableOfContents: false,
+    editUrl:
+      'https://github.com/commerce-docs/microsite-commerce-storefront/blob/api-playground/src/pages/videos/customize-cart.astro',
+  }}
+  sidebar={[
+    {
+      label: 'Training Videos',
+      items: [
+        { label: 'Overview', link: '/videos/' },
+        { label: 'Add custom product lines to cart summary', link: '/videos/add-product-lines-to-cart-summary/' },
+        { label: 'Buy online, pickup in store', link: '/videos/buy-online-pickup-in-store/' },
+        { label: 'Customize address form layout and address lookup', link: '/videos/customize-address-form-layout/' },
+        { label: 'Customize cart summary', link: '/videos/customize-cart-summary/' },
+        { label: 'Customize order summary lines', link: '/videos/customize-order-summary-lines/' },
+        { label: 'Multi-step guest checkout', link: '/videos/multi-step-checkout/' },
+      ],
+    },
+  ]}
+>
+  <style is:global>
+    .sl-container.sl-container {
+      max-width: 100%;
+    }
+    .meta.sl-flex {
+      margin-top: 0;
+      margin-bottom: 1rem;
+      padding-top: 0;
+    }
+  </style>
+  
+  <h2>What you'll learn</h2>
+
+  <p>Learn how to implement a buy online, pickup in store checkout flow (otherwise known as BOPIS).</p>
+
+  <h2>Who is this video for?</h2>
+
+  <ul>
+    <li>E-commerce businesses looking to enhance the shopping cart with BOPIS functionality.</li>
+    <li>Developers who need to learn how to implement BOPIS</li>
+  </ul>
+
+  <h2>Video content</h2>
+
+  <ul>
+    <li>Update content fragments.</li>
+    <li>Add UI elements for delivery and in-store pickup.</li>
+    <li>Toggle between delivery and in-store pickup.</li>
+    <li>Fetching pickup locations.</li>
+  </ul>
+
+  <div>
+    <iframe
+    width="760"
+    height="430"
+    src="https://video.tv.adobe.com/v/3441699?learn=on"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen
+    ></iframe>
+  </div>
+
+  <div style="max-width: 760px;">
+    <Aside type="note" title="Looking for the documentation?">
+      See the <a href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/checkout/tutorials/buy-online-pickup-in-store/">text-based</a> version of this video tutorial for step-by-step instructions and code samples.
+    </Aside>
+  </div>
+
+</StarlightPage>

--- a/src/pages/videos/buy-online-pickup-in-store.astro
+++ b/src/pages/videos/buy-online-pickup-in-store.astro
@@ -6,7 +6,8 @@ import Aside from '@components/Aside.astro';
 <StarlightPage
   frontmatter={{
     title: 'Buy online, pickup in store',
-    description: 'Learn how to implement a buy online, pickup in store checkout flow with the checkout drop-in components',
+    description:
+      'Learn how to implement a buy online, pickup in store checkout flow with the checkout drop-in components',
     tableOfContents: false,
     editUrl:
       'https://github.com/commerce-docs/microsite-commerce-storefront/blob/api-playground/src/pages/videos/customize-cart.astro',
@@ -16,9 +17,15 @@ import Aside from '@components/Aside.astro';
       label: 'Training Videos',
       items: [
         { label: 'Overview', link: '/videos/' },
-        { label: 'Add custom product lines to cart summary', link: '/videos/add-product-lines-to-cart-summary/' },
+        {
+          label: 'Add custom product lines to cart summary',
+          link: '/videos/add-product-lines-to-cart-summary/',
+        },
         { label: 'Buy online, pickup in store', link: '/videos/buy-online-pickup-in-store/' },
-        { label: 'Customize address form layout and address lookup', link: '/videos/customize-address-form-layout/' },
+        {
+          label: 'Customize address form layout and address lookup',
+          link: '/videos/customize-address-form-layout/',
+        },
         { label: 'Customize cart summary', link: '/videos/customize-cart-summary/' },
         { label: 'Customize order summary lines', link: '/videos/customize-order-summary-lines/' },
         { label: 'Multi-step guest checkout', link: '/videos/multi-step-checkout/' },
@@ -39,38 +46,41 @@ import Aside from '@components/Aside.astro';
   
   <h2>What you'll learn</h2>
 
-  <p>Learn how to implement a buy online, pickup in store checkout flow (otherwise known as BOPIS).</p>
+  <p>Learn how to implement a Buy Online, Pick Up In Store (BOPIS) checkout flow.</p>
 
   <h2>Who is this video for?</h2>
 
   <ul>
-    <li>E-commerce businesses looking to enhance the shopping cart with BOPIS functionality.</li>
-    <li>Developers who need to learn how to implement BOPIS</li>
+    <li>
+      <strong>E-commerce businesses</strong> looking to enhance the shopping cart with BOPIS functionality.
+    </li>
+    <li><strong>Developers</strong> who need to learn how to implement BOPIS.</li>
   </ul>
 
   <h2>Video content</h2>
 
   <ul>
-    <li>Update content fragments.</li>
-    <li>Add UI elements for delivery and in-store pickup.</li>
-    <li>Toggle between delivery and in-store pickup.</li>
+    <li>Updating content fragments.</li>
+    <li>Adding UI elements for delivery and in-store pickup.</li>
+    <li>Toggling between delivery and in-store pickup.</li>
     <li>Fetching pickup locations.</li>
   </ul>
 
   <div>
     <iframe
-    width="760"
-    height="430"
-    src="https://video.tv.adobe.com/v/3441699?learn=on"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowfullscreen
-    ></iframe>
+      width="760"
+      height="430"
+      src="https://video.tv.adobe.com/v/3441699?learn=on"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowfullscreen></iframe>
   </div>
 
   <div style="max-width: 760px;">
     <Aside type="note" title="Looking for the documentation?">
-      See the <a href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/checkout/tutorials/buy-online-pickup-in-store/">text-based</a> version of this video tutorial for step-by-step instructions and code samples.
+      See the <a
+        href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/checkout/tutorials/buy-online-pickup-in-store/"
+        >text-based</a
+      > version of this video tutorial for step-by-step instructions and code samples.
     </Aside>
   </div>
-
 </StarlightPage>

--- a/src/pages/videos/customize-address-form-layout.astro
+++ b/src/pages/videos/customize-address-form-layout.astro
@@ -1,0 +1,94 @@
+---
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+import Aside from '@components/Aside.astro';
+---
+
+<StarlightPage
+  frontmatter={{
+    title: 'Customize address form layout and address lookup',
+    description: 'Learn how to customize the layout of the address form and integrate a third-party API for address verification.',
+    tableOfContents: false,
+    editUrl:
+      'https://github.com/commerce-docs/microsite-commerce-storefront/blob/api-playground/src/pages/videos/customize-cart.astro',
+  }}
+  sidebar={[
+    {
+      label: 'Training Videos',
+      items: [
+        { label: 'Overview', link: '/videos/' },
+        { label: 'Add custom product lines to cart summary', link: '/videos/add-product-lines-to-cart-summary/' },
+        { label: 'Buy online, pickup in store', link: '/videos/buy-online-pickup-in-store/' },
+        { label: 'Customize address form layout and address lookup', link: '/videos/customize-address-form-layout/' },
+        { label: 'Customize cart summary', link: '/videos/customize-cart-summary/' },
+        { label: 'Customize order summary lines', link: '/videos/customize-order-summary-lines/' },
+        { label: 'Multi-step guest checkout', link: '/videos/multi-step-checkout/' },
+      ],
+    },
+  ]}
+>
+  <style is:global>
+    .sl-container.sl-container {
+      max-width: 100%;
+    }
+    .meta.sl-flex {
+      margin-top: 0;
+      margin-bottom: 1rem;
+      padding-top: 0;
+    }
+  </style>
+
+  <h2>What you'll learn</h2>
+
+  <p>In this video, you will learn how to:</p>
+    
+  <ul>
+    <li>Customize the address form layout at checkout to ensure that all fields are 50% width, with the exception of the text area.</li>
+    <li>Integrating a third-party API to enable auto address lookup and validation in the address form.</li>
+    <li>Add a new sidebar menu item to the user account dashboard, linking to a custom page for a store locator.</li>
+  </ul>
+
+  <h2>Who is this video for?</h2>
+
+  <p>Roles that would benefit from reading this transcript include:</p>
+
+  <ul>
+    <li>E-commerce Managers with to goal to understand how the checkout process and user account dashboard can be improved to enhance customer experience.</li>
+    <li>Front-end Developers who need to gain insights into practical implementations of CSS adjustments, third-party API integrations, and UI component customizations.</li>
+    <li>UX/UI Designers looking to see how design changes are implemented and validated to ensure a consistent and user-friendly interface.</li>
+    <li>Project Managers who need to track the progress of development tasks and understand the technical steps involved in achieving project goals.</li>
+    <li>Technical Leads that are overseeing the development process and ensure that best practices are followed in code implementation and integration.</li>
+  </ul>
+
+  <h2>Video content</h2>
+
+  <ul>
+    <li>Consistent Field Widths in Checkout Forms to customize the address form at checkout to ensure all fields.</li>
+    <li>Integration of Google Address API to enable auto address lookup and completion, reducing user input errors and streamlining the checkout process.</li>
+    <li>Validation and Error Handling for the address input fields, ensuring that users receive immediate feedback on incorrect or incomplete entries, enhancing the user experience.</li>
+    <li>Extension of User Account Dashboard that adds a new sidebar menu item to the user account dashboard.</li>
+  </ul>
+
+  <div>
+    <iframe
+    width="760"
+    height="430"
+    src="https://video.tv.adobe.com/v/3442787?learn=on"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen
+    ></iframe>
+  </div>
+
+  <div style="max-width: 760px;">
+    <Aside type="note" title="Looking for the documentation?">
+      See the text-based versions of this video tutorial for step-by-step instructions and code samples.
+
+      <ul>
+          <li><a href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/checkout/tutorials/address-integration/">Address verification</a></li>
+        <li><a href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/user-account/tutorials/">Customize the address form layout</a></li>
+        <li><a href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/user-account/sidebar/">User account sidebar</a></li>
+      </ul>
+
+    </Aside>
+  </div>
+
+</StarlightPage>

--- a/src/pages/videos/customize-address-form-layout.astro
+++ b/src/pages/videos/customize-address-form-layout.astro
@@ -6,7 +6,8 @@ import Aside from '@components/Aside.astro';
 <StarlightPage
   frontmatter={{
     title: 'Customize address form layout and address lookup',
-    description: 'Learn how to customize the layout of the address form and integrate a third-party API for address verification.',
+    description:
+      'Learn how to customize the layout of the address form and integrate a third-party API for address verification.',
     tableOfContents: false,
     editUrl:
       'https://github.com/commerce-docs/microsite-commerce-storefront/blob/api-playground/src/pages/videos/customize-cart.astro',
@@ -16,9 +17,15 @@ import Aside from '@components/Aside.astro';
       label: 'Training Videos',
       items: [
         { label: 'Overview', link: '/videos/' },
-        { label: 'Add custom product lines to cart summary', link: '/videos/add-product-lines-to-cart-summary/' },
+        {
+          label: 'Add custom product lines to cart summary',
+          link: '/videos/add-product-lines-to-cart-summary/',
+        },
         { label: 'Buy online, pickup in store', link: '/videos/buy-online-pickup-in-store/' },
-        { label: 'Customize address form layout and address lookup', link: '/videos/customize-address-form-layout/' },
+        {
+          label: 'Customize address form layout and address lookup',
+          link: '/videos/customize-address-form-layout/',
+        },
         { label: 'Customize cart summary', link: '/videos/customize-cart-summary/' },
         { label: 'Customize order summary lines', link: '/videos/customize-order-summary-lines/' },
         { label: 'Multi-step guest checkout', link: '/videos/multi-step-checkout/' },
@@ -40,55 +47,100 @@ import Aside from '@components/Aside.astro';
   <h2>What you'll learn</h2>
 
   <p>In this video, you will learn how to:</p>
-    
+
   <ul>
-    <li>Customize the address form layout at checkout to ensure that all fields are 50% width, with the exception of the text area.</li>
-    <li>Integrating a third-party API to enable auto address lookup and validation in the address form.</li>
-    <li>Add a new sidebar menu item to the user account dashboard, linking to a custom page for a store locator.</li>
+    <li>
+      Customize the address form layout at checkout to ensure that all fields are 50% width, except
+      for the text area.
+    </li>
+    <li>
+      Integrate a third-party API to enable auto address lookup and validation in the address form.
+    </li>
+    <li>
+      Add a new sidebar menu item to the user account dashboard, linking to a custom page for a
+      store locator.
+    </li>
   </ul>
 
   <h2>Who is this video for?</h2>
 
-  <p>Roles that would benefit from reading this transcript include:</p>
+  <p>This video is beneficial for:</p>
 
   <ul>
-    <li>E-commerce Managers with to goal to understand how the checkout process and user account dashboard can be improved to enhance customer experience.</li>
-    <li>Front-end Developers who need to gain insights into practical implementations of CSS adjustments, third-party API integrations, and UI component customizations.</li>
-    <li>UX/UI Designers looking to see how design changes are implemented and validated to ensure a consistent and user-friendly interface.</li>
-    <li>Project Managers who need to track the progress of development tasks and understand the technical steps involved in achieving project goals.</li>
-    <li>Technical Leads that are overseeing the development process and ensure that best practices are followed in code implementation and integration.</li>
+    <li>
+      <strong>E-commerce managers</strong> looking to understand how the checkout process and user account
+      dashboard can be improved to enhance the customer experience.
+    </li>
+    <li>
+      <strong>Front-end developers</strong> who need insights into practical implementations of CSS adjustments,
+      third-party API integrations, and UI component customizations.
+    </li>
+    <li>
+      <strong>UX/UI designers</strong> interested in how design changes are implemented and validated
+      to ensure a consistent, user-friendly interface.
+    </li>
+    <li>
+      <strong>Project managers</strong> who need to track development progress and understand the technical
+      steps involved in achieving project goals.
+    </li>
+    <li>
+      <strong>Technical leads</strong> overseeing development and ensuring best practices are followed
+      in code implementation and integration.
+    </li>
   </ul>
 
   <h2>Video content</h2>
 
   <ul>
-    <li>Consistent Field Widths in Checkout Forms to customize the address form at checkout to ensure all fields.</li>
-    <li>Integration of Google Address API to enable auto address lookup and completion, reducing user input errors and streamlining the checkout process.</li>
-    <li>Validation and Error Handling for the address input fields, ensuring that users receive immediate feedback on incorrect or incomplete entries, enhancing the user experience.</li>
-    <li>Extension of User Account Dashboard that adds a new sidebar menu item to the user account dashboard.</li>
+    <li>Customizing field widths in checkout forms to ensure a consistent layout.</li>
+    <li>
+      Integrating the Google Address API to enable auto address lookup and completion, reducing user
+      input errors and streamlining the checkout process.
+    </li>
+    <li>
+      Implementing validation and error handling for address input fields to provide immediate
+      feedback on incorrect or incomplete entries, enhancing the user experience.
+    </li>
+    <li>
+      Extending the user account dashboard by adding a new sidebar menu item that links to a store
+      locator page.
+    </li>
   </ul>
 
   <div>
     <iframe
-    width="760"
-    height="430"
-    src="https://video.tv.adobe.com/v/3442787?learn=on"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowfullscreen
-    ></iframe>
+      width="760"
+      height="430"
+      src="https://video.tv.adobe.com/v/3442787?learn=on"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowfullscreen></iframe>
   </div>
 
   <div style="max-width: 760px;">
     <Aside type="note" title="Looking for the documentation?">
-      See the text-based versions of this video tutorial for step-by-step instructions and code samples.
+      See the text-based versions of this video tutorial for step-by-step instructions and code
+      samples.
 
       <ul>
-          <li><a href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/checkout/tutorials/address-integration/">Address verification</a></li>
-        <li><a href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/user-account/tutorials/">Customize the address form layout</a></li>
-        <li><a href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/user-account/sidebar/">User account sidebar</a></li>
+        <li>
+          <a
+            href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/checkout/tutorials/address-integration/"
+            >Address verification</a
+          >
+        </li>
+        <li>
+          <a
+            href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/user-account/tutorials/"
+            >Customize the address form layout</a
+          >
+        </li>
+        <li>
+          <a
+            href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/user-account/sidebar/"
+            >User account sidebar</a
+          >
+        </li>
       </ul>
-
     </Aside>
   </div>
-
 </StarlightPage>

--- a/src/pages/videos/customize-cart-summary.astro
+++ b/src/pages/videos/customize-cart-summary.astro
@@ -1,0 +1,76 @@
+---
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+import Aside from '@components/Aside.astro';
+---
+
+<StarlightPage
+  frontmatter={{
+    title: 'Customize cart summary',
+    description: 'Learn how to customize the layout of the cart summary.',
+    tableOfContents: false,
+    editUrl:
+      'https://github.com/commerce-docs/microsite-commerce-storefront/blob/api-playground/src/pages/videos/customize-cart.astro',
+  }}
+  sidebar={[
+    {
+      label: 'Training Videos',
+      items: [
+        { label: 'Overview', link: '/videos/' },
+        { label: 'Add custom product lines to cart summary', link: '/videos/add-product-lines-to-cart-summary/' },
+        { label: 'Buy online, pickup in store', link: '/videos/buy-online-pickup-in-store/' },
+        { label: 'Customize address form layout and address lookup', link: '/videos/customize-address-form-layout/' },
+        { label: 'Customize cart summary', link: '/videos/customize-cart-summary/' },
+        { label: 'Customize order summary lines', link: '/videos/customize-order-summary-lines/' },
+        { label: 'Multi-step guest checkout', link: '/videos/multi-step-checkout/' },
+      ],
+    },
+  ]}
+>
+  <style is:global>
+    .sl-container.sl-container {
+      max-width: 100%;
+    }
+    .meta.sl-flex {
+      margin-top: 0;
+      margin-bottom: 1rem;
+      padding-top: 0;
+    }
+  </style>
+
+  <h2>What you'll learn</h2>
+
+  <p>In this video, you will learn how to adjust the transactional flow for checkout using the cart drop-in component.</p>
+
+  <h2>Who is this video for?</h2>
+
+  <ul>
+    <li>Developers and store owners learning about Edge Delivery Services with a need to change some cart drop-in elements.</li>
+    <li>Marketers and others who are interested in using SharePoint to manage features and AB testing.</li>
+  </ul>
+
+  <h2>Video content</h2>
+
+  <ul>
+    <li>Quantity Selector Update. Update the product quantity selector from an incrementor to a dropdown, customized to display values from 1 to 20.</li>
+    <li>Discount Display. Implemented features to show discount percentages and dollar amount discounts for sale items in the cart.</li>
+    <li>A/B Testing Flexibility. Enabled configurations through SharePoint, empowering marketers to control and test these features.</li>
+    <li>Enhanced Marketing Control. Easily manage and test configurations, improving user experience and marketing effectiveness.</li>
+  </ul>
+
+  <div>
+    <iframe
+    width="760"
+    height="430"
+    src="https://video.tv.adobe.com/v/3442351?learn=on"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen
+    ></iframe>
+  </div>
+
+  <div style="max-width: 760px;">
+    <Aside type="note" title="Looking for the documentation?">
+      See the <a href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/cart/tutorials/configure-cart-summary/">text-based</a> version of this video tutorial for step-by-step instructions and code samples.
+    </Aside>
+  </div>
+
+</StarlightPage>

--- a/src/pages/videos/customize-cart-summary.astro
+++ b/src/pages/videos/customize-cart-summary.astro
@@ -16,9 +16,15 @@ import Aside from '@components/Aside.astro';
       label: 'Training Videos',
       items: [
         { label: 'Overview', link: '/videos/' },
-        { label: 'Add custom product lines to cart summary', link: '/videos/add-product-lines-to-cart-summary/' },
+        {
+          label: 'Add custom product lines to cart summary',
+          link: '/videos/add-product-lines-to-cart-summary/',
+        },
         { label: 'Buy online, pickup in store', link: '/videos/buy-online-pickup-in-store/' },
-        { label: 'Customize address form layout and address lookup', link: '/videos/customize-address-form-layout/' },
+        {
+          label: 'Customize address form layout and address lookup',
+          link: '/videos/customize-address-form-layout/',
+        },
         { label: 'Customize cart summary', link: '/videos/customize-cart-summary/' },
         { label: 'Customize order summary lines', link: '/videos/customize-order-summary-lines/' },
         { label: 'Multi-step guest checkout', link: '/videos/multi-step-checkout/' },
@@ -39,38 +45,60 @@ import Aside from '@components/Aside.astro';
 
   <h2>What you'll learn</h2>
 
-  <p>In this video, you will learn how to adjust the transactional flow for checkout using the cart drop-in component.</p>
+  <p>
+    In this video, you will learn how to adjust the transactional flow for checkout using the cart
+    drop-in component.
+  </p>
 
   <h2>Who is this video for?</h2>
 
   <ul>
-    <li>Developers and store owners learning about Edge Delivery Services with a need to change some cart drop-in elements.</li>
-    <li>Marketers and others who are interested in using SharePoint to manage features and AB testing.</li>
+    <li>
+      <strong>Developers and store owners</strong> looking to modify cart drop-in elements while working
+      with Edge Delivery Services.
+    </li>
+    <li>
+      <strong>Marketers and business professionals</strong> interested in using SharePoint to manage
+      features and conduct A/B testing.
+    </li>
   </ul>
 
   <h2>Video content</h2>
 
   <ul>
-    <li>Quantity Selector Update. Update the product quantity selector from an incrementor to a dropdown, customized to display values from 1 to 20.</li>
-    <li>Discount Display. Implemented features to show discount percentages and dollar amount discounts for sale items in the cart.</li>
-    <li>A/B Testing Flexibility. Enabled configurations through SharePoint, empowering marketers to control and test these features.</li>
-    <li>Enhanced Marketing Control. Easily manage and test configurations, improving user experience and marketing effectiveness.</li>
+    <li>
+      <strong>Quantity Selector Update:</strong> Change the product quantity selector from an incrementor
+      to a dropdown, displaying values from 1 to 20.
+    </li>
+    <li>
+      <strong>Discount Display:</strong> Implement features that show both discount percentages and dollar
+      amount discounts for sale items in the cart.
+    </li>
+    <li>
+      <strong>A/B Testing Flexibility:</strong> Enable configurations through SharePoint, allowing marketers
+      to control and test features easily.
+    </li>
+    <li>
+      <strong>Enhanced Marketing Control:</strong> Improve user experience and marketing effectiveness
+      by managing and testing configurations efficiently.
+    </li>
   </ul>
 
   <div>
     <iframe
-    width="760"
-    height="430"
-    src="https://video.tv.adobe.com/v/3442351?learn=on"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowfullscreen
-    ></iframe>
+      width="760"
+      height="430"
+      src="https://video.tv.adobe.com/v/3442351?learn=on"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowfullscreen></iframe>
   </div>
 
   <div style="max-width: 760px;">
     <Aside type="note" title="Looking for the documentation?">
-      See the <a href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/cart/tutorials/configure-cart-summary/">text-based</a> version of this video tutorial for step-by-step instructions and code samples.
+      See the <a
+        href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/cart/tutorials/configure-cart-summary/"
+        >text-based</a
+      > version of this video tutorial for step-by-step instructions and code samples.
     </Aside>
   </div>
-
 </StarlightPage>

--- a/src/pages/videos/customize-order-summary-lines.astro
+++ b/src/pages/videos/customize-order-summary-lines.astro
@@ -44,6 +44,8 @@ import Aside from '@components/Aside.astro';
     }
   </style>
 
+  <h2>What you'll learn</h2>
+
   <p>
     In this video, you will learn how to customize the cart drop-in component and adjust the cart
     experience. There are several ways to enhance the cart by making minor changes or updates to the

--- a/src/pages/videos/customize-order-summary-lines.astro
+++ b/src/pages/videos/customize-order-summary-lines.astro
@@ -6,7 +6,8 @@ import Aside from '@components/Aside.astro';
 <StarlightPage
   frontmatter={{
     title: 'Customize order summary lines',
-    description: 'Learn how to customize the lines of the Order Summary of the cart drop-in component.',
+    description:
+      'Learn how to customize the lines of the Order Summary of the cart drop-in component.',
     tableOfContents: false,
     editUrl:
       'https://github.com/commerce-docs/microsite-commerce-storefront/blob/api-playground/src/pages/videos/customize-cart.astro',
@@ -16,9 +17,15 @@ import Aside from '@components/Aside.astro';
       label: 'Training Videos',
       items: [
         { label: 'Overview', link: '/videos/' },
-        { label: 'Add custom product lines to cart summary', link: '/videos/add-product-lines-to-cart-summary/' },
+        {
+          label: 'Add custom product lines to cart summary',
+          link: '/videos/add-product-lines-to-cart-summary/',
+        },
         { label: 'Buy online, pickup in store', link: '/videos/buy-online-pickup-in-store/' },
-        { label: 'Customize address form layout and address lookup', link: '/videos/customize-address-form-layout/' },
+        {
+          label: 'Customize address form layout and address lookup',
+          link: '/videos/customize-address-form-layout/',
+        },
         { label: 'Customize cart summary', link: '/videos/customize-cart-summary/' },
         { label: 'Customize order summary lines', link: '/videos/customize-order-summary-lines/' },
         { label: 'Multi-step guest checkout', link: '/videos/multi-step-checkout/' },
@@ -37,39 +44,45 @@ import Aside from '@components/Aside.astro';
     }
   </style>
 
-  <h2>What you'll learn</h2>
-
-  <p>In this video, you will learn how to customize the cart drop-in component and adjust the cart experience. There are several ways to enhance the cart by making some minor changes or updates to the code.</p>
+  <p>
+    In this video, you will learn how to customize the cart drop-in component and adjust the cart
+    experience. There are several ways to enhance the cart by making minor changes or updates to the
+    code.
+  </p>
 
   <h2>Who is this video for?</h2>
 
   <ul>
-    <li>Developers who need to learn how to implement these customizations for the order summary.</li>
-    <li>Merchandisers to understand what options are available using native features to enhance the customer experience around the order summary.</li>
+    <li><strong>Developers</strong> who need to implement customizations for the order summary.</li>
+    <li>
+      <strong>Merchandisers</strong> looking to explore native features that enhance the customer experience
+      around the order summary.
+    </li>
   </ul>
 
   <h2>Video content</h2>
 
   <ul>
-    <li>Display an estimated shipping cost</li>
-    <li>Include a total amount saved for the cart summary</li>
-    <li>Merge lines in the cart summary into one collapsible section</li>
+    <li>Display an estimated shipping cost.</li>
+    <li>Include the total amount saved in the cart summary.</li>
+    <li>Merge lines in the cart summary into a single collapsible section.</li>
   </ul>
 
   <p>
     <iframe
-    width="760"
-    height="430"
-    src="https://video.tv.adobe.com/v/3441185?learn=on"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowfullscreen
-    ></iframe>
+      width="760"
+      height="430"
+      src="https://video.tv.adobe.com/v/3441185?learn=on"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowfullscreen></iframe>
   </p>
 
   <div style="max-width: 760px;">
     <Aside type="note" title="Looking for the documentation?">
-      See the <a href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/cart/tutorials/order-summary-lines/">text-based</a> version of this video tutorial for step-by-step instructions and code samples.
+      See the <a
+        href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/cart/tutorials/order-summary-lines/"
+        >text-based</a
+      > version of this video tutorial for step-by-step instructions and code samples.
     </Aside>
   </div>
-
 </StarlightPage>

--- a/src/pages/videos/customize-order-summary-lines.astro
+++ b/src/pages/videos/customize-order-summary-lines.astro
@@ -1,0 +1,75 @@
+---
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+import Aside from '@components/Aside.astro';
+---
+
+<StarlightPage
+  frontmatter={{
+    title: 'Customize order summary lines',
+    description: 'Learn how to customize the lines of the Order Summary of the cart drop-in component.',
+    tableOfContents: false,
+    editUrl:
+      'https://github.com/commerce-docs/microsite-commerce-storefront/blob/api-playground/src/pages/videos/customize-cart.astro',
+  }}
+  sidebar={[
+    {
+      label: 'Training Videos',
+      items: [
+        { label: 'Overview', link: '/videos/' },
+        { label: 'Add custom product lines to cart summary', link: '/videos/add-product-lines-to-cart-summary/' },
+        { label: 'Buy online, pickup in store', link: '/videos/buy-online-pickup-in-store/' },
+        { label: 'Customize address form layout and address lookup', link: '/videos/customize-address-form-layout/' },
+        { label: 'Customize cart summary', link: '/videos/customize-cart-summary/' },
+        { label: 'Customize order summary lines', link: '/videos/customize-order-summary-lines/' },
+        { label: 'Multi-step guest checkout', link: '/videos/multi-step-checkout/' },
+      ],
+    },
+  ]}
+>
+  <style is:global>
+    .sl-container.sl-container {
+      max-width: 100%;
+    }
+    .meta.sl-flex {
+      margin-top: 0;
+      margin-bottom: 1rem;
+      padding-top: 0;
+    }
+  </style>
+
+  <h2>What you'll learn</h2>
+
+  <p>In this video, you will learn how to customize the cart drop-in component and adjust the cart experience. There are several ways to enhance the cart by making some minor changes or updates to the code.</p>
+
+  <h2>Who is this video for?</h2>
+
+  <ul>
+    <li>Developers who need to learn how to implement these customizations for the order summary.</li>
+    <li>Merchandisers to understand what options are available using native features to enhance the customer experience around the order summary.</li>
+  </ul>
+
+  <h2>Video content</h2>
+
+  <ul>
+    <li>Display an estimated shipping cost</li>
+    <li>Include a total amount saved for the cart summary</li>
+    <li>Merge lines in the cart summary into one collapsible section</li>
+  </ul>
+
+  <p>
+    <iframe
+    width="760"
+    height="430"
+    src="https://video.tv.adobe.com/v/3441185?learn=on"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen
+    ></iframe>
+  </p>
+
+  <div style="max-width: 760px;">
+    <Aside type="note" title="Looking for the documentation?">
+      See the <a href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/cart/tutorials/order-summary-lines/">text-based</a> version of this video tutorial for step-by-step instructions and code samples.
+    </Aside>
+  </div>
+
+</StarlightPage>

--- a/src/pages/videos/customize-pdp.astro
+++ b/src/pages/videos/customize-pdp.astro
@@ -34,13 +34,15 @@ import Aside from '@components/Aside.astro';
     }
   </style>
 
-  <p>In this video you will learn how to customize the PDP drop-in.</p>
+<p>In this video, you will learn how to customize the PDP drop-in.</p>
 
-  <div style="max-width: 700px;">
-    <Aside type="tip" title="Roadmap">
-      This will be the first video in a series of videos that will teach you how to customize the
-      commerce boilerplate drop-in components to create a polished, production-ready storefront. Check back
-      later for updates!
-    </Aside>
-  </div>
+<div>
+
+<div style="max-width: 700px;">
+  <Aside type="tip" title="Roadmap">
+    This is the first video in a series that will teach you how to customize the 
+    commerce boilerplate drop-in components to create a polished, production-ready storefront. 
+    Check back later for updates!
+  </Aside>
+</div>
 </StarlightPage>

--- a/src/pages/videos/index.astro
+++ b/src/pages/videos/index.astro
@@ -16,9 +16,12 @@ import Aside from '@components/Aside.astro';
       label: 'Training Videos',
       items: [
         { label: 'Overview', link: '/videos/' },
-        { label: 'Customize the PDP', link: '/videos/customize-pdp/' },
-        // { label: 'Customize the cart', link: '/videos/customize-cart/' },
-        // { label: 'Customize the checkout', link: '/videos/customize-checkout/' },
+        { label: 'Add custom product lines to cart summary', link: '/videos/add-product-lines-to-cart-summary/' },
+        { label: 'Buy online, pickup in store', link: '/videos/buy-online-pickup-in-store/' },
+        { label: 'Customize address form layout and address lookup', link: '/videos/customize-address-form-layout/' },
+        { label: 'Customize cart summary', link: '/videos/customize-cart-summary/' },
+        { label: 'Customize order summary lines', link: '/videos/customize-order-summary-lines/' },
+        { label: 'Multi-step guest checkout', link: '/videos/multi-step-checkout/' },
       ],
     },
   ]}
@@ -36,11 +39,7 @@ import Aside from '@components/Aside.astro';
 
   <p style="max-width: 760px;">
     Welcome to the home of our Commerce Training Videos! These videos will teach you how to
-    transform the commerce boilerplate into a polished, production-ready storefront.
+    transform the boilerplate template into a polished, production-ready storefront.
   </p>
-  <div style="max-width: 760px;">
-    <Aside type="wip" title="In Development">
-      Our training videos are currently in development. Check back later for updates!
-    </Aside>
-  </div>
+  
 </StarlightPage>

--- a/src/pages/videos/index.astro
+++ b/src/pages/videos/index.astro
@@ -1,12 +1,14 @@
 ---
 import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
-import Aside from '@components/Aside.astro';
+import CardGrid from '@components/CardGrid.astro';
+import LinkCard from '@components/LinkCard.astro';
 ---
 
 <StarlightPage
   frontmatter={{
     title: 'Commerce Training Videos',
-    description: 'Learn about how to build your storefront with drop-in components and customizations.',
+    description:
+      'Learn about how to build your storefront with drop-in components and customizations.',
     tableOfContents: false,
     editUrl:
       'https://github.com/commerce-docs/microsite-commerce-storefront/blob/api-playground/src/pages/videos/index.astro',
@@ -16,9 +18,15 @@ import Aside from '@components/Aside.astro';
       label: 'Training Videos',
       items: [
         { label: 'Overview', link: '/videos/' },
-        { label: 'Add custom product lines to cart summary', link: '/videos/add-product-lines-to-cart-summary/' },
+        {
+          label: 'Add custom product lines to cart summary',
+          link: '/videos/add-product-lines-to-cart-summary/',
+        },
         { label: 'Buy online, pickup in store', link: '/videos/buy-online-pickup-in-store/' },
-        { label: 'Customize address form layout and address lookup', link: '/videos/customize-address-form-layout/' },
+        {
+          label: 'Customize address form layout and address lookup',
+          link: '/videos/customize-address-form-layout/',
+        },
         { label: 'Customize cart summary', link: '/videos/customize-cart-summary/' },
         { label: 'Customize order summary lines', link: '/videos/customize-order-summary-lines/' },
         { label: 'Multi-step guest checkout', link: '/videos/multi-step-checkout/' },
@@ -41,5 +49,74 @@ import Aside from '@components/Aside.astro';
     Welcome to the home of our Commerce Training Videos! These videos will teach you how to
     transform the boilerplate template into a polished, production-ready storefront.
   </p>
-  
+
+  <CardGrid>
+    <LinkCard
+      noborder
+      icon="seti:video"
+      title="Add custom product lines to the cart summary"
+      description="Learn how to add custom lines related to products in the cart summary."
+      link="/videos/add-product-lines-to-cart-summary/"
+      rightIcon="right-arrow"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Link (opens in a new tab)"
+    />
+
+    <LinkCard
+      noborder
+      icon="seti:video"
+      title="Buy online, pickup in store"
+      description="Learn how to implement a Buy Online, Pick Up In Store (BOPIS) checkout flow."
+      link="/videos/buy-online-pickup-in-store/"
+      rightIcon="right-arrow"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Link (opens in a new tab)"
+    />
+    <LinkCard
+      noborder
+      icon="seti:video"
+      title="Customize address form layout and address lookup"
+      description="Learn how to customize the layout of the address form and integrate a third-party API for address verification."
+      link="/videos/customize-address-form-layout/"
+      rightIcon="right-arrow"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Link (opens in a new tab)"
+    />
+    <LinkCard
+      noborder
+      icon="seti:video"
+      title="Customize cart summary"
+      description="Learn how to customize the layout of the cart summary."
+      link="/videos/customize-cart-summary/"
+      rightIcon="right-arrow"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Link (opens in a new tab)"
+    />
+    <LinkCard
+      noborder
+      icon="seti:video"
+      title="Customize order summary lines"
+      description="Learn how to customize the lines of the Order Summary of the cart drop-in component."
+      link="/videos/customize-order-summary-lines/"
+      rightIcon="right-arrow"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Link (opens in a new tab)"
+    />
+    <LinkCard
+      noborder
+      icon="seti:video"
+      title="Multi-step guest checkout"
+      description="Learn how to implement a multi-step checkout using the checkout drop-in component."
+      link="/videos/multi-step-checkout/"
+      rightIcon="right-arrow"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Link (opens in a new tab)"
+    />
+  </CardGrid>
 </StarlightPage>

--- a/src/pages/videos/multi-step-checkout.astro
+++ b/src/pages/videos/multi-step-checkout.astro
@@ -1,0 +1,72 @@
+---
+import StarlightPage from '@astrojs/starlight/components/StarlightPage.astro';
+import Aside from '@components/Aside.astro';
+---
+
+<StarlightPage
+  frontmatter={{
+    title: 'Multi-step guest checkout',
+    description: 'Learn how to implement a multi-step checkout using the checkout drop-in component.',
+    tableOfContents: false,
+    editUrl:
+      'https://github.com/commerce-docs/microsite-commerce-storefront/blob/api-playground/src/pages/videos/customize-cart.astro',
+  }}
+  sidebar={[
+    {
+      label: 'Training Videos',
+      items: [
+        { label: 'Overview', link: '/videos/' },
+        { label: 'Add custom product lines to cart summary', link: '/videos/add-product-lines-to-cart-summary/' },
+        { label: 'Buy online, pickup in store', link: '/videos/buy-online-pickup-in-store/' },
+        { label: 'Customize address form layout and address lookup', link: '/videos/customize-address-form-layout/' },
+        { label: 'Customize cart summary', link: '/videos/customize-cart-summary/' },
+        { label: 'Customize order summary lines', link: '/videos/customize-order-summary-lines/' },
+        { label: 'Multi-step guest checkout', link: '/videos/multi-step-checkout/' },
+      ],
+    },
+  ]}
+>
+  <style is:global>
+    .sl-container.sl-container {
+      max-width: 100%;
+    }
+    .meta.sl-flex {
+      margin-top: 0;
+      margin-bottom: 1rem;
+      padding-top: 0;
+    }
+  </style>
+  
+  <h2>What you'll learn</h2>
+
+  <p>In this video, you will learn how to customize the checkout experience using the checkout drop-in component, focusing on modifying shipping options and implementing a multi-step checkout process for guest shoppers.</p>
+
+  <h2>Who is this video for?</h2>
+
+  <p>Developers and technical professionals working with Adobe Commerce, Edge Delivery Services, and using the checkout drop-in component.</p>
+
+  <h2>Video content</h2>
+
+  <ul>
+    <li>Customization of checkout experience</li>
+    <li>Implementation of multi-step guest checkout</li>
+    <li>Reusing existing code and best practices</li>
+  </ul>
+
+  <p>
+    <iframe
+    width="760"
+    height="430"
+    src="https://video.tv.adobe.com/v/3442650?learn=on"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowfullscreen
+    ></iframe>
+  </p>
+
+  <div style="max-width: 760px;">
+    <Aside type="note" title="Looking for the documentation?">
+      See the <a href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/checkout/tutorials/multi-step/">text-based</a> version of this video tutorial for step-by-step instructions and code samples.
+    </Aside>
+  </div>
+
+</StarlightPage>

--- a/src/pages/videos/multi-step-checkout.astro
+++ b/src/pages/videos/multi-step-checkout.astro
@@ -6,7 +6,8 @@ import Aside from '@components/Aside.astro';
 <StarlightPage
   frontmatter={{
     title: 'Multi-step guest checkout',
-    description: 'Learn how to implement a multi-step checkout using the checkout drop-in component.',
+    description:
+      'Learn how to implement a multi-step checkout using the checkout drop-in component.',
     tableOfContents: false,
     editUrl:
       'https://github.com/commerce-docs/microsite-commerce-storefront/blob/api-playground/src/pages/videos/customize-cart.astro',
@@ -16,9 +17,15 @@ import Aside from '@components/Aside.astro';
       label: 'Training Videos',
       items: [
         { label: 'Overview', link: '/videos/' },
-        { label: 'Add custom product lines to cart summary', link: '/videos/add-product-lines-to-cart-summary/' },
+        {
+          label: 'Add custom product lines to cart summary',
+          link: '/videos/add-product-lines-to-cart-summary/',
+        },
         { label: 'Buy online, pickup in store', link: '/videos/buy-online-pickup-in-store/' },
-        { label: 'Customize address form layout and address lookup', link: '/videos/customize-address-form-layout/' },
+        {
+          label: 'Customize address form layout and address lookup',
+          link: '/videos/customize-address-form-layout/',
+        },
         { label: 'Customize cart summary', link: '/videos/customize-cart-summary/' },
         { label: 'Customize order summary lines', link: '/videos/customize-order-summary-lines/' },
         { label: 'Multi-step guest checkout', link: '/videos/multi-step-checkout/' },
@@ -39,34 +46,42 @@ import Aside from '@components/Aside.astro';
   
   <h2>What you'll learn</h2>
 
-  <p>In this video, you will learn how to customize the checkout experience using the checkout drop-in component, focusing on modifying shipping options and implementing a multi-step checkout process for guest shoppers.</p>
+  <p>
+    In this video, you will learn how to customize the checkout experience using the checkout
+    drop-in component. This includes modifying shipping options and implementing a multi-step
+    checkout process for guest shoppers.
+  </p>
 
   <h2>Who is this video for?</h2>
 
-  <p>Developers and technical professionals working with Adobe Commerce, Edge Delivery Services, and using the checkout drop-in component.</p>
+  <p>
+    This video is for developers and technical professionals working with Adobe Commerce and Edge
+    Delivery Services who are using the checkout drop-in component.
+  </p>
 
   <h2>Video content</h2>
 
   <ul>
-    <li>Customization of checkout experience</li>
-    <li>Implementation of multi-step guest checkout</li>
-    <li>Reusing existing code and best practices</li>
+    <li>Customizing the checkout experience.</li>
+    <li>Implementing a multi-step guest checkout.</li>
+    <li>Reusing existing code and following best practices.</li>
   </ul>
 
   <p>
     <iframe
-    width="760"
-    height="430"
-    src="https://video.tv.adobe.com/v/3442650?learn=on"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowfullscreen
-    ></iframe>
+      width="760"
+      height="430"
+      src="https://video.tv.adobe.com/v/3442650?learn=on"
+      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+      allowfullscreen></iframe>
   </p>
 
   <div style="max-width: 760px;">
     <Aside type="note" title="Looking for the documentation?">
-      See the <a href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/checkout/tutorials/multi-step/">text-based</a> version of this video tutorial for step-by-step instructions and code samples.
+      See the <a
+        href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/checkout/tutorials/multi-step/"
+        >text-based</a
+      > version of this video tutorial for step-by-step instructions and code samples.
     </Aside>
   </div>
-
 </StarlightPage>


### PR DESCRIPTION
This pull request (PR) adds the demo videos for the initial storefront GA (12/2004). This is a time-sensitive update to help enable sales.

These are also published in the commerce-learn.en repo, but the PM has requested they be added to the microsite.

We need to do some optimization on the `.astro` file editing experience. Using HTML/MDX tags is cumbersome and including the side nav in every file doesn't seem efficient. We can improve on all of that later.