### PR TITLE
fix: add redirect for old localizing topic

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -110,7 +110,8 @@ async function config() {
       '/discovery/luma-bridge': `${basePath}/setup/discovery/luma-bridge`,
       '/dropins/all/eventbus': `${basePath}/sdk/reference/events`,
       '/dropins/other/recommendations': `${basePath}/dropins/recommendations`,
-      '/dropins/other/search': `${basePath}/dropins/product-discovery`
+      '/dropins/other/search': `${basePath}/dropins/product-discovery`,
+      '/dropins/all/localizing': `${basePath}/dropins/all/labeling`
     },
     integrations: [
       starlight({


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a redirect from the old localizing topic to the new label.


## Affected pages
From: https://experienceleague.adobe.com/developer/commerce/storefront/dropins/all/localizing/
To: https://experienceleague.adobe.com/developer/commerce/storefront/dropins/all/labeling/