### PR TITLE
Custom badge component (PaaS vs SaaS)

### DIFF
--- a/src/components/overrides/Badge.astro
+++ b/src/components/overrides/Badge.astro
@@ -1,0 +1,28 @@
+---
+import { Badge as StarlightBadge } from '@astrojs/starlight/components';
+import { setBasePath } from '@utils/basePath';
+
+interface Props {
+  text: string;
+  variant?: 'default' | 'note' | 'danger' | 'success' | 'tip' | 'caution';
+  size?: 'small' | 'medium' | 'large';
+  href?: string;
+}
+
+const { text, variant = 'default', size = 'medium', href } = Astro.props;
+const isExternal = href?.toString().startsWith('https://');
+const fullHref = href ? (isExternal ? href : setBasePath(href)) : undefined;
+---
+
+{href ? (
+  <a
+    href={fullHref}
+    target={isExternal ? '_blank' : '_self'}
+    rel={isExternal ? 'noopener noreferrer' : undefined}
+    class="sl-badge-link"
+  >
+    <StarlightBadge text={text} variant={variant} size={size} />
+  </a>
+) : (
+  <StarlightBadge text={text} variant={variant} size={size} />
+)}

--- a/src/components/overrides/Badge.astro
+++ b/src/components/overrides/Badge.astro
@@ -7,9 +7,10 @@ interface Props {
   variant?: 'default' | 'note' | 'danger' | 'success' | 'tip' | 'caution';
   size?: 'small' | 'medium' | 'large';
   href?: string;
+  tooltip?: string;
 }
 
-const { text, variant = 'default', size = 'medium', href } = Astro.props;
+const { text, variant = 'default', size = 'medium', href, tooltip } = Astro.props;
 const isExternal = href?.toString().startsWith('https://');
 const fullHref = href ? (isExternal ? href : setBasePath(href)) : undefined;
 ---
@@ -20,6 +21,7 @@ const fullHref = href ? (isExternal ? href : setBasePath(href)) : undefined;
     target={isExternal ? '_blank' : '_self'}
     rel={isExternal ? 'noopener noreferrer' : undefined}
     class="sl-badge-link"
+    {...(tooltip ? { title: tooltip } : {})}
   >
     <StarlightBadge text={text} variant={variant} size={size} />
   </a>

--- a/src/content/docs/dropins/cart/index.mdx
+++ b/src/content/docs/dropins/cart/index.mdx
@@ -16,27 +16,27 @@ The following table provides an overview of the Adobe Commerce features that the
 
 | Feature                                                          | Status                                       |
 | ---------------------------------------------------------------- | -------------------------------------------- |
-| Adobe Experience Platform Audiences                              | <Badge text="Roadmap" variant="note" />      |
-| All product types                                                | <Badge text="Supported" variant="success" /> |
-| Apply coupons                                                    | <Badge text="Supported" variant="success" /> |
-| Apply gift cards                                                 | <Badge text="Supported" variant="success" />      |
-| Apply gift options                                               | <Badge text="Supported" variant="success" />
-| Cart API extensibility                                           | <Badge text="Supported" variant="success" /> |
-| Cart rules                                                       | <Badge text="Supported" variant="success" /> |
-| Cart with 100+ products                                          | <Badge text="Roadmap" variant="note" />      |
-| Commerce segments                                                | <Badge text="Supported" variant="success" /> |
-| Customer cart                                                    | <Badge text="Supported" variant="success" /> |
-| Estimate tax/shipping                                            | <Badge text="Supported" variant="success" /> |
-| Guest cart                                                       | <Badge text="Supported" variant="success" /> |
-| Low product stock alert                                          | <Badge text="Supported" variant="success" /> |
-| Mini-cart                                                        | <Badge text="Supported" variant="success" /> |
-| No-code UI configurations                                        | <Badge text="Supported" variant="success" /> |
-| Out of stock/insufficient quantity products                      | <Badge text="Supported" variant="success" /> |
-| Product line discounts (catalog rule, special price, tier price) | <Badge text="Supported" variant="success" /> |
-| Save to wishlist                                                 | <Badge text="Roadmap" variant="note" />      |
-| Slots for extensibility                                          | <Badge text="Supported" variant="success" /> |
-| Taxes: Fixed                                                     | <Badge text="Roadmap" variant="note" />      |
-| Taxes: Sales, VAT                                                | <Badge text="Supported" variant="success" /> |
+| Adobe Experience Platform Audiences                              | <Badge text="Roadmap" variant="caution" />      |
+| All product types                                                | <Badge text="Supported" variant="tip" /> |
+| Apply coupons                                                    | <Badge text="Supported" variant="tip" /> |
+| Apply gift cards                                                 | <Badge text="Supported" variant="tip" />      |
+| Apply gift options                                               | <Badge text="Supported" variant="tip" />
+| Cart API extensibility                                           | <Badge text="Supported" variant="tip" /> |
+| Cart rules                                                       | <Badge text="Supported" variant="tip" /> |
+| Cart with 100+ products                                          | <Badge text="Roadmap" variant="caution" />      |
+| Commerce segments                                                | <Badge text="Supported" variant="tip" /> |
+| Customer cart                                                    | <Badge text="Supported" variant="tip" /> |
+| Estimate tax/shipping                                            | <Badge text="Supported" variant="tip" /> |
+| Guest cart                                                       | <Badge text="Supported" variant="tip" /> |
+| Low product stock alert                                          | <Badge text="Supported" variant="tip" /> |
+| Mini-cart                                                        | <Badge text="Supported" variant="tip" /> |
+| No-code UI configurations                                        | <Badge text="Supported" variant="tip" /> |
+| Out of stock/insufficient quantity products                      | <Badge text="Supported" variant="tip" /> |
+| Product line discounts (catalog rule, special price, tier price) | <Badge text="Supported" variant="tip" /> |
+| Save to wishlist                                                 | <Badge text="Roadmap" variant="caution" />      |
+| Slots for extensibility                                          | <Badge text="Supported" variant="tip" /> |
+| Taxes: Fixed                                                     | <Badge text="Roadmap" variant="caution" />      |
+| Taxes: Sales, VAT                                                | <Badge text="Supported" variant="tip" /> |
 
 ## Section topics
 

--- a/src/content/docs/dropins/checkout/index.mdx
+++ b/src/content/docs/dropins/checkout/index.mdx
@@ -16,23 +16,23 @@ The following table provides an overview of the Adobe Commerce features that the
 
 | Feature                                                                            | Status                                       |
 | ---------------------------------------------------------------------------------- | -------------------------------------------- |
-| All product types                                                                  | <Badge text="Supported" variant="success" /> |
-| Any checkout flow (BOPIS, one/two step)                                            | <Badge text="Supported" variant="success" /> |
-| Any checkout layout                                                                | <Badge text="Supported" variant="success" /> |
-| Apply coupons to the order                                                         | <Badge text="Supported" variant="success" />      |
-| Apply gift cards to the order                                                      | <Badge text="Roadmap" variant="note" />      |
-| Cart rules                                                                         | <Badge text="Supported" variant="success" /> |
-| Create account after checkout                                                      | <Badge text="Supported" variant="success" /> |
-| Custom customer address attributes                                                 | <Badge text="Supported" variant="success" /> |
-| Customer address selection at checkout                                             | <Badge text="Supported" variant="success" /> |
-| Customer checkout                                                                  | <Badge text="Supported" variant="success" /> |
-| Customer segments                                                                  | <Badge text="Supported" variant="success" /> |
-| Default customer shipping and billing applied at checkout                          | <Badge text="Supported" variant="success" /> |
-| Extensibility for payment providers                                                | <Badge text="Supported" variant="success" /> |
-| Guest checkout                                                                     | <Badge text="Supported" variant="success" /> |
-| Log in during checkout                                                             | <Badge text="Supported" variant="success" /> |
-| Low product stock alert                                                            | <Badge text="Supported" variant="success" /> |
-| Out of stock/insufficient quantity products                                        | <Badge text="Supported" variant="success" /> |
-| Taxes: Fixed                                                                       | <Badge text="Roadmap" variant="note" />      |
-| Taxes: Sales, VAT                                                                  | <Badge text="Supported" variant="success" /> |
-| Zero subtotal checkout                                                             | <Badge text="Supported" variant="success" /> |
+| All product types                                                                  | <Badge text="Supported" variant="tip" /> |
+| Any checkout flow (BOPIS, one/two step)                                            | <Badge text="Supported" variant="tip" /> |
+| Any checkout layout                                                                | <Badge text="Supported" variant="tip" /> |
+| Apply coupons to the order                                                         | <Badge text="Supported" variant="tip" />      |
+| Apply gift cards to the order                                                      | <Badge text="Roadmap" variant="caution" />      |
+| Cart rules                                                                         | <Badge text="Supported" variant="tip" /> |
+| Create account after checkout                                                      | <Badge text="Supported" variant="tip" /> |
+| Custom customer address attributes                                                 | <Badge text="Supported" variant="tip" /> |
+| Customer address selection at checkout                                             | <Badge text="Supported" variant="tip" /> |
+| Customer checkout                                                                  | <Badge text="Supported" variant="tip" /> |
+| Customer segments                                                                  | <Badge text="Supported" variant="tip" /> |
+| Default customer shipping and billing applied at checkout                          | <Badge text="Supported" variant="tip" /> |
+| Extensibility for payment providers                                                | <Badge text="Supported" variant="tip" /> |
+| Guest checkout                                                                     | <Badge text="Supported" variant="tip" /> |
+| Log in during checkout                                                             | <Badge text="Supported" variant="tip" /> |
+| Low product stock alert                                                            | <Badge text="Supported" variant="tip" /> |
+| Out of stock/insufficient quantity products                                        | <Badge text="Supported" variant="tip" /> |
+| Taxes: Fixed                                                                       | <Badge text="Roadmap" variant="caution" />      |
+| Taxes: Sales, VAT                                                                  | <Badge text="Supported" variant="tip" /> |
+| Zero subtotal checkout                                                             | <Badge text="Supported" variant="tip" /> |

--- a/src/content/docs/dropins/order/index.mdx
+++ b/src/content/docs/dropins/order/index.mdx
@@ -37,14 +37,14 @@ The following table provides an overview of the Adobe Commerce guest user featur
 
 | Feature | Status |
 | ------- | ------ |
-| Access wishlist while guest cart content is available | <Badge text="Roadmap" variant="note" /> |
-| Add product to wishlist | <Badge text="Roadmap" variant="note" /> |
-| Cancel order (with email confirmation) | <Badge text="Supported" variant="success" /> |
-| Create a return | <Badge text="Supported" variant="success" /> |
+| Access wishlist while guest cart content is available | <Badge text="Roadmap" variant="caution" /> |
+| Add product to wishlist | <Badge text="Roadmap" variant="caution" /> |
+| Cancel order (with email confirmation) | <Badge text="Supported" variant="tip" /> |
+| Create a return | <Badge text="Supported" variant="tip" /> |
 | Merge guest cart with customer cart | <Badge text="API only" variant="tip" /> |
-| Move products from wishlist to cart | <Badge text="Roadmap" variant="note" /> |
-| Place order | <Badge text="Supported" variant="success" /> |
-| Reorder | <Badge text="Supported" variant="success" /> |
-| Remove products from wishlist | <Badge text="Roadmap" variant="note" /> |
-| View order status | <Badge text="Supported" variant="success" /> |
-| View return status | <Badge text="Supported" variant="success" /> |
+| Move products from wishlist to cart | <Badge text="Roadmap" variant="caution" /> |
+| Place order | <Badge text="Supported" variant="tip" /> |
+| Reorder | <Badge text="Supported" variant="tip" /> |
+| Remove products from wishlist | <Badge text="Roadmap" variant="caution" /> |
+| View order status | <Badge text="Supported" variant="tip" /> |
+| View return status | <Badge text="Supported" variant="tip" /> |

--- a/src/content/docs/dropins/product-details/index.mdx
+++ b/src/content/docs/dropins/product-details/index.mdx
@@ -33,14 +33,14 @@ The following table provides an overview of the Adobe Commerce features that the
 
 | Feature                         | Status                                       |
 | ------------------------------- | -------------------------------------------- |
-| Bundle product type             | <Badge text="Supported" variant="success" /> |
-| Configurable product type       | <Badge text="Supported" variant="success" /> |
-| Image gallery                   | <Badge text="Supported" variant="success" /> |
-| Grouped products                | <Badge text="Roadmap" variant="note" />      |
-| Product details                 | <Badge text="Supported" variant="success" /> |
-| Simple product type             | <Badge text="Supported" variant="success" /> |
-| Virtual product type            | <Badge text="Roadmap" variant="note" />      |
-| Zoom                            | <Badge text="Supported" variant="success" /> |
+| Bundle product type             | <Badge text="Supported" variant="tip" /> |
+| Configurable product type       | <Badge text="Supported" variant="tip" /> |
+| Image gallery                   | <Badge text="Supported" variant="tip" /> |
+| Grouped products                | <Badge text="Roadmap" variant="caution" />      |
+| Product details                 | <Badge text="Supported" variant="tip" /> |
+| Simple product type             | <Badge text="Supported" variant="tip" /> |
+| Virtual product type            | <Badge text="Roadmap" variant="caution" />      |
+| Zoom                            | <Badge text="Supported" variant="tip" /> |
 
 ## Render product types
 

--- a/src/content/docs/dropins/user-account/index.mdx
+++ b/src/content/docs/dropins/user-account/index.mdx
@@ -16,18 +16,18 @@ The following tables provide an overview of the Adobe Commerce features that the
 
 | Feature                                | Status                                       |
 |----------------------------------------|----------------------------------------------|
-| Add/remove new address                 | <Badge text="Supported" variant="success" /> |
-| Cancel order (before it is processed)  | <Badge text="Supported" variant="success" /> |
-| Change email                           | <Badge text="Supported" variant="success" /> |
-| Change password                        | <Badge text="Supported" variant="success" /> |
-| Create a return                        | <Badge text="Supported" variant="success" /> |
-| Filter orders by time of purchase      | <Badge text="Supported" variant="success" /> |
-| Login as customer                      | <Badge text="Roadmap" variant="note" />      |
-| Manage products in wishlist            | <Badge text="Roadmap" variant="note" />      |
-| Re-order                               | <Badge text="Supported" variant="success" /> |
-| Search orders                          | <Badge text="Roadmap" variant="note" />      |
-| Update address                         | <Badge text="Supported" variant="success" /> |
-| View addresses saved during checkout   | <Badge text="Supported" variant="success" /> |
-| View list of orders on the account     | <Badge text="Supported" variant="success" /> |
-| View order status                      | <Badge text="Supported" variant="success" /> |
-| View return status                     | <Badge text="Supported" variant="success" /> |
+| Add/remove new address                 | <Badge text="Supported" variant="tip" /> |
+| Cancel order (before it is processed)  | <Badge text="Supported" variant="tip" /> |
+| Change email                           | <Badge text="Supported" variant="tip" /> |
+| Change password                        | <Badge text="Supported" variant="tip" /> |
+| Create a return                        | <Badge text="Supported" variant="tip" /> |
+| Filter orders by time of purchase      | <Badge text="Supported" variant="tip" /> |
+| Login as customer                      | <Badge text="Roadmap" variant="caution" />      |
+| Manage products in wishlist            | <Badge text="Roadmap" variant="caution" />      |
+| Re-order                               | <Badge text="Supported" variant="tip" /> |
+| Search orders                          | <Badge text="Roadmap" variant="caution" />      |
+| Update address                         | <Badge text="Supported" variant="tip" /> |
+| View addresses saved during checkout   | <Badge text="Supported" variant="tip" /> |
+| View list of orders on the account     | <Badge text="Supported" variant="tip" /> |
+| View order status                      | <Badge text="Supported" variant="tip" /> |
+| View return status                     | <Badge text="Supported" variant="tip" /> |

--- a/src/content/docs/dropins/user-auth/index.mdx
+++ b/src/content/docs/dropins/user-auth/index.mdx
@@ -16,9 +16,9 @@ The following table provides an overview of the Adobe Commerce features that the
 
 | Feature                                | Status                                       |
 | -------------------------------------- | -------------------------------------------- |
-| Account confirmation email             | <Badge text="Supported" variant="success" /> |
-| Custom customer attributes for sign up | <Badge text="Supported" variant="success" /> |
-| ReCAPTCHA protection for web forms     | <Badge text="Supported" variant="success" /> |
-| Retrieve password                      | <Badge text="Supported" variant="success" /> |
-| Sign in                                | <Badge text="Supported" variant="success" /> |
-| Sign up                                | <Badge text="Supported" variant="success" /> |
+| Account confirmation email             | <Badge text="Supported" variant="tip" /> |
+| Custom customer attributes for sign up | <Badge text="Supported" variant="tip" /> |
+| ReCAPTCHA protection for web forms     | <Badge text="Supported" variant="tip" /> |
+| Retrieve password                      | <Badge text="Supported" variant="tip" /> |
+| Sign in                                | <Badge text="Supported" variant="tip" /> |
+| Sign up                                | <Badge text="Supported" variant="tip" /> |

--- a/src/content/docs/setup/configuration/content-delivery-network.mdx
+++ b/src/content/docs/setup/configuration/content-delivery-network.mdx
@@ -3,11 +3,14 @@ title: Content delivery network (CDN)
 description: Learn how to configure a CDN for your Adobe Commerce on Edge Delivery Services storefront project.
 ---
 
+import Badge from '@components/overrides/Badge.astro';
 import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 import Task from '@components/Task.astro';
 import Tasks from '@components/Tasks.astro';
 
 Decide early which CDN to use. A popular option is Fastly, which is included with your Adobe Commerce license.
+
+<Badge tooltip="Applies to Adobe Commerce on Cloud projects (Adobe-managed PaaS infrastructure) and on-premises projects only." text="PaaS only" variant="note" href="https://experienceleague.adobe.com/en/docs/commerce/user-guides/product-solutions" />
 
 This page provides instructions and guidance for configuring Adobe Commerce with Fastly. It focuses on routing use cases, configuration, validation, and debugging.
 

--- a/src/content/docs/setup/configuration/storefront-compatibility/install.mdx
+++ b/src/content/docs/setup/configuration/storefront-compatibility/install.mdx
@@ -6,6 +6,7 @@ sidebar:
   order: 1
 ---
 
+import Badge from '@components/overrides/Badge.astro';
 import Tasks from '@components/Tasks.astro';
 import Task from '@components/Task.astro';
 import Callouts from '@components/Callouts.astro';
@@ -13,6 +14,8 @@ import Aside from '@components/Aside.astro';
 import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 
 The Storefront Compatibility Package contains changes to the Adobe Commerce codebase that enable drop-in component functionality. On [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview), it is installed and updated automatically.
+
+<Badge tooltip="Applies to Adobe Commerce on Cloud projects (Adobe-managed PaaS infrastructure) and on-premises projects only." text="PaaS only" variant="note" href="https://experienceleague.adobe.com/en/docs/commerce/user-guides/product-solutions" />
 
 ## Installation
 

--- a/src/content/docs/setup/discovery/luma-bridge.mdx
+++ b/src/content/docs/setup/discovery/luma-bridge.mdx
@@ -3,10 +3,13 @@ title: Luma Bridge
 description: Learn how to implement the Luma Bridge for your Adobe Commerce on Edge Delivery Services project.
 ---
 
+import Badge from '@components/overrides/Badge.astro';
 import { Icon } from '@astrojs/starlight/components';
 import OptionsTable from '@components/OptionsTable.astro';
 
 This section provides guidance on how to implement the Luma Bridge for your Adobe Commerce on Edge Delivery Services project.
+
+<Badge tooltip="Applies to Adobe Commerce on Cloud projects (Adobe-managed PaaS infrastructure) and on-premises projects only." text="PaaS only" variant="note" href="https://experienceleague.adobe.com/en/docs/commerce/user-guides/product-solutions" />
 
 Before starting an implementation, clarify the following:
 


### PR DESCRIPTION
This pull request adds an override for the default Badge component we use from the Starlight package. It adds the following  functionality to align with our badging strategy across the devsite and ExL:

- Links
- Tooltips

>[!NOTE]
>I didn't include support for metadata-based badges because I couldn't really figure out how without overcomplicating the implementation.

As part of this initial update, I've also re-assigned the Badge variants we've been using to indicate supported/roadmap Commerce features across drop-in components. The assumption here is that we should reserve the `default`/`note` and `success` variants for PaaS and SaaS (respectively). The blue and green are already used in other repos.

I'll submit additional PRs to the `CCSAAS-2095-storefront-badging` integration branch for ACO issues identified by @meker  in the comments of CCSAAS-2095.