### PR TITLE
CDN edits

### DIFF
--- a/src/content/docs/setup/configuration/content-delivery-network.mdx
+++ b/src/content/docs/setup/configuration/content-delivery-network.mdx
@@ -11,7 +11,7 @@ import Tasks from '@components/Tasks.astro';
 
 A CDN is a critical component of your Commerce Storefront. It is responsible for delivering content to your customers in the most efficient and secure way possible.
 
-CDN features, usage, and provider details vary depending on your backend commerce implementation. By default, Adobe Commerce on Cloud projects use Fastly, while Adobe Commerce as a Cloud Service and Adobe Commerce Optimizer projects use an Adobe-managed CDN service.
+CDN features, usage, and provider details vary depending on your backend commerce implementation. By default, Adobe Commerce on Cloud projects use Fastly, while Adobe Commerce as a Cloud Service projects use an Adobe-managed CDN service.
 
 If necessary, you can configure your own CDN, also known as "Bring Your Own CDN" (BYO CDN). See [BYO CDN Setup](https://www.aem.live/docs/byo-cdn-setup) for required settings and vendor-specific setup instructions.
 

--- a/src/content/docs/setup/configuration/content-delivery-network.mdx
+++ b/src/content/docs/setup/configuration/content-delivery-network.mdx
@@ -11,7 +11,7 @@ import Tasks from '@components/Tasks.astro';
 
 A CDN is a critical component of your Commerce Storefront. It is responsible for delivering content to your customers in the most efficient and secure way possible.
 
-CDN features, usage, and provider details vary depending on your backend commerce implementation. By default, Adobe Commerce on Cloud projects use Fastly, while Adobe Commerce as a Cloud Service and Adobe Commerce Optimizer projects use a fully managed CDN service through [Adobe Experience Manager](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/implementing/content-delivery/cdn).
+CDN features, usage, and provider details vary depending on your backend commerce implementation. By default, Adobe Commerce on Cloud projects use Fastly, while Adobe Commerce as a Cloud Service and Adobe Commerce Optimizer projects use an Adobe-managed CDN service.
 
 If necessary, you can configure your own CDN, also known as "Bring Your Own CDN" (BYO CDN). See [BYO CDN Setup](https://www.aem.live/docs/byo-cdn-setup) for required settings and vendor-specific setup instructions.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes the link to AEM docs since they don't apply to commerce storefronts by default. They only apply if customers purchase a license for AEM Sites. It also removes the reference to ACO, since ACO doesn't have a CDN.