### PR TITLE
hotfix: clarify usage of environment parameter

### DIFF
--- a/src/content/docs/setup/analytics/instrumentation.mdx
+++ b/src/content/docs/setup/analytics/instrumentation.mdx
@@ -18,7 +18,7 @@ Instrumentation is the process of adding code to your storefront to collect data
 User interaction events collected through instrumentation enable:
 
 - **Adobe Sensei features**: Intelligent merchandising and search result optimization in Live Search
-- **Product recommendations**: Personalized product suggestions based on user behavior  
+- **Product recommendations**: Personalized product suggestions based on user behavior
 - **Performance analytics**: Detailed dashboards showing search performance, conversion rates, and user engagement
 - **Business intelligence**: Data-driven insights for inventory management and marketing strategies
 
@@ -64,7 +64,7 @@ To enable proper event collection, you need to configure your store's analytics 
  ...
   "analytics": {
     "base-currency-code": "USD",
-    "environment": "Production",
+    "environment": "Testing",
     "store-id": 1,
     "store-name": "Main Website Store",
     "store-url": "https://adobe-commerce.example.com",
@@ -81,7 +81,7 @@ To enable proper event collection, you need to configure your store's analytics 
 | Parameter | Description | Example | Required |
 |-----------|-------------|---------|----------|
 | `base-currency-code` | Default currency for your store | `"USD"`, `"EUR"` | Yes |
-| `environment` | Current environment | `"Production"`, `"Testing"` | Yes |
+| `environment` | Current environment type | `"Testing"`, `"Production"` | Yes |
 | `store-id` | Unique identifier for your store | `1`, `2` | Yes |
 | `store-name` | Human-readable store name | `"Main Website Store"` | Yes |
 | `store-url` | Your store's primary URL | `"https://example.com"` | Yes |
@@ -89,6 +89,10 @@ To enable proper event collection, you need to configure your store's analytics 
 | `store-view-name` | Human-readable store view name | `"Default Store View"` | Yes |
 | `website-id` | Unique identifier for website | `1`, `2` | Yes |
 | `website-name` | Human-readable website name | `"Main Website"` | Yes |
+
+<Aside type="note" title="environment">
+The `environment` parameter is used to determine the type of environment your store is running in. This is important because it affects how data is collected and processed. Be sure to set this to `"Testing"` when you are developing your storefront, and `"Production"` when you are ready to deploy your storefront.
+</Aside>
 
 ### Data Services Configuration
 
@@ -108,7 +112,7 @@ The Commerce boilerplate includes the [Storefront Events Collector](https://gith
 
 <Steps>
 1. **Listens for ACDL events**: Monitors the data layer for new events
-1. **Validates event structure**: Ensures events conform to required schemas  
+1. **Validates event structure**: Ensures events conform to required schemas
 1. **Batches and sends data**: Efficiently transmits events to Adobe Commerce
 1. **Handles errors**: Manages network issues and retry logic
 </Steps>
@@ -156,7 +160,7 @@ For optimal performance, Adobe recommends writing events directly to ACDL rather
 1. **Check for ACDL**: Verify `window.adobeDataLayer` exists and contains events
 1. **Monitor network requests**: Look for successful data transmission to Adobe services
 1. **Validate event data**: Inspect event payloads for completeness and accuracy
-1. **Confirm that event data is collected**: To confirm that data is being collected from your Commerce store, use the Adobe Experience Platform debugger to examine your Commerce site. 
+1. **Confirm that event data is collected**: To confirm that data is being collected from your Commerce store, use the Adobe Experience Platform debugger to examine your Commerce site.
 </Steps>
 
 <Aside type="note" title="Debugging events">
@@ -166,14 +170,14 @@ The AEP Debugger provides an Events view that you can use to examine the events 
 ### Common Validation Issues
 
 - **Missing configuration**: Ensure all required analytics parameters are set
-- **Incorrect store IDs**: Verify store and website IDs match your Adobe Commerce setup  
+- **Incorrect store IDs**: Verify store and website IDs match your Adobe Commerce setup
 - **Network connectivity**: Check that your storefront can reach Adobe Commerce endpoints
 - **Event timing**: Confirm events fire at the correct moments in the user journey
 
 ## Troubleshooting Configuration Issues
 
 **Problem**: Events not being sent<br />
-**Solution**: 
+**Solution**:
 <Steps>
 1. Verify your `config.json` contains all required analytics parameters
 1. Check that store IDs match your Adobe Commerce backend configuration

--- a/src/content/docs/setup/launch/index.mdx
+++ b/src/content/docs/setup/launch/index.mdx
@@ -96,6 +96,7 @@ Avoid scheduling a launch shortly before a weekend. The Adobe engineering team m
       events](https://github.com/adobe/commerce-events/tree/main/examples/events/snowplow-debugger)
       implementation and ensure that data is displayed in your Live Search and Product
       Recommendation dashboards in the Adobe Commerce Admin.
+* [ ] Ensure that the `environment` analytics config parameter is set appropriately in the `config.json` file. It should be set to `"Testing"` when you are developing your storefront, and `"Production"` when you are ready to deploy your storefront. See the [Instrumentation](/setup/analytics/instrumentation) documentation for more information.
 * [ ] Ensure that the site's Lighthouse score is green; targeting `100` on every page (taking into
       account previous considerations mentioned on this document).
 </Checklist>

--- a/src/content/docs/setup/launch/index.mdx
+++ b/src/content/docs/setup/launch/index.mdx
@@ -96,7 +96,7 @@ Avoid scheduling a launch shortly before a weekend. The Adobe engineering team m
       events](https://github.com/adobe/commerce-events/tree/main/examples/events/snowplow-debugger)
       implementation and ensure that data is displayed in your Live Search and Product
       Recommendation dashboards in the Adobe Commerce Admin.
-* [ ] Ensure that the `environment` analytics config parameter is set appropriately in the `config.json` file. It should be set to `"Testing"` when you are developing your storefront, and `"Production"` when you are ready to deploy your storefront. See the [Instrumentation](/setup/analytics/instrumentation) documentation for more information.
+* [ ] Ensure that the `environment` analytics config parameter is set appropriately in your [Commerce configuration](/setup/configuration/commerce-configuration). It should be set to `"Testing"` when you are developing your storefront, and `"Production"` when you are ready to deploy your storefront. See the [Instrumentation](/setup/analytics/instrumentation) documentation for more information.
 * [ ] Ensure that the site's Lighthouse score is green; targeting `100` on every page (taking into
       account previous considerations mentioned on this document).
 </Checklist>


### PR DESCRIPTION
https://magento.slack.com/archives/C03J16UAEHZ/p1754578311614489

The `environment` parameter is not being used correctly. Partially due to default config generation, and partially due to user error.

Let's improve the docs to make sure it is clear.