### PR TITLE
fix: remove Textfield component entry in sidenav

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -633,10 +633,6 @@ async function config() {
                       link: '/sdk/components/skeleton/'
                     },
                     {
-                      label: 'TextField',
-                      link: '/sdk/components/textfield/'
-                    },
-                    {
                       label: 'Tag',
                       link: '/sdk/components/tag/'
                     },


### PR DESCRIPTION
This PR removes the sidebar navigation link to Textfield, an old shared component that no longer exists in the SDK.