### PR TITLE
Personalization: copy edits for initial draft (merchant)

### DIFF
--- a/src/content/docs/merchants/get-started/personalization.mdx
+++ b/src/content/docs/merchants/get-started/personalization.mdx
@@ -1,6 +1,6 @@
 ---
 title: Personalization
-description: Learn how to use Targeted block for displaying personalized content.
+description: Learn how to display personalized content using Targeted Blocks.
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
@@ -13,7 +13,7 @@ import Tasks from '@components/Tasks.astro';
 import Task from '@components/Task.astro';
 import OptionsTable from '@components/OptionsTable.astro';
 
-This topic describes how to use Targeted Blocks and use them to deliver personalized experiences.
+This topic describes how to use Targeted Blocks to deliver personalized experiences.
 
 ## Vocabulary
 
@@ -21,7 +21,7 @@ This topic describes how to use Targeted Blocks and use them to deliver personal
 
 ### Targeted Block
 
-A block that is wrapping the content targeted for specific customer groups, segments or cart rules.
+A block that wraps the content targeted for specific customer groups, segments, or cart rules.
 
 ### Group
 
@@ -37,45 +37,45 @@ A block that is wrapping the content targeted for specific customer groups, segm
 
 </Vocabulary>
 
-## About Targeted Block
+## About Targeted Blocks
 
-Targeted Blocks can be added to a Commerce storefront page and accept the following parameters:
+You can add Targeted Blocks to a Commerce storefront page. They accept the following parameters:
 
 <OptionsTable
   compact
   options={[
     ['Parameter', 'Description'],
-    ['Customer Groups', 'Comma-separated ids of customer groups the block can be displayed to'],
-    ['Customer Segments', 'Comma-separated ids of customer segments the block can be displayed to'],
-    ['Cart Rules', 'Comma-separated ids of cart rules the block can be displayed to'],
-    ['Fragment', 'The path to the fragment containing the content'],
-    ['Type', 'The type of the block is used for the fallback chain creation. Only the first block satisfying the conditions of each type will be displayed'],
+    ['Customer Groups', 'Comma-separated list of customer group IDs that determine which customers can view the block.'],
+    ['Customer Segments', 'Comma-separated list of customer segment IDs that determine which customers can view the block.'],
+    ['Cart Rules', 'Comma-separated list of cart rule IDs that determine which customers can view the block.'],
+    ['Fragment', 'The path to the fragment containing the content.'],
+    ['Type', 'The type of block to use for the fallback chain creation. Only the first block that satisfies the conditions of each type is displayed.'],
   ]}
 />
 
-If the fragment is not used for a targeted block, the last merged row of block configuration have to contain the content.
+If the fragment is not used for a Targeted Block, the last merged row of the block configuration must contain the content.
 
-## Targeted block for specific customer segments
+## Specific customer segments
 
-Specify the comma separated IDs of customer segments from Adobe Commerce to ensure the block is displayed only to customers matching these segments.
+Specify the comma-separated list of customer segment IDs from Adobe Commerce to ensure that the block displays for customers matching these segments only.
 
-The content of the targeted block in the following example will be displayed only to the customers of 1st and 2nd segments:
+The content of the Targeted Block in the following example will be displayed to the customers of the 1st and 2nd segments only:
 
 <Diagram caption="Targeted block for specific customer segments">![Targeted block for specific customer segments](@images/dropins/personalization/targeted-block.png)</Diagram>
 
-## Targeted block loading interactive content from a fragment
+## Load interactive content from a fragment
 
-Instead of wrapping the content to the Targeted Block, you can specify the path to the fragment. In this case the content of the document in the specified path will be loaded as the Targeted Block content.
+Instead of embedding content directly in the Targeted Block, you can specify a path to a fragment file. When you use a fragment, the system loads the content from the specified document path and displays it as the Targeted Block content.
 
-The content of the targeted block in the following example will be loaded from a documents following the path specified in the Fragment property:
+The content of the Targeted Block in the following example will be loaded from a document following the path specified in the Fragment property:
 
 <Diagram caption="Targeted block loading interactive content from a fragment">![Targeted block loading interactive content from a fragment](@images/dropins/personalization/targeted-block-fragment.png)</Diagram>
 
-## Targeted blocks fallback using block type
+## Fallback using block type
 
-When the type is specified for several targeted blocks on the page, only the first matching targeted block will be displayed to the customer. This is useful for configuring a targeted block with default content visible for everyone, that is replaced with specific blocks for specific groups or segments.
+When multiple Targeted Blocks on a page share the same type, only the first matching Targeted Block displays to the customer. This fallback behavior enables you to configure a Targeted Block with default content that is visible to everyone, which specific blocks for particular groups or segments can then replace.
 
-The first targeted block in this example is visible only to customers when the cart price rule with ID 5 applies to their shopping cart. The second targeted block does not have conditions, so it should be visible for everyone. However, as the "Type" of the second block is the same as the first block, the second block will not be displayed when the first block is displayed. The blocks of the same type are replacing each other:
+In this example, the first Targeted Block displays only to customers whose shopping cart meets the conditions of cart price rule ID 5. The second Targeted Block has no conditions and should display to all customers. However, because both blocks share the same "Type" value, the second block will not display when the first block is active. Blocks with the same type replace each other in the display hierarchy:
 
 <Diagram caption="Targeted blocks fallback using block type">![Targeted blocks fallback using block type](@images/dropins/personalization/targeted-block-type.png)</Diagram>
 

--- a/src/content/docs/merchants/get-started/personalization.mdx
+++ b/src/content/docs/merchants/get-started/personalization.mdx
@@ -61,15 +61,15 @@ Specify the comma-separated list of customer segment IDs from Adobe Commerce to 
 
 The content of the Targeted Block in the following example will be displayed to the customers of the 1st and 2nd segments only:
 
-<Diagram caption="Targeted block for specific customer segments">![Targeted block for specific customer segments](@images/dropins/personalization/targeted-block.png)</Diagram>
+<Diagram caption="Targeted Block for specific customer segments">![Targeted Block for specific customer segments](@images/dropins/personalization/targeted-block.png)</Diagram>
 
 ## Load interactive content from a fragment
 
-Instead of embedding content directly in the Targeted Block, you can specify a path to a fragment file. When you use a fragment, the system loads the content from the specified document path and displays it as the Targeted Block content.
+Instead of embedding content directly in the Targeted Block, you can specify a path to a fragment. When you use a fragment, the system loads the content from the specified document path and displays it as the Targeted Block content.
 
-The content of the Targeted Block in the following example will be loaded from a document following the path specified in the Fragment property:
+The content of the Targeted Block in the following example will be loaded from a document following the path specified in the fragment property:
 
-<Diagram caption="Targeted block loading interactive content from a fragment">![Targeted block loading interactive content from a fragment](@images/dropins/personalization/targeted-block-fragment.png)</Diagram>
+<Diagram caption="Targeted Block loading interactive content from a fragment">![Targeted Block loading interactive content from a fragment](@images/dropins/personalization/targeted-block-fragment.png)</Diagram>
 
 ## Fallback using block type
 
@@ -77,7 +77,7 @@ When multiple Targeted Blocks on a page share the same type, only the first matc
 
 In this example, the first Targeted Block displays only to customers whose shopping cart meets the conditions of cart price rule ID 5. The second Targeted Block has no conditions and should display to all customers. However, because both blocks share the same "Type" value, the second block will not display when the first block is active. Blocks with the same type replace each other in the display hierarchy:
 
-<Diagram caption="Targeted blocks fallback using block type">![Targeted blocks fallback using block type](@images/dropins/personalization/targeted-block-type.png)</Diagram>
+<Diagram caption="Targeted Block fallback using block type">![Targeted Block fallback using block type](@images/dropins/personalization/targeted-block-type.png)</Diagram>
 
 ## Next steps
 


### PR DESCRIPTION
This pull request refines the documentation for Targeted Blocks in the personalization guide to improve clarity, grammar, and consistency. The changes include updates to descriptions, terminology, and examples to ensure better readability and understanding for users.

Related to #330 

### Documentation Improvements:

* **Enhanced Descriptions and Terminology**:
  - Updated the description of Targeted Blocks to clarify their purpose and usage. For example, replaced "wrapping the content" with "wraps the content" for better readability.
  - Improved parameter descriptions in the options table to provide more precise and user-friendly explanations.

* **Section Title Refinements**:
  - Standardized section titles for better consistency, such as changing "Targeted block for specific customer segments" to "Specific customer segments" and "Targeted block loading interactive content from a fragment" to "Load interactive content from a fragment."

* **Example Clarifications**:
  - Reworded example explanations to make them more concise and easier to follow, such as specifying how fallback behavior works when multiple Targeted Blocks share the same type.