### PR TITLE
fix: graphiql component styles

### DIFF
--- a/src/components/Graphiql/GraphiQLEditor.css
+++ b/src/components/Graphiql/GraphiQLEditor.css
@@ -336,10 +336,6 @@ button.graphiql-history-item-action {
 /* Fullscreen                                *
 /*********************************************/
 
-.graphiql-editor {
-  position: relative;
-}
-
 .fullscreen {
   position: absolute;
   top: 0;

--- a/src/components/Graphiql/graphiql-overrides.css
+++ b/src/components/Graphiql/graphiql-overrides.css
@@ -2,35 +2,45 @@
  * Component CSS and Overrides 
  *********************************************/
 
-.graphiql-container {
-  display: flex;
-  height: 100%;
+.graphiql-editor {
+  height: 300px !important;
   width: 100%;
+  display: flex;
   flex-direction: column;
+}
+
+:global(.graphiql-container) {
+  display: flex;
+  height: 100% !important;
+  width: 100%;
+  flex-direction: row;
   flex-grow: 1;
   border-radius: 0 0 8px 8px;
   border: 0.5px solid #d1d5db;
+  position: relative;
 }
 
 /*********************************************
  * Sidebar
  *********************************************/
 
-.graphiql-container .graphiql-sidebar {
+:global(.graphiql-container .graphiql-sidebar) {
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   padding: var(--px-4) var(--px-8);
   width: var(--sidebar-width);
 }
-.graphiql-container .graphiql-sidebar .graphiql-sidebar-section {
+
+:global(.graphiql-container .graphiql-sidebar .graphiql-sidebar-section) {
   display: flex;
   flex-direction: row;
   gap: var(--px-8);
   align-items: baseline;
   padding-bottom: 0;
 }
-.graphiql-container .graphiql-sidebar button {
+
+:global(.graphiql-container .graphiql-sidebar button) {
   display: flex;
   align-items: center;
   justify-content: center;
@@ -38,13 +48,16 @@
   height: calc(var(--sidebar-width) - (2 * var(--px-8)));
   width: calc(var(--sidebar-width) - (2 * var(--px-8)));
 }
-.graphiql-container .graphiql-sidebar button.active {
+
+:global(.graphiql-container .graphiql-sidebar button.active) {
   color: hsla(var(--color-neutral), 1);
 }
-.graphiql-container .graphiql-sidebar button:not(:first-child) {
+
+:global(.graphiql-container .graphiql-sidebar button:not(:first-child)) {
   margin-top: var(--px-4);
 }
-.graphiql-container .graphiql-sidebar button > svg {
+
+:global(.graphiql-container .graphiql-sidebar button > svg) {
   height: var(--px-20);
   width: var(--px-20);
 }
@@ -53,54 +66,49 @@
  * Main
  *********************************************/
 
-.graphiql-container .graphiql-main {
+:global(.graphiql-container .graphiql-main) {
   display: flex;
   flex: 1;
-  height: auto;
+  height: 100% !important;
   min-width: 0;
-  min-height: calc(100vh - 530px);
+  position: relative;
 }
 
-.graphiql-container .graphiql-main > div:first-child {
+:global(.graphiql-container .graphiql-main > div:first-child) {
   display: flex;
-  min-width: 0 !important;
-  height: 400px !important;
-  min-height: calc(100vh - 530px);
-  width: auto !important;
+  min-width: 0;
+  height: 100% !important;
+  width: auto;
+  position: relative;
 }
 
 /*********************************************
  * Session and Tabs
  *********************************************/
 
-.graphiql-container .graphiql-sessions {
+:global(.graphiql-container .graphiql-sessions) {
   background-color: hsla(var(--color-neutral), var(--alpha-background-light));
-  /* Adding the 8px of padding to the inner border radius of the query editor */
   border-radius: calc(var(--border-radius-12) + var(--px-8));
   display: flex;
   flex-direction: column;
   flex: 1;
-  max-height: 100%;
+  height: 100% !important;
   margin: var(--px-16);
   margin-left: 0;
   min-width: 0;
-  /* overrides */
   margin-top: 0;
   margin-right: 0;
   margin-bottom: 0;
+  position: relative;
 }
 
 /*********************************************
  * Session Header — containing tabs and logo
  *********************************************/
-/* Hidden */
-.graphiql-container .graphiql-session-header {
+:global(.graphiql-container .graphiql-session-header) {
   align-items: center;
-  display: flex;
-  justify-content: space-between;
-  height: var(--session-header-height);
-  /* overrides — hide session header */
   display: none;
+  justify-content: space-between;
   height: 0;
 }
 
@@ -108,11 +116,12 @@
  * Button to add new Tab
  *********************************************/
 
-button.graphiql-tab-add {
+:global(button.graphiql-tab-add) {
   height: 100%;
   padding: var(--px-4);
 }
-button.graphiql-tab-add > svg {
+
+:global(button.graphiql-tab-add > svg) {
   color: hsla(var(--color-neutral), var(--alpha-secondary));
   display: block;
   height: var(--px-16);
@@ -122,10 +131,8 @@ button.graphiql-tab-add > svg {
 /*********************************************
  * Right side of the session header
  *********************************************/
-.graphiql-container .graphiql-session-header-right {
+:global(.graphiql-container .graphiql-session-header-right) {
   align-items: center;
-  display: flex;
-  /* overrides — hide */
   display: none;
   height: 0;
 }
@@ -133,14 +140,14 @@ button.graphiql-tab-add > svg {
 /*********************************************
  * GraphiQL Logo
  *********************************************/
-.graphiql-container .graphiql-logo {
+:global(.graphiql-container .graphiql-logo) {
   color: hsla(var(--color-neutral), var(--alpha-secondary));
   font-size: var(--font-size-h4);
   font-weight: var(--font-weight-medium);
   padding: var(--px-12) var(--px-16);
 }
-/* Undo default link styling for the default GraphiQL logo link */
-.graphiql-container .graphiql-logo .graphiql-logo-link {
+
+:global(.graphiql-container .graphiql-logo .graphiql-logo-link) {
   color: hsla(var(--color-neutral), var(--alpha-secondary));
   text-decoration: none;
 }
@@ -148,7 +155,7 @@ button.graphiql-tab-add > svg {
 /*********************************************
  * Editor of the session
  *********************************************/
-.graphiql-container .graphiql-session {
+:global(.graphiql-container .graphiql-session) {
   display: flex;
   flex: 1;
   padding: 0 var(--px-8) var(--px-8);
@@ -157,7 +164,7 @@ button.graphiql-tab-add > svg {
 /*********************************************
  * All editors (query, variable, headers)
  *********************************************/
-.graphiql-container .graphiql-editors {
+:global(.graphiql-container .graphiql-editors) {
   background-color: hsl(var(--color-base));
   border-radius: calc(var(--border-radius-12));
   box-shadow: var(--popover-box-shadow);
@@ -165,15 +172,15 @@ button.graphiql-tab-add > svg {
   flex: 1;
   flex-direction: column;
 }
-.graphiql-container .graphiql-editors.full-height {
+
+:global(.graphiql-container .graphiql-editors.full-height) {
   margin-top: 0.5rem;
-  /* margin-top: calc(var(--px-8) - var(--session-header-height)); */
 }
 
 /*********************************************
  * QueryEditor and Toolbar on the right
  *********************************************/
-.graphiql-container .graphiql-query-editor {
+:global(.graphiql-container .graphiql-query-editor) {
   flex-grow: 1;
   padding: var(--px-16);
   column-gap: var(--px-16);
@@ -181,22 +188,18 @@ button.graphiql-tab-add > svg {
   width: 100%;
   padding-bottom: 0;
   padding-top: 0;
-  /* padding: var(--px-8); */
-  /* column-gap: var(--px-8); */
 }
 
-/* The vertical toolbar, right of query editor */
-.graphiql-container .graphiql-toolbar {
+:global(.graphiql-container .graphiql-toolbar) {
   width: var(--toolbar-width);
-  /* additional rule */
   margin-top: 1rem;
 }
-.graphiql-container .graphiql-toolbar > * + * {
+
+:global(.graphiql-container .graphiql-toolbar > * + *) {
   margin-top: var(--px-8);
-  /* margin-top: 1rem; */
 }
-/* The toolbar icons */
-.graphiql-toolbar-icon {
+
+:global(.graphiql-toolbar-icon) {
   color: hsla(var(--color-neutral), var(--alpha-tertiary));
   display: block;
   height: calc(var(--toolbar-width) - (var(--px-8) * 2));
@@ -206,59 +209,55 @@ button.graphiql-tab-add > svg {
 /*********************************************
  * Tab bar for editor tools
  *********************************************/
-.graphiql-container .graphiql-editor-tools {
+:global(.graphiql-container .graphiql-editor-tools) {
   cursor: row-resize;
   display: flex;
   width: 100%;
   column-gap: var(--px-8);
   padding: var(--px-8);
 }
-.graphiql-container .graphiql-editor-tools button {
+
+:global(.graphiql-container .graphiql-editor-tools button) {
   color: hsla(var(--color-neutral), var(--alpha-secondary));
 }
-.graphiql-container .graphiql-editor-tools button.active {
+
+:global(.graphiql-container .graphiql-editor-tools button.active) {
   color: hsla(var(--color-neutral), 1);
 }
 
 /*********************************************
  * Tab buttons to switch between editor tools
  *********************************************/
-.graphiql-container .graphiql-editor-tools > button:not(.graphiql-toggle-editor-tools) {
+:global(.graphiql-container .graphiql-editor-tools > button:not(.graphiql-toggle-editor-tools)) {
   padding: var(--px-8) var(--px-12);
 }
-.graphiql-container .graphiql-editor-tools .graphiql-toggle-editor-tools {
+
+:global(.graphiql-container .graphiql-editor-tools .graphiql-toggle-editor-tools) {
   margin-left: auto;
 }
 
 /*********************************************
-/* Editor tool— Variable or Header editor
-*********************************************/
-.graphiql-container .graphiql-editor-tool {
+ * Editor tool— Variable or Header editor
+ *********************************************/
+:global(.graphiql-container .graphiql-editor-tool) {
   flex: 1;
   padding: var(--px-16);
 }
 
-/**
-* The way CodeMirror editors are styled they overflow their containing
-* element. For some OS-browser-combinations this might cause overlap issues,
-* setting the position of this to `relative` makes sure this element will
-* always be on top of any editors.
-*/
-.graphiql-container .graphiql-toolbar,
-.graphiql-container .graphiql-editor-tools,
-.graphiql-container .graphiql-editor-tool {
+:global(.graphiql-container .graphiql-toolbar),
+:global(.graphiql-container .graphiql-editor-tools),
+:global(.graphiql-container .graphiql-editor-tool) {
   position: relative;
 }
 
 /*********************************************
  * Response View
  *********************************************/
-.graphiql-container .graphiql-response {
+:global(.graphiql-container .graphiql-response) {
   --editor-background: transparent;
   display: flex;
   width: 100%;
   flex-direction: column;
-  /* overrides */
   padding-bottom: 1rem;
   margin-top: 0.5rem;
   border-radius: 0.75rem;
@@ -269,7 +268,7 @@ button.graphiql-tab-add > svg {
 /*********************************************
  * Response View wrapper — result-window
  *********************************************/
-.graphiql-container .graphiql-response .result-window {
+:global(.graphiql-container .graphiql-response .result-window) {
   position: relative;
   flex: 1;
 }
@@ -277,31 +276,31 @@ button.graphiql-tab-add > svg {
 /*********************************************
  * Footer below the Response View
  *********************************************/
-.graphiql-container .graphiql-footer {
+:global(.graphiql-container .graphiql-footer) {
   border-top: 1px solid hsla(var(--color-neutral), var(--alpha-background-heavy));
 }
 
 /*********************************************
  * Plugin Container
  *********************************************/
-.graphiql-container .graphiql-plugin {
+:global(.graphiql-container .graphiql-plugin) {
   border-left: 1px solid hsla(var(--color-neutral), var(--alpha-background-heavy));
   flex: 1;
   overflow-y: auto;
   padding: var(--px-16);
   padding-right: 0;
   padding-left: 1rem;
-  /* overflow-y: hidden; */
 }
 
 /*********************************************
  * Generic drag bar for horizontal resizing
  *********************************************/
-.graphiql-horizontal-drag-bar {
+:global(.graphiql-horizontal-drag-bar) {
   width: var(--px-12);
   cursor: col-resize;
 }
-.graphiql-horizontal-drag-bar:hover::after {
+
+:global(.graphiql-horizontal-drag-bar:hover::after) {
   border: var(--px-2) solid hsla(var(--color-neutral), var(--alpha-background-heavy));
   border-radius: var(--border-radius-2);
   content: '';
@@ -309,11 +308,11 @@ button.graphiql-tab-add > svg {
   height: 25%;
   margin: 0 auto;
   position: relative;
-  /* (100% - 25%) / 2 = 37.5% */
   top: 37.5%;
   width: 0;
 }
-.graphiql-container .graphiql-chevron-icon {
+
+:global(.graphiql-container .graphiql-chevron-icon) {
   color: hsla(var(--color-neutral), var(--alpha-tertiary));
   display: block;
   height: var(--px-12);
@@ -324,9 +323,10 @@ button.graphiql-tab-add > svg {
 /*********************************************
  * Generic spin animation
  *********************************************/
-.graphiql-spin {
+:global(.graphiql-spin) {
   animation: spin 0.8s linear 0s infinite;
 }
+
 @keyframes spin {
   from {
     transform: rotate(0deg);
@@ -339,60 +339,62 @@ button.graphiql-tab-add > svg {
 /*********************************************
  * Settings Dialog
  *********************************************/
-
-/* The header of the settings dialog */
-.graphiql-dialog .graphiql-dialog-header {
+:global(.graphiql-dialog .graphiql-dialog-header) {
   align-items: center;
   display: flex;
   justify-content: space-between;
   padding: var(--px-24);
 }
-/* The title of the settings dialog */
-.graphiql-dialog .graphiql-dialog-title {
+
+:global(.graphiql-dialog .graphiql-dialog-title) {
   font-size: var(--font-size-h3);
   font-weight: var(--font-weight-medium);
   margin: 0;
 }
-/* A section inside the settings dialog */
-.graphiql-dialog .graphiql-dialog-section {
+
+:global(.graphiql-dialog .graphiql-dialog-section) {
   align-items: center;
   border-top: 1px solid hsla(var(--color-neutral), var(--alpha-background-heavy));
   display: flex;
   justify-content: space-between;
   padding: var(--px-24);
 }
-.graphiql-dialog .graphiql-dialog-section > :not(:first-child) {
+
+:global(.graphiql-dialog .graphiql-dialog-section > :not(:first-child)) {
   margin-left: var(--px-24);
 }
-/* The section title in the settings dialog */
-.graphiql-dialog .graphiql-dialog-section-title {
+
+:global(.graphiql-dialog .graphiql-dialog-section-title) {
   font-size: var(--font-size-h4);
   font-weight: var(--font-weight-medium);
 }
-/* The section caption in the settings dialog */
-.graphiql-dialog .graphiql-dialog-section-caption {
+
+:global(.graphiql-dialog .graphiql-dialog-section-caption) {
   color: hsla(var(--color-neutral), var(--alpha-secondary));
 }
-.graphiql-dialog .graphiql-warning-text {
+
+:global(.graphiql-dialog .graphiql-warning-text) {
   color: hsl(var(--color-warning));
   font-weight: var(--font-weight-medium);
 }
-.graphiql-dialog .graphiql-table {
+
+:global(.graphiql-dialog .graphiql-table) {
   border-collapse: collapse;
   width: 100%;
 }
-.graphiql-dialog .graphiql-table :is(th, td) {
+
+:global(.graphiql-dialog .graphiql-table :is(th, td)) {
   border: 1px solid hsla(var(--color-neutral), var(--alpha-background-heavy));
   padding: var(--px-8) var(--px-12);
 }
-/* A single key the short-key dialog */
-.graphiql-dialog .graphiql-key {
+
+:global(.graphiql-dialog .graphiql-key) {
   background-color: hsla(var(--color-neutral), var(--alpha-background-medium));
   border-radius: var(--border-radius-4);
   padding: var(--px-4);
 }
-/* Avoid showing native tooltips for icons with titles */
-.graphiql-container svg {
+
+:global(.graphiql-container svg) {
   pointer-events: none;
 }
 


### PR DESCRIPTION
This pull request (PR) fixes the GraphiQL component styles to follow Astro's guidance on CSS specificity. specifically, it uses Astro's `:global()` selector to ensure that styles are treated as global and maintain their specificity across both development and production builds.

The issue we're seeing is that production styles are not the same as development styles. This is likely because the base GraphiQL styles are being processed differently in production, affecting the specificity order.

Since this is a third-party React component (GraphiQL) being used in an Astro project, and the issue only occurs in production builds, this aligns with Astro's documentation about CSS bundling and optimization in production.

According to the Astro docs, during production builds:

1. CSS is minified and combined into chunks
1. CSS shared between pages is split into separate chunks
1. By default, stylesheets under 4kB are inlined into <style> tags while larger ones are linked externally

## Production

Current `develop` branch

![production](https://github.com/user-attachments/assets/b4107c3c-a86f-4595-8f95-f85f614ce525)

## Development

Current `develop` branch

![development](https://github.com/user-attachments/assets/0fa1bc4c-253d-4dfd-8961-76b98e805a10)

## Proposed

Current `fix-playground-layout` branch with both development and production build

![proposed](https://github.com/user-attachments/assets/45c0b61c-eb46-4b6e-9c36-9c2db35f9ea0)
