### PR TITLE
fix: indent format of sidenav

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -466,6 +466,21 @@ ol.sl-steps li {
   color: var(--sl-color-text-accent);
 }
 
+.summary.summary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: .2em 0;
+    line-height: 1.4;
+    cursor: pointer;
+    user-select: none;
+}
+
+.large.large {
+  font-size: var(--sl-text-base);
+  padding: 0.225rem 0;
+}
+
 @media (min-width: 50rem) {
   .starlight-sidebar-topics {
     --topic-background-color-current: var(--sl-color-gray-6);


### PR DESCRIPTION
This PR fixes something Carlos Solis brought up and that I have been putting off while developing content. From what Carlos mentioned:

BEFORE:
![{B22C52BA-B90D-4EC8-A323-F462683BB7C5}](https://github.com/user-attachments/assets/7e372fc6-af7a-4df6-ad52-61d4afcb9933)

AFTER:
![{8D91FBFB-009A-4CD7-866B-8B306E12F5DD}](https://github.com/user-attachments/assets/9b8fafd5-168c-4307-afa8-743db98a80b6)
