### PR TITLE
Fixes CSS styles for lists in Tasks; updates to the GraphiQL editor CSS

### DIFF
--- a/src/components/Graphiql/graphiql-overrides.css
+++ b/src/components/Graphiql/graphiql-overrides.css
@@ -63,14 +63,14 @@
   flex: 1;
   height: auto;
   min-width: 0;
-  min-height: calc(100vh - 530px);
+  min-height: 500px;
 }
 
 .graphiql-container .graphiql-main>div:first-child {
   display: flex;
   min-width: 0 !important;
-  height: 400px !important;
-  min-height: calc(100vh - 530px);
+  height: 500px !important;
+  min-height: 500px;
   width: auto !important;
 }
 
@@ -221,7 +221,7 @@ button.graphiql-tab-add>svg {
   display: flex;
   width: 100%;
   column-gap: var(--px-8);
-  padding: var(--px-8);
+  padding: 0 var(--px-8);
 }
 
 .graphiql-container .graphiql-editor-tools button {
@@ -248,7 +248,7 @@ button.graphiql-tab-add>svg {
 *********************************************/
 .graphiql-container .graphiql-editor-tool {
   flex: 1;
-  padding: var(--px-16);
+  padding: 0 0.5rem;
 }
 
 /**

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -407,7 +407,6 @@ ol.sl-steps li {
 
 .sl-markdown-content .ac-tasks .ac-task ul li:not(:where(.not-content *)) {
   margin-top: 0;
-  margin-left: -1.25rem;
 }
 
 .sl-markdown-content .ac-tasks .ac-task .callouts ul li:not(:where(.not-content *)) {
@@ -502,7 +501,6 @@ ul li ul {
 
 .sl-markdown-content>ul {
   padding-left: 0;
-  margin-top: 0 !important;
 }
 
 main {


### PR DESCRIPTION
This PR fixes the indentation of bullets within the Task component. It also fixes the GraphiQL editor layout on smaller screens to ensure that the Variables and Header section can still be accessed.

Fix:
<img width="780" alt="image" src="https://github.com/user-attachments/assets/4eec355e-70a1-4a41-99fa-4747bc141485" />
