### PR TITLE
Add link to personalization on merchant home page

### DIFF
--- a/src/content/docs/merchants/get-started/index.mdx
+++ b/src/content/docs/merchants/get-started/index.mdx
@@ -49,4 +49,12 @@ Welcome to the Merchant Documentation! This section is designed to help you enri
     link="/merchants/get-started/product-recommendations/"
     rightIcon="right-arrow"
   />
+  <LinkCard
+    noborder
+    icon='document'
+    title="Personalization"
+    description="Learn how to set up personalization for your storefront."
+    link="/merchants/get-started/personalization/"
+    rightIcon="right-arrow"
+  />
 </CardGrid>


### PR DESCRIPTION
This pull request adds a new `LinkCard` component to the "Get Started" page of the merchant documentation. The new card provides a link to a guide on setting up personalization for storefronts.

Key change:

* [`src/content/docs/merchants/get-started/index.mdx`](diffhunk://#diff-c97c8ec0fc0160b0acaefffc2123ec5691ffcbdc7bb44b5d4dd411dbca27e68aR52-R59): Added a `LinkCard` for "Personalization," which includes an icon, title, description, and link to the personalization setup guide.