### PR TITLE
Updated Payment Services drop-in version to v1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@dropins/storefront-cart": "^1.0.1",
     "@dropins/storefront-checkout": "^1.0.0",
     "@dropins/storefront-order": "^1.0.0",
-    "@dropins/storefront-payment-services": "^1.0.0",
+    "@dropins/storefront-payment-services": "^1.0.1",
     "@dropins/storefront-pdp": "^1.0.0",
     "@dropins/tools": "0.38.0",
     "@expressive-code/plugin-collapsible-sections": "^0.38.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,8 +45,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       '@dropins/storefront-payment-services':
-        specifier: ^1.0.0
-        version: 1.0.0
+        specifier: ^1.0.1
+        version: 1.0.1
       '@dropins/storefront-pdp':
         specifier: ^1.0.0
         version: 1.0.0
@@ -401,8 +401,8 @@ packages:
   '@dropins/storefront-order@1.0.0':
     resolution: {integrity: sha512-3bhRUqiFkOLvJ5ovZpVplPBs5DcbSfSnlEX7pkl1fyJ3upFDM1CPBFjQEv3+iQF2OarzlOaYCeFdzke3LNxVcg==}
 
-  '@dropins/storefront-payment-services@1.0.0':
-    resolution: {integrity: sha512-9af9Ssd3MegtNWuWdcZvWSY9vLAdEnP5hckzG+emk7Qe5wXwr6xtf9uT5FeSnisQUooxa6ep4ddWhktFot7YOA==}
+  '@dropins/storefront-payment-services@1.0.1':
+    resolution: {integrity: sha512-ikuH2Yg4TxFtln2zHoyKBh5FJQmHpinFhWdGrAdE9jy7YPvdhsGGewnRC41bQR/BRnNgDO1suo3Hg0I/5B3iPw==}
 
   '@dropins/storefront-pdp@1.0.0':
     resolution: {integrity: sha512-OKfvTYdNYrU5QEKr8FWrEOv607rIVshzD0hJYFZuD6KjJ/+mQKoA7QNn6RSqn05fvYK+rG/yc0+M6smUP+mCrw==}
@@ -4472,7 +4472,7 @@ snapshots:
 
   '@dropins/storefront-order@1.0.0': {}
 
-  '@dropins/storefront-payment-services@1.0.0': {}
+  '@dropins/storefront-payment-services@1.0.1': {}
 
   '@dropins/storefront-pdp@1.0.0': {}
 

--- a/src/content/docs/get-started/release.mdx
+++ b/src/content/docs/get-started/release.mdx
@@ -16,7 +16,7 @@ The following table shows the compatibility between all of the storefront releas
 | **Adobe Commerce** | | 2.4.7 |
 | **Storefront Compatibility Package** | | 4.7.0 |
 | **Drop-in SDK** | | `@dropins/tools@0.38.0`<br/>`@dropins/build-tools@0.1.1` |
-| **Drop-in components** | | `@dropins/storefront-cart@1.0.1`<br/>`@dropins/storefront-checkout@1.0.0`<br/>`@dropins/storefront-order@1.0.0`<br/>`@dropins/storefront-payment-services@1.0.0`<br/>`@dropins/storefront-pdp@1.0.0`<br/>`@dropins/storefront-user-account@1.0.0`<br/>`@dropins/storefront-user-auth@1.0.0` |
+| **Drop-in components** | | `@dropins/storefront-cart@1.0.1`<br/>`@dropins/storefront-checkout@1.0.0`<br/>`@dropins/storefront-order@1.0.0`<br/>`@dropins/storefront-payment-services@1.0.1`<br/>`@dropins/storefront-pdp@1.0.0`<br/>`@dropins/storefront-user-account@1.0.0`<br/>`@dropins/storefront-user-auth@1.0.0` |
 
 ## Code changes
 


### PR DESCRIPTION
This PR runs `pnpm update @dropins/storefront-payment-services@v1.0.1` to update Payment Services drop-in version to v1.0.1.

## Additional information

Preview [gh page](https://commerce-docs.github.io/microsite-commerce-storefront/dropins/payment-services/dictionary/)