### PR TITLE
Documentation update for SCP-4.8.4 and SCP-4.7.6 releases

### DIFF
--- a/src/content/docs/releases/changelog.mdx
+++ b/src/content/docs/releases/changelog.mdx
@@ -234,15 +234,16 @@ import ChangelogEntry from '@components/changelog/ChangelogEntry.astro';
 
     <ChangelogEntry
       date="2025-06-25"
-      title="Storefront Compatibility Package v4.8.4"
+      title="Storefront Compatibility Package v4.8.4, v4.7.6"
       components={['Storefront Compatibility Package']}
     >
       The Storefront Compatibility Package has been updated to include the following changes:
 
-      - Introduced a new admin configuration to control cart merge behavior between guest and logged-in customers via GraphQL mutations.
-      - Added the OrderTotal.grand_total_excl_tax field to the GraphQL order response to retrieve the grand total excluding tax.
+      - Added the **Merge Cart Preference** field to the **Store** > **Sales** > **Checkout** > **Shopping Cart** configuration panel in the Admin. It controls cart merge behavior when a GraphQL mutation merges guest or logged-in customer carts. 
+      - Added the `OrderTotal.grand_total_excl_tax` field to the GraphQL order response to retrieve the grand total excluding tax.
       - Introduced a new error code REQUIRED_PARAMETER_MISSING to handle missing configurable product options during the add-to-cart process via GraphQL.
-      - Added a new REST endpoint /V1/customers/:customerId/token to facilitate the social login feature through App Builder.
+      - Added a new REST endpoint `POST /V1/customers/:customerId/token` to facilitate the social login feature through App Builder.
+      - (v4.7.6 only) Fixed an issue where plugins for `GiftCardAccountManagementInterface` methods were not working for webhooks.
 
     </ChangelogEntry>
 
@@ -291,21 +292,6 @@ import ChangelogEntry from '@components/changelog/ChangelogEntry.astro';
       - Added the `clearWishlist` mutation.
       - Added enhanced support gift options to the `cart`, `orders`, and `products` queries.
       - Miscellaneous bugfixes and enhancements.
-    </ChangelogEntry>
-
-    <ChangelogEntry
-       date="2025-06-25"
-       title="Storefront Compatibility Package v4.7.6"
-       components={['Storefront Compatibility Package']}
-    >
-       The Storefront Compatibility Package has been updated to include the following changes:
-
-       - Fixed issue where plugins for GiftCardAccountManagementInterface methods were not working for webhooks.
-       - Introduced a new admin configuration to control cart merge behavior between guest and logged-in customers via GraphQL mutations.
-       - Added the OrderTotal.grand_total_excl_tax field to the GraphQL order response to retrieve the grand total excluding tax.
-       - Introduced a new error code REQUIRED_PARAMETER_MISSING to handle missing configurable product options during the add-to-cart process via GraphQL.
-       - Added a new REST endpoint /V1/customers/:customerId/token to facilitate the social login feature through App Builder.
-
     </ChangelogEntry>
 
     <ChangelogEntry

--- a/src/content/docs/releases/changelog.mdx
+++ b/src/content/docs/releases/changelog.mdx
@@ -239,7 +239,7 @@ import ChangelogEntry from '@components/changelog/ChangelogEntry.astro';
     >
       The Storefront Compatibility Package has been updated to include the following changes:
 
-      - Introduced a new admin setting to control cart merge behavior between guest and logged-in customers via GraphQL APIs.
+      - Introduced a new admin configuration to control cart merge behavior between guest and logged-in customers via GraphQL mutations.
       - Added the OrderTotal.grand_total_excl_tax field to the GraphQL order response to retrieve the grand total excluding tax.
       - Introduced a new error code REQUIRED_PARAMETER_MISSING to handle missing configurable product options during the add-to-cart process via GraphQL.
       - Added a new REST endpoint /V1/customers/:customerId/token to facilitate the social login feature through App Builder.
@@ -301,7 +301,7 @@ import ChangelogEntry from '@components/changelog/ChangelogEntry.astro';
        The Storefront Compatibility Package has been updated to include the following changes:
 
        - Fixed issue where plugins for GiftCardAccountManagementInterface methods were not working for webhooks.
-       - Introduced a new admin setting to control cart merge behavior between guest and logged-in customers via GraphQL APIs.
+       - Introduced a new admin configuration to control cart merge behavior between guest and logged-in customers via GraphQL mutations.
        - Added the OrderTotal.grand_total_excl_tax field to the GraphQL order response to retrieve the grand total excluding tax.
        - Introduced a new error code REQUIRED_PARAMETER_MISSING to handle missing configurable product options during the add-to-cart process via GraphQL.
        - Added a new REST endpoint /V1/customers/:customerId/token to facilitate the social login feature through App Builder.

--- a/src/content/docs/releases/changelog.mdx
+++ b/src/content/docs/releases/changelog.mdx
@@ -233,6 +233,20 @@ import ChangelogEntry from '@components/changelog/ChangelogEntry.astro';
 ************************************/}
 
     <ChangelogEntry
+      date="2025-06-25"
+      title="Storefront Compatibility Package v4.8.4"
+      components={['Storefront Compatibility Package']}
+    >
+      The Storefront Compatibility Package has been updated to include the following changes:
+
+      - Introduced a new admin setting to control cart merge behavior between guest and logged-in customers via GraphQL APIs.
+      - Added the OrderTotal.grand_total_excl_tax field to the GraphQL order response to retrieve the grand total excluding tax.
+      - Introduced a new error code REQUIRED_PARAMETER_MISSING to handle missing configurable product options during the add-to-cart process via GraphQL.
+      - Added a new REST endpoint /V1/customers/:customerId/token to facilitate the social login feature through App Builder.
+
+    </ChangelogEntry>
+
+    <ChangelogEntry
       date="2025-05-29"
       title="Storefront Compatibility Package v4.8.3"
       components={['Storefront Compatibility Package']}
@@ -277,6 +291,21 @@ import ChangelogEntry from '@components/changelog/ChangelogEntry.astro';
       - Added the `clearWishlist` mutation.
       - Added enhanced support gift options to the `cart`, `orders`, and `products` queries.
       - Miscellaneous bugfixes and enhancements.
+    </ChangelogEntry>
+
+    <ChangelogEntry
+       date="2025-06-25"
+       title="Storefront Compatibility Package v4.7.6"
+       components={['Storefront Compatibility Package']}
+    >
+       The Storefront Compatibility Package has been updated to include the following changes:
+
+       - Fixed issue where plugins for GiftCardAccountManagementInterface methods were not working for webhooks.
+       - Introduced a new admin setting to control cart merge behavior between guest and logged-in customers via GraphQL APIs.
+       - Added the OrderTotal.grand_total_excl_tax field to the GraphQL order response to retrieve the grand total excluding tax.
+       - Introduced a new error code REQUIRED_PARAMETER_MISSING to handle missing configurable product options during the add-to-cart process via GraphQL.
+       - Added a new REST endpoint /V1/customers/:customerId/token to facilitate the social login feature through App Builder.
+
     </ChangelogEntry>
 
     <ChangelogEntry

--- a/src/content/docs/setup/configuration/storefront-compatibility/install.mdx
+++ b/src/content/docs/setup/configuration/storefront-compatibility/install.mdx
@@ -49,6 +49,8 @@ Use this method to install the Storefront Compatibility Package using the Cloud 
        composer require adobe-commerce/storefront-compatibility:4.8.4
        ```
 
+       To check the latest version of the Storefront Compatibility Package, go to the [changelog](/releases/changelog/).
+
     1. Update package dependencies.
 
        ```bash
@@ -85,6 +87,8 @@ Use this method to install the Storefront Compatibility Package for an on-premis
    ```bash
    composer require adobe-commerce/storefront-compatibility:4.8.4
    ```
+
+   To check the latest version of the Storefront Compatibility Package, go to the [changelog](/releases/changelog/).
 
 1. Upgrade Adobe Commerce:
 

--- a/src/content/docs/setup/configuration/storefront-compatibility/install.mdx
+++ b/src/content/docs/setup/configuration/storefront-compatibility/install.mdx
@@ -42,11 +42,11 @@ Use this method to install the Storefront Compatibility Package using the Cloud 
 
        For Adobe Commerce 2.4.7, run:
        ```bash
-       composer require adobe-commerce/storefront-compatibility:^4.7
+       composer require adobe-commerce/storefront-compatibility:4.7.6
        ```
        For Adobe Commerce 2.4.8, run:
        ```bash
-       composer require adobe-commerce/storefront-compatibility:^4.8
+       composer require adobe-commerce/storefront-compatibility:4.8.4
        ```
 
     1. Update package dependencies.
@@ -79,11 +79,11 @@ Use this method to install the Storefront Compatibility Package for an on-premis
 
    For Adobe Commerce 2.4.7, run:
    ```bash
-   composer require adobe-commerce/storefront-compatibility:^4.7
+   composer require adobe-commerce/storefront-compatibility:4.7.6
    ```
    For Adobe Commerce 2.4.8, run:
    ```bash
-   composer require adobe-commerce/storefront-compatibility:^4.8
+   composer require adobe-commerce/storefront-compatibility:4.8.4
    ```
 
 1. Upgrade Adobe Commerce:

--- a/src/content/docs/setup/configuration/storefront-compatibility/install.mdx
+++ b/src/content/docs/setup/configuration/storefront-compatibility/install.mdx
@@ -38,8 +38,15 @@ Use this method to install the Storefront Compatibility Package using the Cloud 
 
     1. Add the Storefront Compatibility module.
 
+       Use the appropriate package version based on your Adobe Commerce version:
+
+       For Adobe Commerce 2.4.7, run:
        ```bash
-       composer require adobe-commerce/storefront-compatibility
+       composer require adobe-commerce/storefront-compatibility:^4.7
+       ```
+       For Adobe Commerce 2.4.8, run:
+       ```bash
+       composer require adobe-commerce/storefront-compatibility:^4.8
        ```
 
     1. Update package dependencies.
@@ -68,8 +75,15 @@ Use this method to install the Storefront Compatibility Package for an on-premis
 
 1. Use Composer to add the package module to your project:
 
+   Use the appropriate package version based on your Adobe Commerce version:
+
+   For Adobe Commerce 2.4.7, run:
    ```bash
-   composer require adobe-commerce/storefront-compatibility
+   composer require adobe-commerce/storefront-compatibility:^4.7
+   ```
+   For Adobe Commerce 2.4.8, run:
+   ```bash
+   composer require adobe-commerce/storefront-compatibility:^4.8
    ```
 
 1. Upgrade Adobe Commerce:


### PR DESCRIPTION
This PR updates Storefront Compatibility Documentation after SCP 4.8.4 and 4.7.6 release