### PR TITLE
fix: npm registry for recaptcha

### DIFF
--- a/src/content/docs/dropins/user-auth/recaptcha.mdx
+++ b/src/content/docs/dropins/user-auth/recaptcha.mdx
@@ -15,7 +15,7 @@ The reCAPTCHA module is implemented as a standalone SDK package. It enables reCA
 To install this functionality, run the following command:
 
 ```bash
-npm i @adobe/reCAPTCHA
+npm i @adobe-commerce/recaptcha
 ```
 
 [Google reCAPTCHA](https://experienceleague.adobe.com/en/docs/commerce-admin/systems/security/captcha/security-google-recaptcha) in the _Admin Systems Guide_ describes how to configure Adobe Commerce.


### PR DESCRIPTION
This pull request fixes the [installation instructions](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/user-auth/recaptcha/) for the recaptcha component.

The current instructions produce the following error:

```
npm i @adobe/recaptcha                                                 
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@adobe%2frecaptcha - Not found
npm error 404
npm error 404  '@adobe/recaptcha@*' is not in this registry.
```