### PR TITLE
Simplify and Clarify configs Spreadsheet Documentation

### DIFF
--- a/src/content/docs/merchants/get-started/multistore.mdx
+++ b/src/content/docs/merchants/get-started/multistore.mdx
@@ -31,10 +31,12 @@ The Sharepoint file structure of a multi-store is shown below. Remove the `.docx
   - placeholders.xlsx _-- Stores reusable tokens for text and UI components._
   - index.docx _-- The home page of the English US store._
   - store-switcher.docx _-- Manages the list of stores and their URL to render in the UI_
+  - analytics-config.xlsx _-- Adobe Commerce environment variables for the English US store._
 - **en_ca/** _-- English Canadian Store_
   - placeholders_overrides.xlsx _-- Entries that override the English store._
   - index.docx _-- The home page of the English Canadian store._
   - store-switcher.docx _-- Manages the list of stores and their URL to render in the UI_
+  - analytics-config.xlsx _-- Adobe Commerce environment variables for the English Canadian store._
 - fstab.yaml _-- Sets mountpoints and folder mappings._
 - metadata.xlsx _-- URL, root path, and placeholder mappings for multi-store_
 </FileTree>
@@ -96,7 +98,7 @@ folders:
 
 ## Store-specific files
 
-The content and placeholder files help define the experience in each store view as described here.
+The content, placeholders, and analytics files help define the experience in each store view as described here.
 
 ### Content files
 
@@ -105,7 +107,11 @@ The content files provide the structure of the pages served to your shoppers. Th
 
 ### Placeholders
 
-The `placeholders.xlsx` file stores reusable tokens for text and UI components. This file is used to define the text that is displayed on your storefront. The `placeholders.json` file is generated from this file and is used to replace the tokens in your content files. Optionally, you can create a `placeholders-overrides.json` file to define text values that supersede those specified in the `en` store view.
+The `placeholders.xlsx` file stores reusable tokens for text and UI components. This file is used to define the text that is displayed on your storefront. The `placeholders.json` file is generated from this file and is used to replace the tokens in your content files. Optionally, you can create a `placeholders-overrides.json` file to define text values that supersede those specified in the `en` store view. For more information, see [Placeholders](/resources/placeholders).
+
+### Analytics
+
+The `analytics-config` spreadsheet stores the Adobe Commerce environment variables for the store view used by the Analytics API. For more information, see [Analytics](/setup/analytics/instrumentation).
 
 ## Step-by-Step
 
@@ -120,7 +126,7 @@ Create an `en_ca` store view in the Commerce Admin and perform the following ste
 
 <Steps>
 1. Create the `en_ca` folder under the project root in Sharepoint or Google Docs.
-1. Copy the configuration files, placeholders file, and document pages from the `en` directory to the `en_ca` directory.
+1. Copy the configuration files, placeholders file, analytics file, and document pages from the `en` directory to the `en_ca` directory.
 </Steps>
 
 </Task>
@@ -133,6 +139,7 @@ Next, localize or translate the files in your project.
 <Steps>
 1. Translate or localize content files in the `/en_ca/` folders.
 1. Ensure all labels in `placeholders` file (SharePoint `.xlsx` or Google sheet) are accurately translated into the desired language.
+1. Update the `analytics-config` file (SharePoint `.xlsx` or Google sheet) with the new store view's environment variables.
 </Steps>
 
 </Task>

--- a/src/content/docs/setup/analytics/instrumentation.mdx
+++ b/src/content/docs/setup/analytics/instrumentation.mdx
@@ -30,7 +30,7 @@ The Commerce boilerplate includes the ACDL by default.
 
 ## Configuration
 
-To configure environment variables for your Commerce backend, you must update the `analytics-config` spreadsheet located in the root of your SharePoint content directory. Open the file to view the connection **keys** and **values** of the sample backend. They should look similar (but not exact) to the following:
+To configure environment variables for your Commerce backend, you must update the `analytics-config` spreadsheet located in the root of your SharePoint content directory. Open the file to view the connection **keys** and **values** of the sample backend, which should resemble the following:
 
 <OptionsTable
   options={[

--- a/src/content/docs/setup/analytics/instrumentation.mdx
+++ b/src/content/docs/setup/analytics/instrumentation.mdx
@@ -3,6 +3,8 @@ title: Instrumentation
 description: Learn how to instrument your Adobe Commerce on Edge Delivery Services storefront project.
 ---
 
+import OptionsTable from '@components/OptionsTable.astro';
+
 For Live Search and Product Recommendation APIs to work correctly, you must collect and send user interaction events to Commerce.
 
 User interaction events power Adobe Sensei features, like intelligent merchandising for Live Search and to personalize product recommendations units. These events also populate performance dashboards for [Live Search](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/live-search/live-search-admin/performance) and [Product Recommendations](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/product-recommendations/admin/workspace).
@@ -25,6 +27,25 @@ The ACDL provides an API to:
 :::tip
 The Commerce boilerplate includes the ACDL by default.
 :::
+
+## Configuration
+
+To configure environment variables for your Commerce backend, you must update the `analytics-config` spreadsheet located in the root of your SharePoint content directory. Open the file to view the connection **keys** and **values** of the sample backend. They should look similar (but not exact) to the following:
+
+<OptionsTable
+  options={[
+    ['#', 'Key', 'Value'],
+    ['1', 'commerce-environment', 'Production'],
+    ['2', 'commerce-store-id', '1'],
+    ['3', 'commerce-store-name', 'Main Website Store'],
+    ['4', 'commerce-store-url', 'https://www.aemshop.net/'],
+    ['5', 'commerce-store-view-id', '1'],
+    ['6', 'commerce-store-view-name', 'Default Store View'],
+    ['7', 'commerce-website-id', '1'],
+    ['8', 'commerce-website-name', 'Main Website'],
+  ]}
+/>
+
 
 ## Validate storefront events
 

--- a/src/content/docs/setup/configuration/commerce-configuration.mdx
+++ b/src/content/docs/setup/configuration/commerce-configuration.mdx
@@ -53,7 +53,6 @@ You can find the `configs` file in your content drive by clicking on the mountpo
     ['7', 'commerce.headers.cs.Magento-Store-View-Code', 'default'],
     ['8', 'commerce.headers.cs.Magento-Customer-group', 'd0b8ea36fca097dc92c02b1d104e6f41099184cb'],
     ['9', 'commerce.headers.cs.x-api-key', 'a6b4e2f69a4a4267a8f423c8caaf6a47'],
-    ['3', 'commerce-root-category-id', '2'],
   ]}
 />
 

--- a/src/content/docs/setup/configuration/commerce-configuration.mdx
+++ b/src/content/docs/setup/configuration/commerce-configuration.mdx
@@ -53,6 +53,7 @@ You can find the `configs` file in your content drive by clicking on the mountpo
     ['7', 'commerce.headers.cs.Magento-Store-View-Code', 'default'],
     ['8', 'commerce.headers.cs.Magento-Customer-group', 'd0b8ea36fca097dc92c02b1d104e6f41099184cb'],
     ['9', 'commerce.headers.cs.x-api-key', 'a6b4e2f69a4a4267a8f423c8caaf6a47'],
+    ['3', 'commerce-root-category-id', '2'],
   ]}
 />
 

--- a/src/content/docs/setup/configuration/commerce-configuration.mdx
+++ b/src/content/docs/setup/configuration/commerce-configuration.mdx
@@ -14,7 +14,7 @@ In this section, you'll learn how Commerce blocks in your storefront connect to 
 In the [Create your storefront tutorial](/get-started/), the sample content archive provided you a `configs` spreadsheet file in the root folder. This file contains the environment values for your Commerce backend including GraphQl endpoints and headers.
 
 When implementing your own project, you must update the configuration values with:
-- The Catalog Service header values specific to your Adobe Commerce backend.
+- The header values specific to your Adobe Commerce Catalog Services environment.
 - The Adobe Commerce and Catalog Service GraphQL endpoint that you configured as part of the [content delivery network (CDN) setup](/setup/configuration/content-delivery-network/).
 
 ## Vocabulary

--- a/src/content/docs/setup/configuration/commerce-configuration.mdx
+++ b/src/content/docs/setup/configuration/commerce-configuration.mdx
@@ -9,26 +9,20 @@ import Tasks from '@components/Tasks.astro';
 import Task from '@components/Task.astro';
 import Vocabulary from '@components/Vocabulary.astro';
 
-In this section, you'll learn how Commerce blocks in your storefront connect to a Commerce backend using values from the `configs`, `configs-stage` or `configs-dev` spreadsheets in the root of your SharePoint content directory.
+In this section, you'll learn how Commerce blocks in your storefront connect to a Commerce backend using values from the `configs` spreadsheet in the root of your SharePoint content directory.
 
-In the [Create your storefront tutorial](/get-started/), the sample content archive provided you with several `configs` spreadsheet files in the root folder. These files are one way in which authors can provide values to frontend blocks. Notably, the three files correspond to the different EDS environments. `configs` is used by aem.live, and represents production. `configs-stage` is used by aem.page and represents staging. `configs-dev` is used on localhost when you are running your EDS storefront locally.
-
-You can forcibly change which config is fetched and used on your page by setting `environment` in SessionStorage to either `dev`, `stage`, or `prod`.
+In the [Create your storefront tutorial](/get-started/), the sample content archive provided you a `configs` spreadsheet file in the root folder. This file contains the environment values for your Commerce backend including GraphQl endpoints and headers.
 
 When implementing your own project, you must update the configuration values with:
-
 - The Catalog Service header values specific to your Adobe Commerce backend.
-
-- The Adobe Commerce and Catalog Service GraphQL endpoints that you configured as part of the [content delivery network (CDN) setup](/setup/configuration/content-delivery-network/).
-
-- Other values which are utilized by the Storefront codebase like `commerce-environment`, `commerce-base-currency-code` etc.
+- The Adobe Commerce and Catalog Service GraphQL endpoint that you configured as part of the [content delivery network (CDN) setup](/setup/configuration/content-delivery-network/).
 
 ## Vocabulary
 
 <Vocabulary>
 ### Storefront configuration
 
-The `configs`, `configs-stage` and `configs-dev` spreadsheets contain the connection settings for your Commerce blocks. Each row in the sheet contains a `key` and a `value` that corresponds to a specific setting or usage in your Commerce backend or in the Storefront codebase. The `key` is used to retrieve the `value` from the `configs` spreadsheet and is used to connect your Commerce blocks to your Commerce backend.
+The `configs` spreadsheet contains the connection settings for your Commerce blocks. Each row in the sheet contains a `key` and a `value` that corresponds to a specific setting or usage in your Commerce backend. The `key` is used to retrieve the `value` from the `configs` spreadsheet and is used to connect your Commerce blocks to your Commerce backend.
 
 ### default values
 
@@ -53,7 +47,6 @@ You can find the `configs` file in your content drive by clicking on the mountpo
     ['#', 'Key', 'Value'],
     ['1', 'commerce-endpoint', 'https://catalog-service.adobe.io/graphql'],
     ['2', 'commerce-core-endpoint', 'https://mystorefront.com/graphql'],
-    ['3', 'commerce-root-category-id', '2'],
     ['4', 'commerce.headers.cs.Magento-Environment-Id', '7cb935fd-d3bc-487b-9a2f-e5965c30f2a1'],
     ['5', 'commerce.headers.cs.Magento-Website-Code', 'base'],
     ['6', 'commerce.headers.cs.Magento-Store-Code', 'main_website_store'],
@@ -64,7 +57,7 @@ You can find the `configs` file in your content drive by clicking on the mountpo
 />
 
 :::note
-The `commerce.headers.cs` fields are required, at minimum.
+The default values listed above are all required.
 :::
 
 Each `key` is described below with links to more details. The `value` for each key is specific to your Commerce instance and can be provided by your Commerce administrator.
@@ -74,8 +67,6 @@ Each `key` is described below with links to more details. The `value` for each k
 1. **commerce-endpoint:** (read-only) Services GraphQL endpoint optimized for Catalog Service, Live Search, and Product Recommendations. See [Catalog Service](https://experienceleague.adobe.com/en/docs/commerce-merchant-services/catalog-service/guide-overview) for details.
 
 1. **commerce-core-endpoint:** (read/write) Core GraphQL endpoint for a variety of queries and mutations. See [Adobe Commerce GraphQL API](https://developer.adobe.com/commerce/webapi/graphql/reference/) for details.
-
-1. **commerce-root-category-id:** Determines the products in the storefront's main menu. See [Step 1: Create root categories](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/multi-sites/ms-admin#step-1-create-root-categories), [Catagories overview](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/categories/categories), and [Root category and hierarchy](https://experienceleague.adobe.com/en/docs/commerce-admin/catalog/categories/category-root) for details.
 
 1. **commerce.headers.cs.Magento-Environment-Id:** Connects the storefront to the cloud instance that serves it. See [Cloud Environment overview](https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/project/overview#environment-overview) for details.
 


### PR DESCRIPTION
This PR improves the documentation for the configs spreadsheet by:

- [x] Simplifying environment references: Removed mentions of configs-stage and configs-dev. We are moving to a single configuration.
- [x] Distinctly separated data collection configuration from commerce environment configuration for better structure and understanding.
- [x] Updates multistore documentation to account for analytics configuration per store view.

![image](https://github.com/user-attachments/assets/01132c42-f623-4347-bd8f-902f6010c4d1)

![image](https://github.com/user-attachments/assets/5d05885c-3e58-4510-aa4f-85f22a6d22ff)

![image](https://github.com/user-attachments/assets/30c30e54-a43c-46d3-b44b-9ae9042c17b5)

