### PR TITLE
fix: add deprecated tag badge to ProductDetails container

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -266,7 +266,7 @@ async function config() {
                             { label: 'ProductPrice', link: '/dropins/product-details/containers/product-price/' },
                             { label: 'ProductQuantity', link: '/dropins/product-details/containers/product-quantity/' },
                             { label: 'ProductShortDescription', link: '/dropins/product-details/containers/product-short-description/' },
-                            { label: 'ProductDetails', link: '/dropins/product-details/containers/product-details/' },
+                            { label: 'ProductDetails', link: '/dropins/product-details/containers/product-details/', badge: 'Deprecated' },
                           ]
                         },
                         { label: 'Slots', link: '/dropins/product-details/slots/' },

--- a/src/components/overrides/SidebarSublist.astro
+++ b/src/components/overrides/SidebarSublist.astro
@@ -1,7 +1,7 @@
 ---
-import { flattenSidebar, type SidebarEntry } from '../../utils/navigation';
-import Icon from './Icon.astro';
-import { Badge } from '@astrojs/starlight/components';
+import { flattenSidebar, type SidebarEntry } from "../../utils/navigation";
+import Icon from "./Icon.astro";
+import { Badge } from "@astrojs/starlight/components";
 
 interface Props {
   sublist: SidebarEntry[];
@@ -11,39 +11,45 @@ interface Props {
 const { sublist, nested } = Astro.props;
 ---
 
-<ul class:list={{ 'top-level': !nested }}>
+<ul class:list={{ "top-level": !nested }}>
   {
     sublist.map((entry) => (
       <li>
-        {entry.type === 'link' ? (
+        {entry.type === "link" ? (
           <a
             href={entry.href}
-            aria-current={entry.isCurrent && 'page'}
+            aria-current={entry.isCurrent && "page"}
             class:list={[{ large: !nested }, entry.attrs.class]}
             {...entry.attrs}
           >
             <span>{entry.label}</span>
             {entry.badge && (
               <>
-                {' '}
+                {" "}
                 <Badge
                   text={entry.badge.text}
-                  variant={entry.isCurrent ? 'outline' : entry.badge.variant}
+                  variant={entry.isCurrent ? "outline" : entry.badge.variant}
                 />
               </>
             )}
           </a>
         ) : (
           <details
-            open={flattenSidebar(entry.entries).some((i) => i?.isCurrent) || !entry.collapsed}
+            open={
+              flattenSidebar(entry.entries).some((i) => i?.isCurrent) ||
+              !entry.collapsed
+            }
           >
             <summary>
               <div class="group-label">
                 <span class="large">{entry.label}</span>
                 {entry.badge && (
                   <>
-                    {' '}
-                    <Badge text={entry.badge.text} variant={entry.badge.variant} />
+                    {" "}
+                    <Badge
+                      text={entry.badge.text}
+                      variant={entry.badge.variant}
+                    />
                   </>
                 )}
               </div>
@@ -59,7 +65,7 @@ const { sublist, nested } = Astro.props;
 
 <style>
   ul {
-    --sl-sidebar-item-padding-inline: 1.25rem;
+    --sl-sidebar-item-padding-inline: 0.25rem;
     list-style: none;
     padding: 0;
   }
@@ -110,7 +116,7 @@ const { sublist, nested } = Astro.props;
     transition: transform 0.2s ease-in-out;
     flex-shrink: 0;
   }
-  :global([dir='rtl']) .caret {
+  :global([dir="rtl"]) .caret {
     transform: rotateZ(180deg);
   }
   [open] > summary .caret {
@@ -131,9 +137,9 @@ const { sublist, nested } = Astro.props;
     color: var(--sl-color-white);
   }
 
-  [aria-current='page'],
-  [aria-current='page']:hover,
-  [aria-current='page']:focus {
+  [aria-current="page"],
+  [aria-current="page"]:hover,
+  [aria-current="page"]:focus {
     font-weight: 600;
     color: var(--sl-color-text-invert);
     background-color: var(--sl-color-text-accent);

--- a/src/content/docs/dropins/product-details/containers/product-details.mdx
+++ b/src/content/docs/dropins/product-details/containers/product-details.mdx
@@ -4,12 +4,17 @@ description: Configure the ProductDetails container for the product details page
 tableOfContents:
   minHeadingLevel: 2
   maxHeadingLevel: 2
+badge:
+  text: Deprecated
+  variant: danger
+  size: large
 ---
 
 import OptionsTable from '@components/OptionsTable.astro';
 import Aside from '@components/Aside.astro';
+import { Badge } from '@astrojs/starlight/components';
 
-:::note[Note]
+:::danger[Deprecated]
 Prior to version 1.0.0 of the product details page drop-in component, `ProductDetails` was the only supported container. This container is obsolete and has been removed from the boilerplate. If you have implemented this container, we recommend migrating to the newer containers. It should not be implemented alongside the newer containers.
 :::
 

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -467,18 +467,24 @@ ol.sl-steps li {
 }
 
 .summary.summary {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: .2em 0;
-    line-height: 1.4;
-    cursor: pointer;
-    user-select: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: .2em 0;
+  line-height: 1.4;
+  cursor: pointer;
+  user-select: none;
 }
 
 .large.large {
   font-size: var(--sl-text-base);
   padding: 0.225rem 0;
+}
+
+ul {
+  --sl-sidebar-item-padding-inline: 0.25rem;
+  list-style: none;
+  padding: 0;
 }
 
 @media (min-width: 50rem) {

--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -3,7 +3,7 @@
   --sl-nav-height: 4rem;
   --sl-nav-pad-y: 2rem;
   --sl-nav-pad-x: 1.25rem;
-  --sl-sidebar-width: 17rem;
+  --sl-sidebar-width: 18rem;
   --sl-sidebar-pad-x: 1.5rem;
   --sl-content-width: 48rem;
   --sl-content-pad-x: 2rem;


### PR DESCRIPTION
This PR adds a "deprecated" badge and enhanced callout to indicate that the ProductDetails container is deprecated.