### PR TITLE
fix: graphiql component styles (alternate)

### DIFF
--- a/src/components/Graphiql/graphiql-overrides.css
+++ b/src/components/Graphiql/graphiql-overrides.css
@@ -17,36 +17,39 @@
  *********************************************/
 
 .graphiql-container .graphiql-sidebar {
-  display: flex;
-  flex-direction: row;
-  justify-content: space-between;
-  padding: var(--px-4) var(--px-8);
-  width: var(--sidebar-width);
+  display: flex !important;
+  flex-direction: row !important;
+  justify-content: space-between !important;
+  padding: var(--px-4) var(--px-8) !important;
+  width: var(--sidebar-width) !important;
+  min-width: var(--sidebar-width) !important;
+  max-width: var(--sidebar-width) !important;
+  gap: var(--px-16) !important;
 }
 .graphiql-container .graphiql-sidebar .graphiql-sidebar-section {
-  display: flex;
-  flex-direction: row;
-  gap: var(--px-8);
-  align-items: baseline;
-  padding-bottom: 0;
+  display: flex !important;
+  flex-direction: row !important;
+  gap: var(--px-8) !important;
+  align-items: center !important;
+  padding-bottom: 0 !important;
+  justify-content: flex-start !important;
 }
 .graphiql-container .graphiql-sidebar button {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
   color: hsla(var(--color-neutral), var(--alpha-secondary));
-  height: calc(var(--sidebar-width) - (2 * var(--px-8)));
-  width: calc(var(--sidebar-width) - (2 * var(--px-8)));
+  height: var(--px-32) !important;
+  width: var(--px-32) !important;
+  padding: var(--px-4) !important;
+  margin: 0 !important;
 }
 .graphiql-container .graphiql-sidebar button.active {
   color: hsla(var(--color-neutral), 1);
 }
-.graphiql-container .graphiql-sidebar button:not(:first-child) {
-  margin-top: var(--px-4);
-}
 .graphiql-container .graphiql-sidebar button > svg {
-  height: var(--px-20);
-  width: var(--px-20);
+  height: var(--px-20) !important;
+  width: var(--px-20) !important;
 }
 
 /*********************************************

--- a/src/components/Graphiql/graphiql-overrides.css
+++ b/src/components/Graphiql/graphiql-overrides.css
@@ -25,11 +25,13 @@
   min-width: var(--sidebar-width) !important;
   max-width: var(--sidebar-width) !important;
   gap: var(--px-16) !important;
+  margin-bottom: var(--px-16) !important;
+  margin-top: var(--px-16) !important;
 }
 .graphiql-container .graphiql-sidebar .graphiql-sidebar-section {
   display: flex !important;
   flex-direction: row !important;
-  gap: var(--px-8) !important;
+  gap: var(--px-12) !important;
   align-items: center !important;
   padding-bottom: 0 !important;
   justify-content: flex-start !important;


### PR DESCRIPTION
This is an alternative approach to fixing the APO playground layout proposed in #231.

## TODO

- [ ] Fix history (dev doesn't include; prod does
- [ ] Fix height 