### PR TITLE
Add a redirect for /dropins/all/eventbus

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -106,6 +106,7 @@ async function config() {
       '/discovery/architecture': '/developer/commerce/storefront/setup/discovery/architecture',
       '/discovery/data-export-validation': '/developer/commerce/storefront/setup/discovery/data-export-validation',
       '/discovery/luma-bridge': '/developer/commerce/storefront/setup/discovery/luma-bridge',
+      '/dropins/all/eventbus': `${basePath}/sdk/reference/events`
     },
     integrations: [
       starlight({


### PR DESCRIPTION
This PR is adding a redirect for a stale page https://experienceleague.adobe.com/developer/commerce/storefront/dropins/all/eventbus/.
This is more flexible way for redirecting to allow use of base path as a variable instead of production-only hardcoded base path.
It was validated locally in development, gh-pages, and production modes.
Additionally, this is considered as a test for the redirects update at #311.