### PR TITLE
fix: page title spacing on mobile

### DIFF
--- a/src/components/overrides/PageTitle.astro
+++ b/src/components/overrides/PageTitle.astro
@@ -95,7 +95,7 @@ const { time } = Astro.locals.starlightRoute.entry.data;
       align-items: flex-start;
       font-size: 32px;
       word-break: keep-all;
-      gap: 0.75rem;
+      gap: 0rem;
     }
 
     .time-wrapper {

--- a/src/components/overrides/PageTitle.astro
+++ b/src/components/overrides/PageTitle.astro
@@ -89,12 +89,26 @@ const { time } = Astro.locals.starlightRoute.entry.data;
   @media (max-width: 530px) {
     .title {
       margin-top: 0;
-      margin-bottom: -2rem;
+      margin-bottom: 1rem;
       display: flex;
       flex-direction: column;
-      align-items: baseline;
+      align-items: flex-start;
       font-size: 32px;
       word-break: keep-all;
+      gap: 0.75rem;
+    }
+
+    .time-wrapper {
+      white-space: normal;
+      flex-wrap: wrap;
+      margin-top: 0;
+      gap: 0.5rem;
+    }
+
+    h1 {
+      padding-right: 0;
+      margin-bottom: 0;
+      line-height: 1.1;
     }
   }
 </style>


### PR DESCRIPTION
This pull request fixes a minor issue with page title on mobile devices.

## Issue

As you can see, there's not enough spacing between the heading and the time component. This isn't isolated to the time component though. It also appears on page titles without the time component.

![pagetitle-prod](https://github.com/user-attachments/assets/6308755e-afda-4b60-a4eb-015a8edecb9b)

## Fix

Based on local build using `pnpm build:prod && pnpm preview:prod`.

![pagetitle-fix](https://github.com/user-attachments/assets/28d092b6-58a0-46bc-a336-33e740cda9b8)
