### PR TITLE
Updated Graphql Playground to use ACCS backend through Mesh

### DIFF
--- a/src/components/Graphiql/queries/endpoint.js
+++ b/src/components/Graphiql/queries/endpoint.js
@@ -1,2 +1,2 @@
 export const ENDPOINT =
-  'https://edge-sandbox-graph.adobe.io/api/18205ff7-6701-451b-916e-36372101e2fc/graphql';
+  'https://edge-graph.adobe.io/api/489c8449-21a0-4155-9f95-7608d36970d6/graphql';

--- a/src/components/Graphiql/queries/queries.js
+++ b/src/components/Graphiql/queries/queries.js
@@ -1,54 +1,269 @@
 import dedent from 'dedent';
 
 export const QUERIES = {
-  Cart: dedent`query GUEST_CART_QUERY($cartId: String!) {
-  cart(cart_id: $cartId) {
-    id
-    total_quantity
-    is_virtual
-    prices {
-      subtotal_with_discount_excluding_tax {
-        currency
-        value
+  Cart: dedent`query GUEST_CART_QUERY(
+      $cartId: String!
+      $pageSize: Int! = 100
+      $currentPage: Int! = 1
+      $itemsSortInput: QuoteItemsSortInput! = { field: CREATED_AT, order: DESC }
+    ) {
+      cart(cart_id: $cartId) {
+        ...CART_FRAGMENT
       }
-      subtotal_including_tax {
-        currency
-        value
+    }
+
+    fragment CART_FRAGMENT on Cart {
+      id
+      total_quantity
+      is_virtual
+      prices {
+        subtotal_with_discount_excluding_tax {
+          currency
+          value
+        }
+        subtotal_including_tax {
+          currency
+          value
+        }
+        subtotal_excluding_tax {
+          currency
+          value
+        }
+        grand_total {
+          currency
+          value
+        }
+        grand_total_excluding_tax {
+          currency
+          value
+        }
+        applied_taxes {
+          label
+          amount {
+            value
+            currency
+          }
+        }
+        discounts {
+          amount {
+            value
+            currency
+          }
+          label
+          coupon {
+            code
+          }
+          applied_to
+        }
       }
-      subtotal_excluding_tax {
-        currency
-        value
+      applied_coupons {
+        code
       }
-      grand_total {
-        currency
-        value
+      itemsV2(
+        pageSize: $pageSize
+        currentPage: $currentPage
+        sort: $itemsSortInput
+      ) {
+        items {
+          ...CART_ITEM_FRAGMENT
+        }
       }
-      applied_taxes {
-        label
-        amount {
+      shipping_addresses {
+        country {
+          code
+        }
+        region {
+          code
+        }
+        postcode
+      }
+    }
+    fragment CART_ITEM_FRAGMENT on CartItemInterface {
+      __typename
+      uid
+      quantity
+      is_available
+      not_available_message
+      errors {
+        code
+        message
+      }
+      prices {
+        price {
+          value
+          currency
+        }
+        discounts {
+          amount {
+            value
+            currency
+          }
+          label
+        }
+        total_item_discount {
+          value
+          currency
+        }
+        row_total {
+          value
+          currency
+        }
+        row_total_including_tax {
+          value
+          currency
+        }
+        price_including_tax {
+          value
+          currency
+        }
+        fixed_product_taxes {
+          amount {
+            value
+            currency
+          }
+          label
+        }
+        original_item_price {
+          value
+          currency
+        }
+        original_row_total {
           value
           currency
         }
       }
-      discounts {
+      product {
+        name
+        sku
+        thumbnail {
+          url
+          label
+        }
+        url_key
+        canonical_url
+        categories {
+          url_path
+          url_key
+          name
+        }
+        custom_attributesV2(filters: { is_visible_on_front: true }) {
+          items {
+            code
+            ... on AttributeValue {
+              value
+            }
+            ... on AttributeSelectedOptions {
+              selected_options {
+                value
+                label
+              }
+            }
+          }
+        }
+        only_x_left_in_stock
+        stock_status
+        price_range {
+          ...PRICE_RANGE_FRAGMENT
+        }
+      }
+      ... on SimpleCartItem {
+        customizable_options {
+          ...CUSTOMIZABLE_OPTIONS_FRAGMENT
+        }
+      }
+      ... on ConfigurableCartItem {
+        configurable_options {
+          configurable_product_option_uid
+          option_label
+          value_label
+        }
+        configured_variant {
+          uid
+          sku
+          only_x_left_in_stock
+          stock_status
+          thumbnail {
+            label
+            url
+          }
+          price_range {
+            ...PRICE_RANGE_FRAGMENT
+          }
+        }
+        customizable_options {
+          ...CUSTOMIZABLE_OPTIONS_FRAGMENT
+        }
+      }
+      ... on BundleCartItem {
+        bundle_options {
+          uid
+          label
+          values {
+            uid
+            label
+          }
+        }
+      }
+      ... on GiftCardCartItem {
+        message
+        recipient_email
+        recipient_name
+        sender_email
+        sender_name
         amount {
+          currency
+          value
+        }
+        is_available
+      }
+    }
+
+    fragment PRICE_RANGE_FRAGMENT on PriceRange {
+      minimum_price {
+        regular_price {
           value
           currency
         }
+        final_price {
+          value
+          currency
+        }
+        discount {
+          percent_off
+          amount_off
+        }
+      }
+      maximum_price {
+        regular_price {
+          value
+          currency
+        }
+        final_price {
+          value
+          currency
+        }
+        discount {
+          percent_off
+          amount_off
+        }
+      }
+    }
+
+    fragment CUSTOMIZABLE_OPTIONS_FRAGMENT on SelectedCustomizableOption {
+      type
+      customizable_option_uid
+      label
+      is_required
+      values {
         label
+        value
+        price {
+          type
+          units
+          value
+        }
       }
     }
-    shipping_addresses {
-      country {
-        code
-      }
-      region {
-        code
-      }
-      postcode
-    }
-  }
-  }
   `,
   Products: dedent`query ProductQuery($sku: String!) {
   products(skus: [$sku]) {

--- a/src/components/Graphiql/queries/queryHeaders.json
+++ b/src/components/Graphiql/queries/queryHeaders.json
@@ -4,6 +4,5 @@
   "Magento-Store-Code": "main_website_store",
   "Magento-Store-View-Code": "default",
   "Magento-Website-Code": "base",
-  "x-api-key": "9753cd30401a477e816ed850c4f77e18",
   "Content-Type": "application/json"
 }

--- a/src/components/Graphiql/queries/queryVariables.js
+++ b/src/components/Graphiql/queries/queryVariables.js
@@ -1,14 +1,14 @@
 export const VARIABLES = {
-  Cart: JSON.stringify({ cartId: 'cdKuDrc2cd9AnyWycSuMPIYN4UqWlK85' }, null, 2),
-  Products: JSON.stringify({ sku: '24-WG080' }, null, 2),
+  Cart: JSON.stringify({ cartId: 'z7QmctP3Hs3qg3TCPwKPgWAnsrhdfHIU' }, null, 2),
+  Products: JSON.stringify({ sku: 'ADB256' }, null, 2),
   Recommendations: JSON.stringify(
     {
       pageType: 'Product',
-      currentSku: '24-WG03',
+      currentSku: 'ADB256',
       userViewHistory: [
-        { date: '2024-06-05T18:19:52.730Z', sku: '24-WB06' },
-        { date: '2024-06-05T18:23:22.712Z', sku: '24-UG07' },
-        { date: '2024-06-06T15:05:31.836Z', sku: '24-WG03' },
+        { date: '2025-03-05T18:19:52.730Z', sku: 'ADB256' },
+        { date: '2025-03-05T18:23:22.712Z', sku: 'ADB385' },
+        { date: '2025-03-06T15:05:31.836Z', sku: 'ADB386' },
       ],
       userPurchaseHistory: [],
     },


### PR DESCRIPTION
Updated the following:
1. API Mesh endpoint to point to a new instance backed by `ExL API Playground` ACCS backend
2. Cart query to fetch additional details such as product, shipping and prices
3. Variables to match the new ACCS backend
4. Headers to match the new ACCS backend

<img width="622" alt="image" src="https://github.com/user-attachments/assets/7a21ec76-4547-46d5-9b76-d8ad5aefe3d2" />
