### PR TITLE
Add config of undo banner feature in CartSummaryList and CartSummaryTable containers

### DIFF
--- a/src/content/docs/dropins/cart/containers/cart-summary-list.mdx
+++ b/src/content/docs/dropins/cart/containers/cart-summary-list.mdx
@@ -51,6 +51,7 @@ The `CartSummaryList` container provides the following configuration options:
     ['showSavings', 'boolean', 'No', 'Toggle show savings.'],
     ['quantityType', 'stepper' | 'dropdown', 'No', 'Display quantity changes as a stepper or in a dropdown menu.'],
     ['dropdownOptions', 'string[]', 'No', 'An array of items to display in a dropdown menu.'],
+    ['undo', 'boolean', 'No', 'Enables the undo banner to restore recently removed items to the cart.']
   ]}
 />
 

--- a/src/content/docs/dropins/cart/containers/cart-summary-table.mdx
+++ b/src/content/docs/dropins/cart/containers/cart-summary-table.mdx
@@ -44,7 +44,8 @@ The `CartSummaryTable` container provides the following configuration options:
     ['allowQuantityUpdates', 'boolean', 'No', 'Whether to allow quantity updates. Defaults to true.'],
     ['allowRemoveItems', 'boolean', 'No', 'Whether to allow removing items. Defaults to true.'],
     ['onQuantityUpdate', 'function', 'No', 'Callback function when quantity is updated.'],
-    ['onItemRemove', 'function', 'No', 'Callback function when an item is removed.']
+    ['onItemRemove', 'function', 'No', 'Callback function when an item is removed.'],
+    ['undo', 'boolean', 'No', 'Enables the undo banner to restore recently removed items to the cart.']
   ]}
 />
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) added descriptions for the 'undo' configuration option, which enables the undo banner for restoring removed items.

### Associated JIRA ticket

https://jira.corp.adobe.com/browse/USF-2374

## Affected pages

https://experienceleague.adobe.com/developer/commerce/storefront/dropins/cart/containers/cart-summary-list/

https://experienceleague.adobe.com/developer/commerce/storefront/dropins/cart/containers/cart-summary-table/

## Links to source code

https://github.com/hlxsites/aem-boilerplate-commerce/pull/629

