### PR TITLE
docs: update Experimentation Plugin section

### DIFF
--- a/src/content/docs/merchants/get-started/experiments.mdx
+++ b/src/content/docs/merchants/get-started/experiments.mdx
@@ -38,9 +38,11 @@ The original version of the drop-in component that is used as a baseline for com
 
 The variant of the drop-in component being tested.
 
-### Experimentation plugin
+### Experimentation Plugin
 
-This plugin is included in the Commerce boilerplate ([hlxsites/aem-boilerplate-commerce](https://github.com/hlxsites/aem-boilerplate-commerce)) provides all the features for running A/B experiments on your storefront pages.
+The Experimentation Plugin is **not pre-installed** in the Commerce Boilerplate ([hlxsites/aem-boilerplate-commerce](https://github.com/hlxsites/aem-boilerplate-commerce)). Instead, developers can optionally install it based on their experimentation needs.
+
+To install and configure the plugin, follow the instructions in the [AEM Experimentation GitHub repository](https://github.com/adobe/aem-experimentation/).
 
 ### Placeholders file
 
@@ -58,7 +60,7 @@ Additionally, the plugin allows A/B experiments that can be run on mobile or des
 
 This plugin integrates seamlessly with the AEM boilerplate code, allowing experiments to be loaded early and with minimal impact.
 
-For detailed development information, see https://github.com/hlxsites/aem-boilerplate-commerce/blob/main/plugins/experimentation/README.md.
+For detailed development information, see https://github.com/adobe/aem-experimentation.
 
 ## Step-by-step
 


### PR DESCRIPTION
We are removing the pre-installed experiment plugin out of the box. Instead, merchants will need to install it when needed.

https://github.com/hlxsites/aem-boilerplate-commerce/pull/511