### PR TITLE
Documentation update for SCP-4.8.5 and SCP-4.7.8 releases

### DIFF
--- a/src/content/docs/releases/changelog.mdx
+++ b/src/content/docs/releases/changelog.mdx
@@ -233,6 +233,17 @@ import ChangelogEntry from '@components/changelog/ChangelogEntry.astro';
 ************************************/}
 
     <ChangelogEntry
+      date="2025-07-14"
+      title="Storefront Compatibility Package v4.8.5, v4.7.8"
+      components={['Storefront Compatibility Package']}
+    >
+      The Storefront Compatibility Package has been updated to include the following changes:
+
+      - Miscellaneous bug fixes and enhancements related to cart item and order queries.
+
+    </ChangelogEntry>
+
+    <ChangelogEntry
       date="2025-06-25"
       title="Storefront Compatibility Package v4.8.4, v4.7.6"
       components={['Storefront Compatibility Package']}
@@ -291,7 +302,17 @@ import ChangelogEntry from '@components/changelog/ChangelogEntry.astro';
 
       - Added the `clearWishlist` mutation.
       - Added enhanced support gift options to the `cart`, `orders`, and `products` queries.
-      - Miscellaneous bugfixes and enhancements.
+      - Miscellaneous bug fixes and enhancements.
+    </ChangelogEntry>
+
+    <ChangelogEntry
+      date="2025-07-03"
+      title="Storefront Compatibility Package v4.7.7"
+      components={['Storefront Compatibility Package']}
+    >
+      The Storefront Compatibility Package has been updated to include the following changes:
+
+      - Miscellaneous bug fixes and enhancements.
     </ChangelogEntry>
 
     <ChangelogEntry

--- a/src/content/docs/releases/index.mdx
+++ b/src/content/docs/releases/index.mdx
@@ -54,8 +54,8 @@ This section provides details about the compatibility between Commerce Storefron
 
 | Adobe Commerce | Storefront Compatibility Package |
 |----------------|----------------------------------|
-| `2.4.7`        | `4.7.5`                          |
-| `2.4.8`        | `4.8.3`                          |
+| `2.4.7`        | `4.7.8`                          |
+| `2.4.8`        | `4.8.5`                          |
 
 **Drop-in SDK:**
 

--- a/src/content/docs/setup/configuration/storefront-compatibility/install.mdx
+++ b/src/content/docs/setup/configuration/storefront-compatibility/install.mdx
@@ -42,11 +42,11 @@ Use this method to install the Storefront Compatibility Package using the Cloud 
 
        For Adobe Commerce 2.4.7, run:
        ```bash
-       composer require adobe-commerce/storefront-compatibility:4.7.6
+       composer require adobe-commerce/storefront-compatibility:4.7.8
        ```
        For Adobe Commerce 2.4.8, run:
        ```bash
-       composer require adobe-commerce/storefront-compatibility:4.8.4
+       composer require adobe-commerce/storefront-compatibility:4.8.5
        ```
 
        To check the latest version of the Storefront Compatibility Package, go to the [changelog](/releases/changelog/).
@@ -81,11 +81,11 @@ Use this method to install the Storefront Compatibility Package for an on-premis
 
    For Adobe Commerce 2.4.7, run:
    ```bash
-   composer require adobe-commerce/storefront-compatibility:4.7.6
+   composer require adobe-commerce/storefront-compatibility:4.7.8
    ```
    For Adobe Commerce 2.4.8, run:
    ```bash
-   composer require adobe-commerce/storefront-compatibility:4.8.4
+   composer require adobe-commerce/storefront-compatibility:4.8.5
    ```
 
    To check the latest version of the Storefront Compatibility Package, go to the [changelog](/releases/changelog/).


### PR DESCRIPTION
This PR updates Storefront Compatibility Documentation after SCP 4.8.5 and 4.7.8 release