### PR TITLE
Add beta badge to SDK section

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -475,6 +475,7 @@ async function config() {
             },
             {
               label: 'Drop-in SDK',
+              badge: 'Beta',
               icon: 'puzzle',
               link: '/sdk/',
               items: [


### PR DESCRIPTION
This PR adds a "Beta" badge to the Drop-in SDK section of the docs.

![CleanShot 2025-04-03 at 16 56 46@2x](https://github.com/user-attachments/assets/4c2ca1fe-5e26-4d34-b055-5fefa5990b3a)