### PR TITLE
playground cleanup

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -846,7 +846,7 @@ async function config() {
                       link: '/playgrounds/commerce-services/'
                     },
                     {
-                      label: 'Commerce Optimizer Playground',
+                      label: 'Commerce Optimizer API Playground',
                       link: '/playgrounds/commerce-optimizer/'
                     },
                   ],

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -50,6 +50,6 @@ import Callouts from '@components/Callouts.astro';
     icon="laptop"
     title="Playgrounds"
     description="Get hands-on experience for developing Commerce Storefronts"
-    link="/playgrounds/commerce-services/"
+    link="/playgrounds/"
   />
 </CardGrid>

--- a/src/content/docs/playgrounds/commerce-optimizer.mdx
+++ b/src/content/docs/playgrounds/commerce-optimizer.mdx
@@ -1,5 +1,5 @@
 ---
-title: Commerce Optimizer Playground
+title: Commerce Optimizer API Playground
 description: Explore our Commerce APIs using predefined and custom queries.
 tableOfContents: false
 ---


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a navigation block to the Introduction page for the playgrounds, changes the link on the home page to the intro page of the Playgrounds section.

### Associated JIRA ticket

No ticket


### Staging preview

No preview


## Affected pages

https://experienceleague.adobe.com/developer/commerce/storefront/playgrounds/

## Links to source code

No links

