### PR TITLE
fix: add header to table

### DIFF
--- a/src/content/docs/dropins/product-details/containers/product-gallery.mdx
+++ b/src/content/docs/dropins/product-details/containers/product-gallery.mdx
@@ -14,6 +14,7 @@ The `ProductGallery` container provides the following configuration options:
 <OptionsTable
   compact
   options={[
+    ['Option', 'Type', 'Req?', 'Description'],
     ['controls', 'string', 'No', 'Type of controls for navigation. Options are thumbnailsRow, thumbnailsColumn, dots, or null. Defaults to dots.'],
     ['loop', 'boolean', 'No', 'Whether to loop the images in the carousel. Defaults to true.'],
     ['peak', 'boolean', 'No', 'Whether to enable the peak feature. Defaults to false.'],


### PR DESCRIPTION
This PR adds the missing table header to the ProductGallery container