### PR TITLE
remove beta badge

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -676,7 +676,6 @@ async function config() {
             },
             {
               label: 'Drop-in SDK',
-              badge: 'Beta',
               icon: 'puzzle',
               link: '/sdk/',
               items: [


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes the beta label from the Drop-ins SDK section of the docs.

## Affected pages

<img width="590" height="410" alt="CleanShot 2025-07-17 at 17 10 22@2x" src="https://github.com/user-attachments/assets/d6693a4d-d82d-40ea-89dc-5f0bdad5502b" />