### PR TITLE
USF-2530: Update Wishlist documentation after latest updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@dropins/storefront-payment-services": "~1.0.1",
     "@dropins/storefront-pdp": "1.2.1",
     "@dropins/storefront-recommendations": "^1.0.0",
-    "@dropins/storefront-wishlist": "^1.0.0",
+    "@dropins/storefront-wishlist": "^2.0.0-beta1",
     "@dropins/storefront-personalization": "~1.0.0",
     "@dropins/storefront-product-discovery": "^1.0.1",
     "@dropins/tools": "^1.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,8 +54,8 @@ importers:
         specifier: ^1.0.0
         version: 1.0.0
       '@dropins/storefront-wishlist':
-        specifier: ^1.0.0
-        version: 1.0.1
+        specifier: ^2.0.0-beta1
+        version: 2.0.0-beta1
       '@dropins/tools':
         specifier: ^1.3.0
         version: 1.3.0
@@ -390,8 +390,8 @@ packages:
   '@dropins/storefront-recommendations@1.0.0':
     resolution: {integrity: sha512-4gcKqO8yDQrE759AO5/nZi69WKca6hLjBbIQD88dSinCM+RR7wj22+r+WRLDyoylYy5M1QsohugsHJXLA+68Dw==}
 
-  '@dropins/storefront-wishlist@1.0.1':
-    resolution: {integrity: sha512-0ERGAhQqm9dZBak3nQknHwmRgkZmoJe9gwO5BV9DAM4Iupitrnm07HqgKl/hT6axDzYReb3UyE2bbzc/D85WBA==}
+  '@dropins/storefront-wishlist@2.0.0-beta1':
+    resolution: {integrity: sha512-YuYvmdkX3rW/Uxe267ZT0FWPTCZOFJ70rYlPeC5TEJEeJm7jg2D4UBMzU428dXu4jqc1Kr2ABgBnEGsGGiJ5Qw==}
 
   '@dropins/tools@0.17.0':
     resolution: {integrity: sha512-tQgD3Me61+db6Dhyh8Xr9t20V43p4BSnmp6zz0AIM71L54ZpBDcVUlYM01E4g/ViscKcwHSYlQFKZj/4ZrYTdg==}
@@ -4794,7 +4794,7 @@ snapshots:
 
   '@dropins/storefront-recommendations@1.0.0': {}
 
-  '@dropins/storefront-wishlist@1.0.1': {}
+  '@dropins/storefront-wishlist@2.0.0-beta1': {}
 
   '@dropins/tools@0.17.0': {}
 

--- a/src/content/docs/dropins/wishlist/containers/wishlist-alert.mdx
+++ b/src/content/docs/dropins/wishlist/containers/wishlist-alert.mdx
@@ -20,7 +20,7 @@ The `WishlistAlert` container provides the following configuration options:
 compact
     options={[
         ['Options', 'Type', 'Req?', 'Description'],
-        ['action', 'string', 'Yes', 'Specifies the action to notify the user about. Valid values are "add", "remove", or "move".'],
+        ['action', 'string', 'Yes', 'Specifies the action to notify the user about. Valid values are: "add", "remove", "move", "addError" and "removeError.'],
         ['item', 'object', 'Yes', 'The wishlist item where the action is performed.'],
         ['routeToWishlist', 'string', 'No', 'Specifies the URL to show when the wishlist has products.'],
     ]}
@@ -32,8 +32,8 @@ The following example demonstrates how to render the `WishlistAlert` container:
 
 ```javascript
 provider.render(Wishlist, {
-    action: 'add', // or 'remove', 'move'
-    item: {product: {name: 'Sample Product'}},
+    action: 'add', // or 'remove', 'move', 'addError', 'removeError'
+    item: { product: { name: 'Sample Product' } },
     routeToWishlist: '/wishlist',
   });
 ```

--- a/src/content/docs/dropins/wishlist/containers/wishlist-item.mdx
+++ b/src/content/docs/dropins/wishlist/containers/wishlist-item.mdx
@@ -8,7 +8,7 @@ import OptionsTable from '@components/OptionsTable.astro';
 
 The `WishlistItem` container manages and displays a single product from a wishlist. It allows users to interact with the product, such as moving it to the cart or navigating to the product details page.
 
-For complex products that have no variant selected in the wishlist, the "Move To Cart" button becomes a "Customize" button, where the system prompts users to select a variant first by navigating to the product details page.
+For complex products that have no variant selected in the wishlist, the **Move To Cart** button becomes a **Customize** button. Users must select a variant first by navigating to the product details page.
 Its behavior is driven by configuration options such as `moveProdToCart`, `getProductData`, `getRefinedProduct` and routing via `routeProdDetailPage` callbacks.
 
 <Diagram caption="WishlistItem container">

--- a/src/content/docs/dropins/wishlist/containers/wishlist-item.mdx
+++ b/src/content/docs/dropins/wishlist/containers/wishlist-item.mdx
@@ -8,8 +8,8 @@ import OptionsTable from '@components/OptionsTable.astro';
 
 The `WishlistItem` container manages and displays a single product from a wishlist. It allows users to interact with the product, such as moving it to the cart or navigating to the product details page.
 
-For complex products that have no variant selected in the wishlist, the "move to cart" button becomes disabled. The system prompts users to select a variant first by navigating to the product details page.
-Its behavior is driven by configuration options such as `routeEmptyWishlistCTA`, `routeEmptyWishlistCTA` and routing via `routeProdDetailPage` callbacks.
+For complex products that have no variant selected in the wishlist, the "Move To Cart" button becomes a "Customize" button, where the system prompts users to select a variant first by navigating to the product details page.
+Its behavior is driven by configuration options such as `moveProdToCart`, `getProductData`, `getRefinedProduct` and routing via `routeProdDetailPage` callbacks.
 
 <Diagram caption="WishlistItem container">
   ![Wishlist container](@images/dropins/wish-list/wishlist-item.png)
@@ -23,9 +23,11 @@ The `WishlistItem` container provides the following configuration options:
 compact
     options={[
         ['Options', 'Type', 'Req?', 'Description'],
-        ['initialData', 'Item', 'Yes', 'The wishlisted item.'],
+        ['item', 'Item', 'Yes', 'The wishlisted item.'],
         ['moveProdToCart', 'function', 'Yes', 'A function that is executed when the user clicks the "move product to cart" button.'],
         ['routeProdDetailPage', 'function', 'Yes', 'A function that returns the URL for the product details page.'],
+        ['getProductData', 'function', 'No', 'A function that is executed to retrieve product information when rendering the wishlist item.'],
+        ['getRefinedProduct', 'function', 'No', 'A function that is executed to retrieve complex product information (such as product options) when rendering the wishlist item.']
     ]}
 />
 
@@ -35,8 +37,10 @@ The following example demonstrates how to render the `WishlistItem` container:
 
 ```javascript
 provider.render(WishlistItem, {
-    initialData: sampleWishlistItem,
+    item: sampleWishlistItem,
     moveProdToCart: cartApi.addProductsToCart,
     routeProdDetailPage: (product) => rootLink(`/products/${product.urlKey}/${product.sku}`),
+    getProductData: pdpApi.getProductData,
+    getRefinedProduct: pdpApi.getRefinedProduct
   });
 ```

--- a/src/content/docs/dropins/wishlist/containers/wishlist-toggle.mdx
+++ b/src/content/docs/dropins/wishlist/containers/wishlist-toggle.mdx
@@ -23,7 +23,7 @@ compact
         ['Options', 'Type', 'Req?', 'Description'],
         ['product', 'object', 'Yes', 'The product object to add to or remove from a wishlist.'],
         ['iconWishlisted', 'VNode', 'No', 'The icon to show when the product is already in the wishlist.'],
-        ['iconNotWishlisted', 'VNode', 'No', 'The icon to show when the product is not in the wishlist.'],
+        ['iconToWishlist', 'VNode', 'No', 'The icon to show when the product is not in the wishlist.'],
         ['size', 'string', 'No', 'The size of the button, "medium" or "large".'],
         ['variant', 'string', 'No', 'The variant of the button from "primary", "secondary" or "tertiary".'],
         ['disabled', 'boolean', 'No', 'If true, the button is disabled.'],
@@ -41,7 +41,7 @@ The following example demonstrates how to render the `Wishlist` container:
 provider.render(WishlistToggle, {
     product: sampleProduct,
     iconWishlisted: <Icon name="heart" />,
-    iconNotWishlisted: <Icon name="heart-outline" />,
+    iconToWishlist: <Icon name="heart-outline" />,
     size: 'medium',
     variant: 'primary',
     labelToWishlist: 'Add to Wishlist',

--- a/src/content/docs/dropins/wishlist/containers/wishlist.mdx
+++ b/src/content/docs/dropins/wishlist/containers/wishlist.mdx
@@ -26,7 +26,7 @@ compact
         ['moveProdToCart', 'function', 'Yes', 'A function that is executed when the user clicks the "move product to cart" button.'],
         ['routeProdDetailPage', 'function', 'Yes', 'A function that returns the URL for the product details page.'],
         ['getProductData', 'function', 'No', 'A function that is executed to retrieve product information when rendering the wishlist.'],
-        ['getRefinedProduct', 'function', 'No', 'A function that is executed to retrieve configurable product information (such as product options) when rendering the wishlist.'],
+        ['getRefinedProduct', 'function', 'No', 'A function that is executed to retrieve complex product information (such as product options) when rendering the wishlist.'],
     ]}
 />
 

--- a/src/content/docs/dropins/wishlist/containers/wishlist.mdx
+++ b/src/content/docs/dropins/wishlist/containers/wishlist.mdx
@@ -7,7 +7,7 @@ import Diagram from '@components/Diagram.astro';
 import OptionsTable from '@components/OptionsTable.astro';
 
 This container manages and displays the list of products on a user's wishlist.
-Configuration options such as `routeEmptyWishlistCTA`, `routeEmptyWishlistCTA` and routing via `routeProdDetailPage` callbacks drive the container's behavior.
+Configuration options such as `moveProdToCart`, `getProductData` and `getRefinedProduct`,  and routing via `routeEmptyWishlistCTA`, `routeProdDetailPage` and `routeToWishlist` callbacks drive the container's behavior.
 
 <Diagram caption="Wishlist container">
   ![Wishlist container](@images/dropins/wish-list/wishlist.png)
@@ -25,6 +25,8 @@ compact
         ['routeToWishlist', 'string', 'No', 'Specifies the URL to show when the wishlist has products.'],
         ['moveProdToCart', 'function', 'Yes', 'A function that is executed when the user clicks the "move product to cart" button.'],
         ['routeProdDetailPage', 'function', 'Yes', 'A function that returns the URL for the product details page.'],
+        ['getProductData', 'function', 'No', 'A function that is executed to retrieve product information when rendering the wishlist.'],
+        ['getRefinedProduct', 'function', 'No', 'A function that is executed to retrieve configurable product information (such as product options) when rendering the wishlist.'],
     ]}
 />
 
@@ -36,5 +38,7 @@ The following example demonstrates how to render the `Wishlist` container:
 provider.render(Wishlist, {
     moveProdToCart: cartApi.addProductsToCart,
     routeProdDetailPage: (product) => rootLink(`/products/${product.urlKey}/${product.sku}`),
+    getProductData: pdpApi.getProductData,
+    getRefinedProduct: pdpApi.getRefinedProduct,
   });
 ```

--- a/src/content/docs/dropins/wishlist/containers/wishlist.mdx
+++ b/src/content/docs/dropins/wishlist/containers/wishlist.mdx
@@ -7,7 +7,7 @@ import Diagram from '@components/Diagram.astro';
 import OptionsTable from '@components/OptionsTable.astro';
 
 This container manages and displays the list of products on a user's wishlist.
-Configuration options such as `moveProdToCart`, `getProductData` and `getRefinedProduct`,  and routing via `routeEmptyWishlistCTA`, `routeProdDetailPage` and `routeToWishlist` callbacks drive the container's behavior.
+A container's behavior is controlled by configuration options like `moveProdToCart`, `getProductData`, and `refineProduct`, and routing via `routeEmptyWishlistCTA`, `routeProdDetailPage`, and `routeToWishlist`.
 
 <Diagram caption="Wishlist container">
   ![Wishlist container](@images/dropins/wish-list/wishlist.png)

--- a/src/content/docs/dropins/wishlist/functions.mdx
+++ b/src/content/docs/dropins/wishlist/functions.mdx
@@ -18,18 +18,6 @@ import { addProductsToWishlist } from '@/wishlist/api/addProductToWishlist';
 addProductsToWishlist([{ sku: 'sku_item_1', quantity: 1 }]);
 ```
 
-## getProductBySku
-
-The `getProductBySku` function retrieves product details based on the provided SKU.
-
-### Example function usage
-
-```typescript
-import { getProductBySku } from '@/wishlist/api/addProductToWishlist';
-
-getProductBySku('sku_item_1');
-```
-
 ## getStoreConfig
 
 The `getStoreConfig` function retrieves the store configuration, which includes various settings and preferences for the store.

--- a/src/content/docs/dropins/wishlist/installation.mdx
+++ b/src/content/docs/dropins/wishlist/installation.mdx
@@ -39,7 +39,7 @@ The following steps show how to install the wishlist component into your site.
                             <title>Your Storefront</title>
 
                             <script src="https://cdn.jsdelivr.net/npm/@dropins/tools@latest"></script>
-                            <script src="https://cdn.jsdelivr.net/npm/@dropins/storefront-wishlistp@latest"></script>
+                            <script src="https://cdn.jsdelivr.net/npm/@dropins/storefront-wishlist@latest"></script>
                 </head>
                 ```
 
@@ -66,7 +66,7 @@ The following steps show how to install the wishlist component into your site.
                     {
                         "imports": {
                         "@dropins/tools/": "/node_modules/@dropins/tools/",
-                        "@dropins/storefront-wishlistp/": "/node_modules/@dropins/storefront-wishlist/",
+                        "@dropins/storefront-wishlist/": "/node_modules/@dropins/storefront-wishlist/",
                     }
                     }
                 </script>
@@ -233,4 +233,4 @@ The following steps show how to install the wishlist component into your site.
 
 ## Summary
 
-The installation of all drop-in components follows the same pattern demonstrated by installing the PDP drop-in: Install, Map, Import, Connect, Register, and Render. 
+The installation of all drop-in components follows the same pattern demonstrated by installing the PDP drop-in: Install, Map, Import, Connect, Register, and Render.

--- a/src/content/docs/dropins/wishlist/installation.mdx
+++ b/src/content/docs/dropins/wishlist/installation.mdx
@@ -221,6 +221,8 @@ The following steps show how to install the wishlist component into your site.
                 moveProdToCart: cartApi.addProductsToCart,
                 routeProdDetailPage: (product) => rootLink(`/products/${product.urlKey}/${product.sku}`),
                 onLoginClick: showAuthModal,
+                getProductData: pdpApi.getProductData,
+                getRefinedProduct: pdpApi.getRefinedProduct,
             })(block);
         }
         ```


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates wishlist documentation after the latest releases:
https://github.com/adobe-commerce/storefront-wishlist/releases/tag/v2.0.0-beta1
https://github.com/adobe-commerce/storefront-wishlist/releases/tag/v2.0.0-alpha1

### Associated JIRA ticket

https://jira.corp.adobe.com/browse/USF-2530 Update Wishlist documentation after latest updates

### Staging preview
The most recent updates has been delivered to `integration` branch on `aem-boilerplate-commerce`.
 
https://integration--aem-boilerplate-commerce--hlxsites.aem.live/


## Affected pages

- Wishlist Alert
- Wishlist Item
- Wishlist Toggle
- Wishlist
- Functions
- Installation

## Links to source code

- USF-2476: Dropins support enhanced Wishlist by @loginesta in https://github.com/adobe-commerce/storefront-wishlist/pull/51
- Fixed story for custom image slots by @svera in https://github.com/adobe-commerce/storefront-wishlist/pull/52
- [INTERNAL] Clean up + Correct SAAS environment by @loginesta in https://github.com/adobe-commerce/storefront-wishlist/pull/53
- Removed getProductBySku by @svera in https://github.com/adobe-commerce/storefront-wishlist/pull/54
- Validate GraphQL operations by @sivaschenko in https://github.com/adobe-commerce/storefront-wishlist/pull/36

