### PR TITLE
add security notice to docs

### DIFF
--- a/src/content/docs/get-started/index.mdx
+++ b/src/content/docs/get-started/index.mdx
@@ -23,6 +23,7 @@ import { Icon } from '@astrojs/starlight/components';
 import Link from '@components/Link.astro';
 import Vocabulary from '@components/Vocabulary.astro';
 import Embed from '@components/Embed.astro';
+import SecurityNotice from 'src/content/fragments/security-notice.mdx';
 
 Welcome to your Commerce Storefront journey. Our goal is to make the journey fun and informative. We start every topic with big-picture overviews and relevant vocabulary. We then walk you through the details step-by-step. And finally, we provide a sandbox for practice when possible. Let's get started.
 
@@ -49,6 +50,8 @@ The following diagram shows the steps you'll take to create and configure your s
 1. **Set up Local Environment** to enable the development of the boilerplate into your own storefront.
 
 </Callouts>
+
+<SecurityNotice />
 
 ## Vocabulary
 
@@ -304,6 +307,15 @@ Visit the [Sidekick documentation](https://www.aem.live/docs/sidekick) for more 
 1. Open the project in your favorite code editor. You're now ready to explore the boilerplate and start customizing your storefront!
 
 </Steps>
+
+</Task>
+
+<Task>
+
+### (Optional) Secure your storefront
+While your storefront is now functional, it's important to understand that **your site is not protected by default**. We recommend securing your content, repository, and site access before deploying to production or sharing with external users.
+
+<SecurityNotice />
 
 </Task>
 

--- a/src/content/fragments/security-notice.mdx
+++ b/src/content/fragments/security-notice.mdx
@@ -1,0 +1,11 @@
+import { Aside } from '@astrojs/starlight/components';
+
+<Aside type="caution" title="Your site is NOT protected by default.">
+
+ To secure your content and site:
+
+- **Content in DA**: Configure permissions at [https://da.live/docs/administration/permissions](https://da.live/docs/administration/permissions)
+- **EDS site authentication**: Follow guide at [https://www.aem.live/docs/authentication-setup-authoring](https://www.aem.live/docs/authentication-setup-authoring)
+- **Git repository**: Change your repository to private in GitHub settings
+
+</Aside>


### PR DESCRIPTION
Adds a notice about security/auth to your content and site as it was unclear that the site and content are fully public unless you specifically add auth.

![image](https://github.com/user-attachments/assets/8acc1acc-40c0-4893-9afb-a35182177d21)

![image](https://github.com/user-attachments/assets/ee81ff97-7f41-45e0-9ed3-3b125adfa1d2)
