### PR TITLE
fix: remove forward slash from editUrlPattern

### DIFF
--- a/src/content/docs/get-started/index.mdx
+++ b/src/content/docs/get-started/index.mdx
@@ -263,7 +263,7 @@ To link your storefront repo to your commerce, you can duplicate the [demo-confi
   {
     "project": "My Project",
     "editUrlLabel": "Document Authoring",
-    "editUrlPattern": "https://da.live/edit#/{{org}}/{{site}}/{{pathname}}",
+    "editUrlPattern": "https://da.live/edit#/{{org}}/{{site}}{{pathname}}",
   }
   ```
 


### PR DESCRIPTION
This PR removes the forward slash from the URL of the `editUrlPattern`