### PR TITLE
fix: citisignal demo url

### DIFF
--- a/src/content/docs/get-started/index.mdx
+++ b/src/content/docs/get-started/index.mdx
@@ -87,9 +87,9 @@ The `mountpoint` is the URL that points to your content folder on Google Drive o
 
 ## Example
 
-Our CitiSignal demo site was built from the same boilerplate you will set up to develop your own storefront. You can access the full demo site here: https://main--citisignal--adobedevxsc.aem.live/.
+Our CitiSignal demo site was built from the same boilerplate you will set up to develop your own storefront. You can access the full demo site here: https://main--citisignal-one--adobedevxsc.aem.live/.
 
-<Embed src="https://main--citisignal--adobedevxsc.aem.live/" height="520" />
+<Embed src="https://main--citisignal-one--adobedevxsc.aem.live" height="520" />
 
 ## Step-by-step
 


### PR DESCRIPTION
This pull request (PR) fixes the CitiSignal demo URL. The old one is showing a barebones version of the boilerplate.

>[!NOTE]
>The home page of the new URL is broken right now, but someone is working on fixing it.