### PR TITLE
flip steps 4 and 5

### DIFF
--- a/src/content/docs/get-started/index.mdx
+++ b/src/content/docs/get-started/index.mdx
@@ -43,8 +43,8 @@ The following diagram shows the steps you'll take to create and configure your s
 1. **Create Site Repo** by generating a storefront repository from the [boilerplate template](https://github.com/hlxsites/aem-boilerplate-commerce).
 1. **Link Repo to Content** using the `mountpoint` URL in the **`fstab.yaml`** in your GitHub repo. You can use [default-fstab.yaml](https://github.com/hlxsites/aem-boilerplate-commerce/blob/main/default-fstab.yaml) as a reference.
 1. **Add Code Sync App** to your newly created repo. This app automatically redeploys your storefront when you push changes to the main branch. It also provides the Edge Delivery system (Helix Admin) with access to your repo so it can coordinate code changes with content changes.
-1. **Add Content** to the Document Author environment hosted at `https://da.live/` using the [import tool](https://da.live/app/hlxsites/aem-boilerplate-commerce/tools/site-creator/site-creator). If you already have a site in Sharepoint or Google Drive, you can use the [site importer](https://da.live/docs/operations/import).
 1. **Link Repo to Data** using the values in the **`config.json`** in your GitHub repo.
+1. **Add Content** to the Document Author environment hosted at `https://da.live/` using the [import tool](https://da.live/app/hlxsites/aem-boilerplate-commerce/tools/site-creator/site-creator). If you already have a site in Sharepoint or Google Drive, you can use the [site importer](https://da.live/docs/operations/import).
 1. **Install Sidekick** and configure it to preview, publish, and edit content on your storefront.
 1. **Set up Local Environment** to enable the development of the boilerplate into your own storefront.
 
@@ -219,6 +219,14 @@ The Code Sync app redeploys your storefront site whenever you push or merge chan
 
 <Task>
 
+### Link repo to commerce data
+
+To link your storefront repo to your commerce, you can duplicate the [demo-config.json](https://github.com/hlxsites/aem-boilerplate-commerce/blob/main/demo-config.json) from your storefront repo and rename it to `config.json`. Use the `demo-config.json` file as a starting point for your site's configuration. Make sure to commit and push the `config.json` file to your repo.
+
+</Task>
+
+<Task>
+
 ### Add content
 
 Now let's create and initialize the content side of your storefront. We'll create a new folder and share it with Edge Delivery Services.
@@ -238,14 +246,6 @@ If you do not want demo content, you can create a file in https://da.live/#/{org
 <Diagram caption="Initialize your storefront content">
   ![Initialize your storefront content](images/initialize-content.webp)
 </Diagram>
-
-</Task>
-
-<Task>
-
-### Link repo to commerce data
-
-To link your storefront repo to your commerce, you can duplicate the [demo-config.json](https://github.com/hlxsites/aem-boilerplate-commerce/blob/main/demo-config.json) from your storefront repo and rename it to `config.json`. Use the `demo-config.json` file as a starting point for your site's configuration.
 
 </Task>
 


### PR DESCRIPTION
Step 4 output some links to the site. The site shows an error at that point, unless you have committed config.json (which is done in step 5).

This PR flips step 5 and step 4 to reduce confusion.