### PR TITLE
fix: fix height of iframe to prevent cutoff of content

### DIFF
--- a/src/components/IFrame.astro
+++ b/src/components/IFrame.astro
@@ -69,8 +69,17 @@ const iframeSrc = src
           (iframe as HTMLIFrameElement).contentWindow?.document;
         if (iframeDocument) {
           iframeDocument.documentElement.style.overflow = "hidden";
+
+          // Get the actual content height including margins
+          const contentHeight = Math.max(
+            iframeDocument.documentElement.scrollHeight,
+            iframeDocument.body.scrollHeight,
+            event.data.height
+          );
+
+          // Set the iframe height to the maximum content height
+          iframe.style.height = contentHeight + "px";
         }
-        iframe.style.height = event.data.height + "px";
       }
     }
   });


### PR DESCRIPTION
This PR updates the height of the iFrame component to prevent it from cutting off the bottom of the content.