### PR TITLE
Fix: Lock pnpm version to 9.15.4

### DIFF
--- a/.jenkins/deliver-build.groovy
+++ b/.jenkins/deliver-build.groovy
@@ -14,7 +14,7 @@
 micrositeBuildDeliverPipeline(
     repoName: 'microsite-commerce-storefront',
     reviewer: 'jmatthew',
-    runBuildScript: 'node --version && corepack enable && corepack prepare pnpm@latest-9 --activate && pnpm version && pnpm install && pnpm run build:prod',
+    runBuildScript: 'node --version && corepack enable && pnpm version && pnpm install && pnpm run build:prod',
     deliverBuildScript: 'cp -r dist/* storefront',
     dockerImage: 'node:20.13.1'
 )

--- a/.jenkins/deliver-build.groovy
+++ b/.jenkins/deliver-build.groovy
@@ -14,7 +14,7 @@
 micrositeBuildDeliverPipeline(
     repoName: 'microsite-commerce-storefront',
     reviewer: 'jmatthew',
-    runBuildScript: 'node --version && corepack enable && pnpm version && pnpm install && pnpm run build:prod',
+    runBuildScript: 'node --version && corepack enable && corepack prepare pnpm@9.15.4 --activate && pnpm version && pnpm install && pnpm run build:prod',
     deliverBuildScript: 'cp -r dist/* storefront',
     dockerImage: 'node:20.13.1'
 )

--- a/package.json
+++ b/package.json
@@ -99,5 +99,6 @@
     "type": "git",
     "url": "git@git.corp.adobe.com:AdobeDocs/microsite-commerce-storefront.git"
   },
-  "bugs": "https://git.corp.adobe.com/AdobeDocs/microsite-commerce-storefront/issues"
+  "bugs": "https://git.corp.adobe.com/AdobeDocs/microsite-commerce-storefront/issues",
+  "packageManager": "pnpm@9.15.4+sha512.b2dc20e2fc72b3e18848459b37359a32064663e5627a51e4c74b2c29dd8e8e0491483c3abb40789cfd578bf362fb6ba8261b05f0387d76792ed6e23ea3b1b6a0"
 }


### PR DESCRIPTION
Lock pnpm version to 9.15.4 to avoid unexpected failures due to bugs or backward incompatible changes in new pnpm releases.