### PR TITLE
remove erroneous tips

### DIFF
--- a/src/content/docs/dropins/cart/styles.mdx
+++ b/src/content/docs/dropins/cart/styles.mdx
@@ -15,17 +15,6 @@ import Callouts from '@components/Callouts.astro';
 
 The CSS classes for each UI component that provides the cart drop-in component with its UI are provided here. Override these classes and add new classes to customize the look and feel of your cart to match your specific style requirements.
 
-:::tip[Boilerplate CSS Tip!]
-The cart contains several components that provide its UI. If you plan to make several CSS changes to the drop-in component, we suggest creating CSS files for each drop-in component (in the `cart` directory) and importing those into the `cart.css` file as shown below. This practice makes it easier to maintain and update your CSS in the future.
-
-```css title="cart.css"
-@import 'cart.css';
-@import 'empty-cart.css';
-@import 'mini-cart.css';
-```
-
-:::
-
 ## Customizing your cart styles
 
 The quickest way to override the cart CSS is to inspect the cart UI from your browser's developer tools.

--- a/src/content/docs/dropins/checkout/styles.mdx
+++ b/src/content/docs/dropins/checkout/styles.mdx
@@ -23,26 +23,6 @@ import { Steps } from '@astrojs/starlight/components';
 
 This topic introduces you to the CSS classes for each UI component used in the checkout drop-in component and shows you how to override these classes to customize the component's CSS styling to match your brand.
 
-:::tip[Boilerplate CSS Tip!]
-Checkout contains several components that provide its UI. If you plan to make several CSS changes to the component, we suggest creating CSS files for each drop-in component (in the `blocks/commerce-checkout/` directory) and importing those into the `commerce-checkout.css` file as shown below. This practice makes it easier to maintain and update your CSS in the future.
-
-```css title="commerce-checkout.css"
-@import 'bill-to-shipping-address.css';
-@import 'estimate-shipping.css';
-@import 'heading.css';
-@import 'login-form.css';
-@import 'merged-cart-banner.css';
-@import 'order-confirmation-header.css';
-@import 'out-of-stock.css';
-@import 'overlay-loader.css';
-@import 'payment-methods.css';
-@import 'place-order.css';
-@import 'server-error.css';
-@import 'shipping-methods.css';
-```
-
-:::
-
 ## Big Picture
 
 The quickest way to override checkout CSS is to inspect the checkout UI from your browser's developer tools to discover the BEM class names you want to add to or override. This process is numbered in the image below.

--- a/src/content/docs/dropins/order/styles.mdx
+++ b/src/content/docs/dropins/order/styles.mdx
@@ -27,17 +27,6 @@ import shippingStatusCard from './files/shipping-status-card.css?raw';
 
 The CSS classes for each UI component that provides the order drop-in component with its UI are provided here. Override these classes and add new classes to customize the look and feel of your cart to match your specific style requirements.
 
-:::tip[Boilerplate CSS Tip!]
-The drop-in component contains multiple components that provide its UI. If you plan to make several CSS changes to the drop-in, we suggest creating CSS files for each drop-in component and importing those into a custom `order.css` file as shown below. This practice makes it easier to maintain and update your CSS in the future.
-
-```css title="order.css"
-@import 'commerce-order-returns.css';
-@import 'commerce-order-status.css';
-@import 'commerce-returns-list.css';
-```
-
-:::
-
 [Styling drop-in components](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/styling/) describes how to inspect the drop-in component in your browser's developer tools to discover the BEM class names to be extended.
 
 ## Example CSS overrides

--- a/src/content/docs/dropins/product-details/styles.mdx
+++ b/src/content/docs/dropins/product-details/styles.mdx
@@ -19,21 +19,6 @@ import Callouts from '@components/Callouts.astro';
 
 The CSS classes for each UI component that provides the product details page (PDP) drop-in component with its UI are provided here. Override these classes and add new classes to customize the look and feel of your PDP drop-in component to match your specific style requirements.
 
-:::tip[Boilerplate CSS Tip!]
-Product details (like most other drop-in components) contains several components that provide its UI. If you plan to make several CSS changes to the drop-in component, we suggest creating CSS files for each drop-in component (in the `product-details` directory) and importing those into the `product-details.css` file as shown below. This practice makes it easier to maintain and update your CSS in the future.
-
-```css title="product-details.css"
-@import 'carousel.css';
-@import 'gallery-grid.css';
-@import 'overlay.css';
-@import 'price-range.css';
-@import 'product.css';
-@import 'swatches.css';
-@import 'zoom.css';
-```
-
-:::
-
 ## Customizing your PDP styles
 
 The quickest way to override Product details CSS is to inspect the PDP UI from your browser's developer tools.

--- a/src/content/docs/dropins/product-discovery/styles.mdx
+++ b/src/content/docs/dropins/product-discovery/styles.mdx
@@ -17,16 +17,6 @@ import searchBarResults from './files/search-bar-results.css?raw';
 
 The CSS classes for each UI component that provides the product discovery drop-in component with its UI are provided here. Override these classes and add new classes to customize the look and feel of your product discovery components to match your specific style requirements.
 
-:::tip[Boilerplate CSS Tip!]
-The drop-in component contains multiple components that provide its UI. If you plan to make several CSS changes to the drop-in, we suggest creating CSS files for each drop-in component and importing those into a custom `product-discovery.css` file as shown below. This practice makes it easier to maintain and update your CSS in the future.
-
-```css title="product-discovery.css"
-@import 'search-bar-results.css';
-@import 'product-list.css';
-@import 'facet-list.css';
-```
-:::
-
 [Styling drop-in components](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/styling/) describes how to inspect the drop-in component in your browser's developer tools to discover the BEM class names to be extended.
 
 

--- a/src/content/docs/dropins/recommendations/styles.mdx
+++ b/src/content/docs/dropins/recommendations/styles.mdx
@@ -10,18 +10,6 @@ import Callouts from '@components/Callouts.astro';
 
 The CSS classes for each UI component that provides the recommendations drop-in component with its UI are provided here. Override these classes and add new classes to customize the look and feel of your recommendations to match your specific style requirements.
 
-:::tip[Boilerplate CSS Tip!]
-
-The recommendations drop-in component contains several components that provide its UI. If you plan to make several CSS changes to the drop-in component, we suggest creating CSS files for each drop-in component (in the `recommendations` directory) and importing those into the `recommendations.css` file as shown below. This practice makes it easier to maintain and update your CSS in the future.
-
-
-```css title="recommendations.css"
-@import 'recommendations.css';
-
-```
-
-:::
-
 ## Customizing your recommendations styles
 
 The quickest way to override the recommendations CSS is to inspect the recommendation UI from your browser's developer tools.

--- a/src/content/docs/dropins/user-account/styles.mdx
+++ b/src/content/docs/dropins/user-account/styles.mdx
@@ -25,27 +25,6 @@ import { Steps } from '@astrojs/starlight/components';
 
 This topic introduces you to the CSS classes for each UI component used in the user account drop-in component and shows you how to override these classes to customize the user account component's CSS styling to match your brand.
 
-:::tip[Boilerplate CSS Tip!]
-User account contains multiple components that provide its UI. If you plan to make several CSS changes, Adobe suggests creating CSS files for each drop-in component (in the `blocks/commerce-account/` directory) and importing those into the `commerce-account.css` file as shown below. This practice makes it easier to maintain and update your CSS in the future.
-
-```css title="commerce-account.css"
-@import 'account-loaders.css';
-@import 'address-actions.css';
-@import 'address-card.css';
-@import 'address-form-wrapper.css';
-@import 'address-modal.css';
-@import 'change-password.css';
-@import 'customer-information-card.css';
-@import 'edit-cuatomer-information.css';
-@import 'empty-list.css';
-@import 'form.css';
-@import 'orders-list-action.css';
-@import 'orders-list-card.css';
-@import 'orders-list-wrapper.css';
-```
-
-:::
-
 ## Big Picture
 
 The quickest way to override user account CSS is to inspect the user account UI from your browser's developer tools to discover the BEM class names you want to add to or override. This process is numbered in the image below.

--- a/src/content/docs/dropins/wishlist/styles.mdx
+++ b/src/content/docs/dropins/wishlist/styles.mdx
@@ -14,19 +14,6 @@ import Callouts from '@components/Callouts.astro';
 
 The CSS classes for each UI component that provides the wishlist drop-in component with its UI are provided here. Override these classes and add new classes to customize the look and feel of your wishlist drop-in component to match your specific style requirements.
 
-:::tip[Boilerplate CSS Tip!]
-Wishlist (like most other drop-in components) contains several components that provide its UI. If you plan to make several CSS changes to the drop-in component, we suggest creating CSS files for each drop-in component (in the `wishlist` directory) and importing those into the `wishlist.css` file as shown below. This practice makes it easier to maintain and update your CSS in the future.
-
-```css title="wishlist.css"
-@import 'files/EmptyWishlist.css';
-@import 'files/ImageCarousel.css';
-@import 'files/Login.css';
-@import 'files/ProductItem.css';
-@import 'files/Wishlist.css';
-```
-
-:::
-
 ## Customizing your Wishlist styles
 
 The quickest way to override wishlist CSS is to inspect the wishlist UI from your browser's developer tools.


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes all the Boilerplate CSS styling tips from multiple drop-ins.

### Associated JIRA ticket

None. Slack message from @fnhipster.

### Staging preview

https://commerce-docs.github.io/microsite-commerce-storefront/

## Affected pages

All drop-in styles pages. Example:
https://experienceleague.adobe.com/developer/commerce/storefront/dropins/product-details/styles/
