### PR TITLE
Clarify multi-store documentation and store-switcher file usage

### DIFF
--- a/src/content/docs/merchants/get-started/multistore.mdx
+++ b/src/content/docs/merchants/get-started/multistore.mdx
@@ -22,7 +22,7 @@ To maintain storefronts that implement Edge Delivery Services, you must be famil
 
 Multi-store refers to a streamlined architecture that enables managing multiple stores with unique catalogs and localization while leveraging a shared code base and unified content delivery. The content hierarchy follows [Edge Delivery Services](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/edge-delivery/overview) best practices, emphasizing a single-tier structure.
 
-Content is organized primarily by language, enabling global reuse and minimizing duplication. US English files should be placed in the `en` directory of the project root. All other language- and region-specific files should be placed in a directory that is named in the format `*region-code_language-code*`. For example, the `/en/` directory contains data for the US market, while the  `/en_ca/` directory contains data for Canada. French content should be placed in directories with names like `fr_fr` for France and `fr_ca` for Canada.
+Content is organized primarily by language. US English files should be placed in the `en` directory of the project root. All other language- and region-specific files should be placed in a directory that is named in the format `*region-code_language-code*`. For example, the `/en/` directory contains data for the US market, while the  `/en_ca/` directory contains data for Canada. French content should be placed in directories with names like `fr_fr` for France and `fr_ca` for Canada.
 
 The Sharepoint file structure of a multi-store is shown below. Remove the `.docx` and `.xlsx` extensions for Google Drive files.
 
@@ -31,13 +31,14 @@ The Sharepoint file structure of a multi-store is shown below. Remove the `.docx
   - configs.xls _-- Defines API endpoints, headers, and other environment-specific data._
   - placeholders.xlsx _-- Stores reusable tokens for text and UI components._
   - index.docx _-- The home page of the English US store._
+  - store-switcher.docx _-- Manages the list of stores and their URL to render in the UI_
 - **en_ca/** _-- English Canadian Store_
   - configs.xls _-- Environment specific data for the English Canadian Store_
   - placeholders_overrides.xlsx _-- Entries that override the English store._
   - index.docx _-- The home page of the English Canadian store._
+  - store-switcher.docx _-- Manages the list of stores and their URL to render in the UI_
 - fstab.yaml _-- Sets mountpoints and folder mappings._
 - metadata.xlsx _-- URL, root path, and placeholder mappings for multi-store_
-- store-switcher.docx _-- Manages the list of stores and their URL to render in the UI_
 </FileTree>
 
 Default files are provided in the sample content. These files can be customized to suit your needs.
@@ -62,9 +63,9 @@ The **URL** value defines the path to the store view. The **root** value specifi
 
 ### Store Switcher
 
-The `store-switcher` file adds the list of stores displayed in the store-switcher component. This component renders a button in the footer that opens a modal containing the stores within the `store-switcher` file.
+Each store view has its own `store-switcher` file to add the list of stores displayed in the store-switcher component in their corresponding language. This component renders a button in the footer that opens a modal containing the stores within the `store-switcher` file.
 
-After creating the `metadata.xlsx` file in the root of your project with the URL, root, and placeholder values, you must create a `store-switcher.docx` file containing a bulleted list. Each line must define the display name of your store with an active link to the store, as shown below:
+After creating the `metadata.xlsx` file in the root of your project with the URL, root, and placeholder values, you must create a `store-switcher.docx` file containing a bulleted list inside each store view root folder. Each line must define the display name of your store with an active link to the store, as shown below:
 
 ```text
 **Select a store:**


### PR DESCRIPTION
Enhance the clarity of the multi-store documentation, specifically regarding the organization of language-specific files and the usage of the store-switcher file.

--- 

I don't believe this statement was entirely accurate:

>  Content is organized primarily by language, enabling global reuse and minimizing duplication. 

Documents are duplicated and not re-used. The only file that can be re-used is the placeholders spreadsheet using the override fallback. However,  pages will be copied across multiple root folders. i.e., `en/index` and `en_ca/index `

Also, the store-switcher.docx must be added to each root folder since store-switchers may be in different locales/languages.