### PR TITLE
Fix: Ensure Google Drive files convert correctly during upload

### DIFF
--- a/src/content/docs/get-started/index.mdx
+++ b/src/content/docs/get-started/index.mdx
@@ -332,7 +332,6 @@ Now let's add the boilerplate sample files to your content folder. Choose the ta
       This method ensures that all documents follow the correct format while maintaining the folder structure.
     </Aside>
 
-
   </TabItem>
 
   <TabItem label="SharePoint">

--- a/src/content/docs/get-started/index.mdx
+++ b/src/content/docs/get-started/index.mdx
@@ -319,6 +319,20 @@ Now let's add the boilerplate sample files to your content folder. Choose the ta
     1. Unzip the file and drag the contents into your folder. This will convert the Word and Excel files to Google Docs and Sheets.
     </Callouts>
 
+    <Aside type="note" title="Handling Upload Conversion Issues">
+      In some cases, when uploading Word and Excel files directly to Google Drive, they may not be automatically converted to Google Docs and Sheets format. However, files inside folders are converted as expected.
+
+      #### Workaround for Direct File Uploads
+
+      1. **Create a temporary folder** inside your Google Drive.  
+      2. **Move the unconverted Word and Excel files** into this temporary folder.  
+      3. **Upload the folder** to Google Drive—this ensures that the files inside are converted to Google Docs and Sheets.  
+      4. **After conversion, move the files** to their intended location within your storefront folder.  
+
+      This method ensures that all documents follow the correct format while maintaining the folder structure.
+    </Aside>
+
+
   </TabItem>
 
   <TabItem label="SharePoint">

--- a/src/content/docs/get-started/index.mdx
+++ b/src/content/docs/get-started/index.mdx
@@ -319,17 +319,8 @@ Now let's add the boilerplate sample files to your content folder. Choose the ta
     1. Unzip the file and drag the contents into your folder. This will convert the Word and Excel files to Google Docs and Sheets.
     </Callouts>
 
-    <Aside type="note" title="Handling Upload Conversion Issues">
-      In some cases, when uploading Word and Excel files directly to Google Drive, they may not be automatically converted to Google Docs and Sheets format. However, files inside folders are converted as expected.
-
-      #### Workaround for Direct File Uploads
-
-      1. **Create a temporary folder** inside your Google Drive.  
-      2. **Move the unconverted Word and Excel files** into this temporary folder.  
-      3. **Upload the folder** to Google Drive—this ensures that the files inside are converted to Google Docs and Sheets.  
-      4. **After conversion, move the files** to their intended location within your storefront folder.  
-
-      This method ensures that all documents follow the correct format while maintaining the folder structure.
+    <Aside type="note" title="Ensure Google Drive Uploads Convert Properly">
+      To ensure Word and Excel files are automatically converted to Google Docs and Sheets, **always upload them inside a folder** rather than as individual files. The Google Drive setting for automatic conversion applies to folder uploads, but not to direct file uploads.  
     </Aside>
 
   </TabItem>


### PR DESCRIPTION
This update adds a note inside an `<Aside>` block to address an issue where Word and Excel files uploaded directly to Google Drive are not automatically converted to Google Docs and Sheets format.

**Changes:**
- Added instructions on how to handle conversion issues by uploading files inside a temporary folder first.
- Ensures consistency in document formats within the Google Drive content workflow.

**Why this change?**
Without this workaround, users may face inconsistencies in document formats, leading to manual fixes. This contribution improves the onboarding experience and ensures a smoother content setup process.
