### PR TITLE
COMOPT-617-update-storefront-config

### DIFF
--- a/ec.config.mjs
+++ b/ec.config.mjs
@@ -1,0 +1,7 @@
+import { pluginCollapsibleSections } from '@expressive-code/plugin-collapsible-sections'
+import { pluginLineNumbers } from '@expressive-code/plugin-line-numbers'
+
+/** @type {import('@astrojs/starlight/expressive-code').StarlightExpressiveCodeOptions} */
+export default {
+    plugins: [pluginCollapsibleSections(), pluginLineNumbers()],
+}

--- a/package.json
+++ b/package.json
@@ -33,11 +33,13 @@
     "@dropins/storefront-order": "~1.3.0-beta3",
     "@dropins/storefront-payment-services": "~1.0.1",
     "@dropins/storefront-pdp": "1.3.0-beta1",
-    "@dropins/storefront-recommendations": "^1.1.0-beta1",
-    "@dropins/storefront-wishlist": "^2.0.0-beta1",
     "@dropins/storefront-personalization": "~1.0.1-beta1",
     "@dropins/storefront-product-discovery": "^1.1.0-beta2",
+    "@dropins/storefront-recommendations": "^1.1.0-beta1",
+    "@dropins/storefront-wishlist": "^2.0.0-beta1",
     "@dropins/tools": "^1.4.0-beta4",
+    "@expressive-code/plugin-collapsible-sections": "^0.41.3",
+    "@expressive-code/plugin-line-numbers": "^0.41.3",
     "@graphiql/plugin-explorer": "3.2.5",
     "@graphiql/react": "0.28.2",
     "@graphiql/toolkit": "0.11.1",
@@ -50,6 +52,7 @@
     "@typescript-eslint/eslint-plugin": "^8.29.1",
     "@typescript-eslint/parser": "^8.29.1",
     "astro": "^5.8.1",
+    "astro-expressive-code": "^0.41.3",
     "cache": "^3.0.0",
     "dedent": "^1.5.3",
     "dotenv": "^17.2.1",
@@ -97,6 +100,9 @@
   },
   "engines": {
     "node": "^20.13.1"
+  },
+  "overrides": {
+    "astro-expressive-code": "latest"
   },
   "engine-strict": true,
   "private": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,12 @@ importers:
       '@dropins/tools':
         specifier: ^1.4.0-beta4
         version: 1.4.0
+      '@expressive-code/plugin-collapsible-sections':
+        specifier: ^0.41.3
+        version: 0.41.3
+      '@expressive-code/plugin-line-numbers':
+        specifier: ^0.41.3
+        version: 0.41.3
       '@graphiql/plugin-explorer':
         specifier: 3.2.5
         version: 3.2.5(@graphiql/react@0.28.2(@codemirror/language@6.0.0)(@types/node@24.2.1)(@types/react-dom@19.1.7(@types/react@19.1.9))(@types/react@19.1.9)(graphql@16.11.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(graphql@16.11.0)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -95,6 +101,9 @@ importers:
       astro:
         specifier: ^5.8.1
         version: 5.12.9(@types/node@24.2.1)(lightningcss@1.30.1)(rollup@4.46.2)(terser@5.42.0)(typescript@5.8.3)(yaml@2.8.1)
+      astro-expressive-code:
+        specifier: ^0.41.3
+        version: 0.41.3(astro@5.12.9(@types/node@24.2.1)(lightningcss@1.30.1)(rollup@4.46.2)(terser@5.42.0)(typescript@5.8.3)(yaml@2.8.1))
       cache:
         specifier: ^3.0.0
         version: 3.0.0
@@ -180,8 +189,8 @@ importers:
 
 packages:
 
-  '@adobe/css-tools@4.4.3':
-    resolution: {integrity: sha512-VQKMkwriZbaOgVCby1UDY/LDk5fIjhQicCvVPFqfe+69fWaPWydbWJ3wRt59/YzIwda1I81loas3oCoHxnqvdA==}
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -429,158 +438,158 @@ packages:
   '@emotion/memoize@0.7.4':
     resolution: {integrity: sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==}
 
-  '@esbuild/aix-ppc64@0.25.8':
-    resolution: {integrity: sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==}
+  '@esbuild/aix-ppc64@0.25.9':
+    resolution: {integrity: sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.25.8':
-    resolution: {integrity: sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w==}
+  '@esbuild/android-arm64@0.25.9':
+    resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.25.8':
-    resolution: {integrity: sha512-RONsAvGCz5oWyePVnLdZY/HHwA++nxYWIX1atInlaW6SEkwq6XkP3+cb825EUcRs5Vss/lGh/2YxAb5xqc07Uw==}
+  '@esbuild/android-arm@0.25.9':
+    resolution: {integrity: sha512-5WNI1DaMtxQ7t7B6xa572XMXpHAaI/9Hnhk8lcxF4zVN4xstUgTlvuGDorBguKEnZO70qwEcLpfifMLoxiPqHQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.25.8':
-    resolution: {integrity: sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA==}
+  '@esbuild/android-x64@0.25.9':
+    resolution: {integrity: sha512-I853iMZ1hWZdNllhVZKm34f4wErd4lMyeV7BLzEExGEIZYsOzqDWDf+y082izYUE8gtJnYHdeDpN/6tUdwvfiw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.25.8':
-    resolution: {integrity: sha512-Jw0mxgIaYX6R8ODrdkLLPwBqHTtYHJSmzzd+QeytSugzQ0Vg4c5rDky5VgkoowbZQahCbsv1rT1KW72MPIkevw==}
+  '@esbuild/darwin-arm64@0.25.9':
+    resolution: {integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.25.8':
-    resolution: {integrity: sha512-Vh2gLxxHnuoQ+GjPNvDSDRpoBCUzY4Pu0kBqMBDlK4fuWbKgGtmDIeEC081xi26PPjn+1tct+Bh8FjyLlw1Zlg==}
+  '@esbuild/darwin-x64@0.25.9':
+    resolution: {integrity: sha512-jhHfBzjYTA1IQu8VyrjCX4ApJDnH+ez+IYVEoJHeqJm9VhG9Dh2BYaJritkYK3vMaXrf7Ogr/0MQ8/MeIefsPQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.25.8':
-    resolution: {integrity: sha512-YPJ7hDQ9DnNe5vxOm6jaie9QsTwcKedPvizTVlqWG9GBSq+BuyWEDazlGaDTC5NGU4QJd666V0yqCBL2oWKPfA==}
+  '@esbuild/freebsd-arm64@0.25.9':
+    resolution: {integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.25.8':
-    resolution: {integrity: sha512-MmaEXxQRdXNFsRN/KcIimLnSJrk2r5H8v+WVafRWz5xdSVmWLoITZQXcgehI2ZE6gioE6HirAEToM/RvFBeuhw==}
+  '@esbuild/freebsd-x64@0.25.9':
+    resolution: {integrity: sha512-mrKX6H/vOyo5v71YfXWJxLVxgy1kyt1MQaD8wZJgJfG4gq4DpQGpgTB74e5yBeQdyMTbgxp0YtNj7NuHN0PoZg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.25.8':
-    resolution: {integrity: sha512-WIgg00ARWv/uYLU7lsuDK00d/hHSfES5BzdWAdAig1ioV5kaFNrtK8EqGcUBJhYqotlUByUKz5Qo6u8tt7iD/w==}
+  '@esbuild/linux-arm64@0.25.9':
+    resolution: {integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.25.8':
-    resolution: {integrity: sha512-FuzEP9BixzZohl1kLf76KEVOsxtIBFwCaLupVuk4eFVnOZfU+Wsn+x5Ryam7nILV2pkq2TqQM9EZPsOBuMC+kg==}
+  '@esbuild/linux-arm@0.25.9':
+    resolution: {integrity: sha512-HBU2Xv78SMgaydBmdor38lg8YDnFKSARg1Q6AT0/y2ezUAKiZvc211RDFHlEZRFNRVhcMamiToo7bDx3VEOYQw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.8':
-    resolution: {integrity: sha512-A1D9YzRX1i+1AJZuFFUMP1E9fMaYY+GnSQil9Tlw05utlE86EKTUA7RjwHDkEitmLYiFsRd9HwKBPEftNdBfjg==}
+  '@esbuild/linux-ia32@0.25.9':
+    resolution: {integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.25.8':
-    resolution: {integrity: sha512-O7k1J/dwHkY1RMVvglFHl1HzutGEFFZ3kNiDMSOyUrB7WcoHGf96Sh+64nTRT26l3GMbCW01Ekh/ThKM5iI7hQ==}
+  '@esbuild/linux-loong64@0.25.9':
+    resolution: {integrity: sha512-Sbe10Bnn0oUAB2AalYztvGcK+o6YFFA/9829PhOCUS9vkJElXGdphz0A3DbMdP8gmKkqPmPcMJmJOrI3VYB1JQ==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.8':
-    resolution: {integrity: sha512-uv+dqfRazte3BzfMp8PAQXmdGHQt2oC/y2ovwpTteqrMx2lwaksiFZ/bdkXJC19ttTvNXBuWH53zy/aTj1FgGw==}
+  '@esbuild/linux-mips64el@0.25.9':
+    resolution: {integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.25.8':
-    resolution: {integrity: sha512-GyG0KcMi1GBavP5JgAkkstMGyMholMDybAf8wF5A70CALlDM2p/f7YFE7H92eDeH/VBtFJA5MT4nRPDGg4JuzQ==}
+  '@esbuild/linux-ppc64@0.25.9':
+    resolution: {integrity: sha512-++0HQvasdo20JytyDpFvQtNrEsAgNG2CY1CLMwGXfFTKGBGQT3bOeLSYE2l1fYdvML5KUuwn9Z8L1EWe2tzs1w==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.8':
-    resolution: {integrity: sha512-rAqDYFv3yzMrq7GIcen3XP7TUEG/4LK86LUPMIz6RT8A6pRIDn0sDcvjudVZBiiTcZCY9y2SgYX2lgK3AF+1eg==}
+  '@esbuild/linux-riscv64@0.25.9':
+    resolution: {integrity: sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.25.8':
-    resolution: {integrity: sha512-Xutvh6VjlbcHpsIIbwY8GVRbwoviWT19tFhgdA7DlenLGC/mbc3lBoVb7jxj9Z+eyGqvcnSyIltYUrkKzWqSvg==}
+  '@esbuild/linux-s390x@0.25.9':
+    resolution: {integrity: sha512-Mfiphvp3MjC/lctb+7D287Xw1DGzqJPb/J2aHHcHxflUo+8tmN/6d4k6I2yFR7BVo5/g7x2Monq4+Yew0EHRIA==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.8':
-    resolution: {integrity: sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ==}
+  '@esbuild/linux-x64@0.25.9':
+    resolution: {integrity: sha512-iSwByxzRe48YVkmpbgoxVzn76BXjlYFXC7NvLYq+b+kDjyyk30J0JY47DIn8z1MO3K0oSl9fZoRmZPQI4Hklzg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.8':
-    resolution: {integrity: sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw==}
+  '@esbuild/netbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.25.8':
-    resolution: {integrity: sha512-nVDCkrvx2ua+XQNyfrujIG38+YGyuy2Ru9kKVNyh5jAys6n+l44tTtToqHjino2My8VAY6Lw9H7RI73XFi66Cg==}
+  '@esbuild/netbsd-x64@0.25.9':
+    resolution: {integrity: sha512-RLLdkflmqRG8KanPGOU7Rpg829ZHu8nFy5Pqdi9U01VYtG9Y0zOG6Vr2z4/S+/3zIyOxiK6cCeYNWOFR9QP87g==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.8':
-    resolution: {integrity: sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ==}
+  '@esbuild/openbsd-arm64@0.25.9':
+    resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.25.8':
-    resolution: {integrity: sha512-1h8MUAwa0VhNCDp6Af0HToI2TJFAn1uqT9Al6DJVzdIBAd21m/G0Yfc77KDM3uF3T/YaOgQq3qTJHPbTOInaIQ==}
+  '@esbuild/openbsd-x64@0.25.9':
+    resolution: {integrity: sha512-1MkgTCuvMGWuqVtAvkpkXFmtL8XhWy+j4jaSO2wxfJtilVCi0ZE37b8uOdMItIHz4I6z1bWWtEX4CJwcKYLcuA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.25.8':
-    resolution: {integrity: sha512-r2nVa5SIK9tSWd0kJd9HCffnDHKchTGikb//9c7HX+r+wHYCpQrSgxhlY6KWV1nFo1l4KFbsMlHk+L6fekLsUg==}
+  '@esbuild/openharmony-arm64@0.25.9':
+    resolution: {integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.25.8':
-    resolution: {integrity: sha512-zUlaP2S12YhQ2UzUfcCuMDHQFJyKABkAjvO5YSndMiIkMimPmxA+BYSBikWgsRpvyxuRnow4nS5NPnf9fpv41w==}
+  '@esbuild/sunos-x64@0.25.9':
+    resolution: {integrity: sha512-WjH4s6hzo00nNezhp3wFIAfmGZ8U7KtrJNlFMRKxiI9mxEK1scOMAaa9i4crUtu+tBr+0IN6JCuAcSBJZfnphw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.25.8':
-    resolution: {integrity: sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ==}
+  '@esbuild/win32-arm64@0.25.9':
+    resolution: {integrity: sha512-mGFrVJHmZiRqmP8xFOc6b84/7xa5y5YvR1x8djzXpJBSv/UsNK6aqec+6JDjConTgvvQefdGhFDAs2DLAds6gQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.8':
-    resolution: {integrity: sha512-hiGgGC6KZ5LZz58OL/+qVVoZiuZlUYlYHNAmczOm7bs2oE1XriPFi5ZHHrS8ACpV5EjySrnoCKmcbQMN+ojnHg==}
+  '@esbuild/win32-ia32@0.25.9':
+    resolution: {integrity: sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.25.8':
-    resolution: {integrity: sha512-cn3Yr7+OaaZq1c+2pe+8yxC8E144SReCQjN6/2ynubzYjvyqZjTXfQJpAcQpsdJq3My7XADANiYGHoFC69pLQw==}
+  '@esbuild/win32-x64@0.25.9':
+    resolution: {integrity: sha512-PPOl1mi6lpLNQxnGoyAfschAodRFYXJ+9fs6WHXz7CSWKbOqiMZsubC+BQsVKuul+3vKLuwTHsS2c2y9EoKwxQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -626,8 +635,14 @@ packages:
   '@expressive-code/core@0.41.3':
     resolution: {integrity: sha512-9qzohqU7O0+JwMEEgQhnBPOw5DtsQRBXhW++5fvEywsuX44vCGGof1SL5OvPElvNgaWZ4pFZAFSlkNOkGyLwSQ==}
 
+  '@expressive-code/plugin-collapsible-sections@0.41.3':
+    resolution: {integrity: sha512-cuHIN7Ipl7gUcaWFfsgy6G3wn0Svk8dQ6WKXNQha63BURbm7CSBhD6y9qFGeIOrxaJtvH4Pj3Xb4C2Ni0OVwYA==}
+
   '@expressive-code/plugin-frames@0.41.3':
     resolution: {integrity: sha512-rFQtmf/3N2CK3Cq/uERweMTYZnBu+CwxBdHuOftEmfA9iBE7gTVvwpbh82P9ZxkPLvc40UMhYt7uNuAZexycRQ==}
+
+  '@expressive-code/plugin-line-numbers@0.41.3':
+    resolution: {integrity: sha512-eig82a4CRC3XgVPQ2S/TMDcLiHJokOCD/mAdNVImpD3segVewxfjGgtj5DXQRo0E0q6f0R0EH34YzTFl5CEPqg==}
 
   '@expressive-code/plugin-shiki@0.41.3':
     resolution: {integrity: sha512-RlTARoopzhFJIOVHLGvuXJ8DCEme/hjV+ZnRJBIxzxsKVpGPW4Oshqg9xGhWTYdHstTsxO663s0cdBLzZj9TQA==}
@@ -2282,8 +2297,8 @@ packages:
     peerDependencies:
       esbuild: '>=0.12 <1'
 
-  esbuild@0.25.8:
-    resolution: {integrity: sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==}
+  esbuild@0.25.9:
+    resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4450,7 +4465,7 @@ packages:
 
 snapshots:
 
-  '@adobe/css-tools@4.4.3': {}
+  '@adobe/css-tools@4.4.4': {}
 
   '@ampproject/remapping@2.3.0':
     dependencies:
@@ -4847,82 +4862,82 @@ snapshots:
   '@emotion/memoize@0.7.4':
     optional: true
 
-  '@esbuild/aix-ppc64@0.25.8':
+  '@esbuild/aix-ppc64@0.25.9':
     optional: true
 
-  '@esbuild/android-arm64@0.25.8':
+  '@esbuild/android-arm64@0.25.9':
     optional: true
 
-  '@esbuild/android-arm@0.25.8':
+  '@esbuild/android-arm@0.25.9':
     optional: true
 
-  '@esbuild/android-x64@0.25.8':
+  '@esbuild/android-x64@0.25.9':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.8':
+  '@esbuild/darwin-arm64@0.25.9':
     optional: true
 
-  '@esbuild/darwin-x64@0.25.8':
+  '@esbuild/darwin-x64@0.25.9':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.8':
+  '@esbuild/freebsd-arm64@0.25.9':
     optional: true
 
-  '@esbuild/freebsd-x64@0.25.8':
+  '@esbuild/freebsd-x64@0.25.9':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.8':
+  '@esbuild/linux-arm64@0.25.9':
     optional: true
 
-  '@esbuild/linux-arm@0.25.8':
+  '@esbuild/linux-arm@0.25.9':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.8':
+  '@esbuild/linux-ia32@0.25.9':
     optional: true
 
-  '@esbuild/linux-loong64@0.25.8':
+  '@esbuild/linux-loong64@0.25.9':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.8':
+  '@esbuild/linux-mips64el@0.25.9':
     optional: true
 
-  '@esbuild/linux-ppc64@0.25.8':
+  '@esbuild/linux-ppc64@0.25.9':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.8':
+  '@esbuild/linux-riscv64@0.25.9':
     optional: true
 
-  '@esbuild/linux-s390x@0.25.8':
+  '@esbuild/linux-s390x@0.25.9':
     optional: true
 
-  '@esbuild/linux-x64@0.25.8':
+  '@esbuild/linux-x64@0.25.9':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.25.8':
+  '@esbuild/netbsd-arm64@0.25.9':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.8':
+  '@esbuild/netbsd-x64@0.25.9':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.25.8':
+  '@esbuild/openbsd-arm64@0.25.9':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.8':
+  '@esbuild/openbsd-x64@0.25.9':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.25.8':
+  '@esbuild/openharmony-arm64@0.25.9':
     optional: true
 
-  '@esbuild/sunos-x64@0.25.8':
+  '@esbuild/sunos-x64@0.25.9':
     optional: true
 
-  '@esbuild/win32-arm64@0.25.8':
+  '@esbuild/win32-arm64@0.25.9':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.8':
+  '@esbuild/win32-ia32@0.25.9':
     optional: true
 
-  '@esbuild/win32-x64@0.25.8':
+  '@esbuild/win32-x64@0.25.9':
     optional: true
 
   '@eslint-community/eslint-utils@4.7.0(eslint@9.33.0)':
@@ -4981,7 +4996,15 @@ snapshots:
       unist-util-visit: 5.0.0
       unist-util-visit-parents: 6.0.1
 
+  '@expressive-code/plugin-collapsible-sections@0.41.3':
+    dependencies:
+      '@expressive-code/core': 0.41.3
+
   '@expressive-code/plugin-frames@0.41.3':
+    dependencies:
+      '@expressive-code/core': 0.41.3
+
+  '@expressive-code/plugin-line-numbers@0.41.3':
     dependencies:
       '@expressive-code/core': 0.41.3
 
@@ -5905,7 +5928,7 @@ snapshots:
 
   '@testing-library/jest-dom@6.6.4':
     dependencies:
-      '@adobe/css-tools': 4.4.3
+      '@adobe/css-tools': 4.4.4
       aria-query: 5.3.2
       css.escape: 1.5.1
       dom-accessibility-api: 0.6.3
@@ -6330,7 +6353,7 @@ snapshots:
       dlv: 1.1.3
       dset: 3.1.4
       es-module-lexer: 1.7.0
-      esbuild: 0.25.8
+      esbuild: 0.25.9
       estree-walker: 3.0.3
       flattie: 1.1.1
       fontace: 0.3.0
@@ -6780,41 +6803,41 @@ snapshots:
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
-  esbuild-register@3.6.0(esbuild@0.25.8):
+  esbuild-register@3.6.0(esbuild@0.25.9):
     dependencies:
       debug: 4.4.1
-      esbuild: 0.25.8
+      esbuild: 0.25.9
     transitivePeerDependencies:
       - supports-color
 
-  esbuild@0.25.8:
+  esbuild@0.25.9:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.8
-      '@esbuild/android-arm': 0.25.8
-      '@esbuild/android-arm64': 0.25.8
-      '@esbuild/android-x64': 0.25.8
-      '@esbuild/darwin-arm64': 0.25.8
-      '@esbuild/darwin-x64': 0.25.8
-      '@esbuild/freebsd-arm64': 0.25.8
-      '@esbuild/freebsd-x64': 0.25.8
-      '@esbuild/linux-arm': 0.25.8
-      '@esbuild/linux-arm64': 0.25.8
-      '@esbuild/linux-ia32': 0.25.8
-      '@esbuild/linux-loong64': 0.25.8
-      '@esbuild/linux-mips64el': 0.25.8
-      '@esbuild/linux-ppc64': 0.25.8
-      '@esbuild/linux-riscv64': 0.25.8
-      '@esbuild/linux-s390x': 0.25.8
-      '@esbuild/linux-x64': 0.25.8
-      '@esbuild/netbsd-arm64': 0.25.8
-      '@esbuild/netbsd-x64': 0.25.8
-      '@esbuild/openbsd-arm64': 0.25.8
-      '@esbuild/openbsd-x64': 0.25.8
-      '@esbuild/openharmony-arm64': 0.25.8
-      '@esbuild/sunos-x64': 0.25.8
-      '@esbuild/win32-arm64': 0.25.8
-      '@esbuild/win32-ia32': 0.25.8
-      '@esbuild/win32-x64': 0.25.8
+      '@esbuild/aix-ppc64': 0.25.9
+      '@esbuild/android-arm': 0.25.9
+      '@esbuild/android-arm64': 0.25.9
+      '@esbuild/android-x64': 0.25.9
+      '@esbuild/darwin-arm64': 0.25.9
+      '@esbuild/darwin-x64': 0.25.9
+      '@esbuild/freebsd-arm64': 0.25.9
+      '@esbuild/freebsd-x64': 0.25.9
+      '@esbuild/linux-arm': 0.25.9
+      '@esbuild/linux-arm64': 0.25.9
+      '@esbuild/linux-ia32': 0.25.9
+      '@esbuild/linux-loong64': 0.25.9
+      '@esbuild/linux-mips64el': 0.25.9
+      '@esbuild/linux-ppc64': 0.25.9
+      '@esbuild/linux-riscv64': 0.25.9
+      '@esbuild/linux-s390x': 0.25.9
+      '@esbuild/linux-x64': 0.25.9
+      '@esbuild/netbsd-arm64': 0.25.9
+      '@esbuild/netbsd-x64': 0.25.9
+      '@esbuild/openbsd-arm64': 0.25.9
+      '@esbuild/openbsd-x64': 0.25.9
+      '@esbuild/openharmony-arm64': 0.25.9
+      '@esbuild/sunos-x64': 0.25.9
+      '@esbuild/win32-arm64': 0.25.9
+      '@esbuild/win32-ia32': 0.25.9
+      '@esbuild/win32-x64': 0.25.9
 
   escalade@3.2.0: {}
 
@@ -8853,8 +8876,8 @@ snapshots:
       '@vitest/mocker': 3.2.4(vite@7.0.6(@types/node@24.2.1)(lightningcss@1.30.1)(terser@5.42.0)(yaml@2.8.1))
       '@vitest/spy': 3.2.4
       better-opn: 3.0.2
-      esbuild: 0.25.8
-      esbuild-register: 3.6.0(esbuild@0.25.8)
+      esbuild: 0.25.9
+      esbuild-register: 3.6.0(esbuild@0.25.9)
       recast: 0.23.11
       semver: 7.7.2
       ws: 8.18.3
@@ -9227,7 +9250,7 @@ snapshots:
 
   vite@6.3.5(@types/node@24.2.1)(lightningcss@1.30.1)(terser@5.42.0)(yaml@2.8.1):
     dependencies:
-      esbuild: 0.25.8
+      esbuild: 0.25.9
       fdir: 6.4.6(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
@@ -9242,7 +9265,7 @@ snapshots:
 
   vite@7.0.6(@types/node@24.2.1)(lightningcss@1.30.1)(terser@5.42.0)(yaml@2.8.1):
     dependencies:
-      esbuild: 0.25.8
+      esbuild: 0.25.9
       fdir: 6.4.6(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6

--- a/src/content/docs/setup/configuration/commerce-configuration.mdx
+++ b/src/content/docs/setup/configuration/commerce-configuration.mdx
@@ -8,6 +8,7 @@ import Callouts from '@components/Callouts.astro';
 import Tasks from '@components/Tasks.astro';
 import Task from '@components/Task.astro';
 import Vocabulary from '@components/Vocabulary.astro';
+import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 
 In this section, you'll learn how Commerce blocks in your storefront connect to a Commerce backend using values from either your site's [public config](https://www.aem.live/docs/admin.html#schema/PublicConfig) or a [config.json](https://github.com/hlxsites/aem-boilerplate-commerce/blob/main/demo-config.json) file in your code repo.
 
@@ -46,9 +47,17 @@ The `getHeaders` function is a helper function which takes a storefront scope (l
 
 ## Examples
 
-You can find the config file in your code repo at either /config.json or /demo-config.json. You can view the sample backend's connection `keys` and `values` in the file. They should look similar to this:
+You can find the configuration file in your code repo at either `/config.json` or `/demo-config.json`. The file provides a template with the `keys` and `values` to configure the connection to the Commerce backend.
 
-```js
+The required configuration depends on the type of Commerce application that you are connecting to. Select the tabs below to review the available templates.
+
+<Tabs>
+
+<TabItem label="Adobe Commerce">
+
+The following example shows the boilerplate `config.json` to configure a storefront connected to Adobe Commerce on Cloud infrastructure or on-premises project.
+
+```json
 {
   "public": {
     "default": {
@@ -82,6 +91,7 @@ You can find the config file in your code repo at either /config.json or /demo-c
   }
 }
 ```
+
 :::note
 The properties listed above are all required, with correct values for your Commerce environment.
 :::
@@ -109,6 +119,153 @@ Each `key` is described below with links to more details. The `value` for each k
 1. **headers.cs.x-api-key:** Provides access to SaaS storefront services (Catalog Service, Live Search, and Product Recommendations). See [Commerce Services Connector](https://experienceleague.adobe.com/en/docs/commerce/user-guides/integration-services/saas) for details.
 
 </Callouts>
+
+</TabItem>
+
+<TabItem label="Adobe Commerce as a Cloud Service">
+
+This example shows the boilerplate `config.json` to configure a storefront connected to Adobe Commerce as a Cloud Service instance.
+
+```json
+{
+  "public": {
+    "default": {
+      "commerce-core-endpoint": "https://na1-sandbox.api.commerce.adobe.com/{{instanceID}}/graphql",
+      "commerce-endpoint": "https://na1-sandbox.api.commerce.adobe.com/{{instanceID}}/graphql",
+      "headers": {
+        "all": {
+          "Store": "default"
+        },
+        "cs": {
+          "Magento-Customer-Group": "b6589fc6ab0dc82cf12099d1c2d40ab994e8410c",
+          "Magento-Store-Code": "main_website_store",
+          "Magento-Store-View-Code": "default",
+          "Magento-Website-Code": "base"
+        }
+      },
+      "analytics": {
+        "base-currency-code": "USD",
+        "environment": "Testing",
+        "environment-id": "{{instanceID}}",
+        "store-code": "main_website_store",
+        "store-id": "main_website_store",
+        "store-name": "Default Store View",
+        "store-url": "https://coresaas-subgraph-external:8000/{{instanceID/",
+        "store-view-code": "default",
+        "store-view-id": "default",
+        "store-view-name": "Default Store View",
+        "website-code": "base",
+        "website-id": "base",
+        "website-name": "Main Website"
+      },
+      "plugins": {
+        "picker": {
+          "rootCategory": "2"
+        }
+      }
+    }
+  }
+}
+```
+
+:::note
+The properties listed above are all required, with correct values for your Commerce environment.
+:::
+
+Each `key` is described below with links to more details. The `value` for each key is specific to your Commerce instance and can be provided by your Commerce administrator.
+
+<Callouts>
+
+1. **commerce-endpoint:** (read-only) Services GraphQL endpoint optimized for Catalog Service, Live Search, and Product Recommendations. See [Catalog Service](https://experienceleague.adobe.com/en/docs/commerce/catalog-service/installation#access-the-service) for details.
+
+1. **commerce-core-endpoint:** (read/write) Core GraphQL endpoint for a variety of queries and mutations. See [Adobe Commerce GraphQL API](https://developer.adobe.com/commerce/webapi/graphql/reference/) for details.
+
+1. **headers.all.Store:** Determines the store view to connect to, for Core requests. See [Core GraphQL Headers documentation](https://developer.adobe.com/commerce/webapi/graphql/usage/headers/) for details.
+
+1. **headers.cs.Magento-Environment-Id:** Connects the storefront to the cloud instance that serves it. See [Cloud Environment overview](https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/project/overview#environment-overview) for details.
+
+1. **headers.cs.Magento-Website-Code:** Determines the website to connect to. See [Step 2: Create websites](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/multi-sites/ms-admin#step-2-create-websites) for details.
+
+1. **headers.cs.Magento-Store-Code:** Determines the store to connect to. See [Step 3: Create stores](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/multi-sites/ms-admin#step-3-create-stores) for details.
+
+1. **headers.cs.Magento-Store-View-Code:** Determines the store view to connect to, for Catalog Service requests. See [Step 4: Create store views](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/multi-sites/ms-admin#step-4-create-store-views) and [Store views](https://experienceleague.adobe.com/en/docs/commerce-admin/stores-sales/site-store/store-views) for details.
+
+1. **headers.cs.Magento-Customer-group:** Determines product discounts and tax classes. See [Customer groups](https://experienceleague.adobe.com/en/docs/commerce-admin/customers/customer-groups) and the [Create Customer Groups](https://experienceleague.adobe.com/en/docs/commerce-learn/tutorials/customers/customer-groups) video for details.
+
+1. **headers.cs.x-api-key:** Provides access to SaaS storefront services (Catalog Service, Live Search, and Product Recommendations). See [Commerce Services Connector](https://experienceleague.adobe.com/en/docs/commerce/user-guides/integration-services/saas) for details.
+
+</Callouts>
+
+</TabItem>
+
+<TabItem label="Adobe Commerce Optmizer">
+
+This example shows the boilerplate `config.json` to configure a storefront connected to Adobe Commerce Optimizer instance.
+
+```json
+{
+  "public": {
+    "default": {
+      "commerce-core-endpoint": "https://na1-sandbox.api.commerce.adobe.com/Fwus6kdpvYCmeEdcCX7PZg/graphql",
+      "commerce-endpoint": "https://na1-sandbox.api.commerce.adobe.com/Fwus6kdpvYCmeEdcCX7PZg/graphql",
+      "headers": {
+        "all": {
+          "Store": "default"
+        },
+        "cs": {
+          "AC-View-ID": "YOUR_HEADER_VALUE",
+          "AC-Price-Book-ID": "YOUR_HEADER_VALUE",
+          "AC-Source-Locale": "YOUR_HEADER_VALUE"
+        }
+      },
+      "analytics": {
+        "base-currency-code": "USD",
+        "environment": "Testing",
+        "environment-id": "Fwus6kdpvYCmeEdcCX7PZg",
+        "store-code": "YOUR_STORE_CODE",
+        "store-id": "YOUR_STORE_ID",
+        "store-name": "YOUR_STORE_NAME",
+        "store-url": "YOUR_STORE_URL",
+        "store-view-code": "YOUR_STORE_VIEW_CODE",
+        "store-view-id": "YOUR_STORE_VIEW_ID",
+        "store-view-name": "YOUR_STORE_VIEW_NAME",
+        "website-code": "YOUR_WEBSITE_CODE",
+        "website-id": "YOUR_WEBSITE_ID",
+        "website-name": "YOUR_WEBSITE_NAME"
+      },
+      "plugins": {
+        "picker": {
+          "rootCategory": "2"
+        }
+      }
+    }
+  }
+}
+```
+:::note
+The properties listed above are all required, with correct values for your Commerce environment.
+:::
+
+Each `key` is described below with links to more details. The `value` for each key is specific to your Commerce instance and can be provided by your Commerce administrator.
+
+ <Callouts>
+
+1. **commerce-endpoint:** (read-only) Services GraphQL endpoint optimized for Catalog and Merchandising services powered by Catalog views and policies. See [Merchandising Services Developer Guide](https://developer.adobe.com/commerce/services/optimizer/) for details.
+
+1. **commerce-core-endpoint:** (read/write) Use the same GraphQL endpoint provided in `commerce-endpoint`.
+
+1. **headers.all.Store:**
+
+1. **headers.cs.AC-View-Id:** Required. The ID for the catalog view that products will be sold through. For example, in the automotive industry, the catalog view could be dealers. In the manufacturing industry, the view could be a manufacturing location for suppliers. See the catalog view configuration in the Adobe Commerce Optimizer UI to get the ID associated with the Ch the correct value.You can view the list of available catalog view and associated ids from the Adobe Commerce Optimizer UI.
+
+1. **headers.cs.AC-Price-Book-Id:** Optional. Defines how prices are calculated for a specific catalog view. Supply this value if the merchant uses price books to calculate product price schedules. See [Price Books](https://developer.adobe.com/commerce/services/optimizer/data-ingestion/#operation/deletePrices) in the _Merchandising Services Developer Guide_.
+
+</Callouts>
+
+</TabItem>
+
+</Tabs>
+
 
 All of the initializer blocks now automatically use any headers for the corresponding block if they are in the config. For example `commerce.headers.cart.Foo` will add a `Foo` header to graphql requests made by the cart dropin. This can be useful if you need to append certain headers for specific requests.
 

--- a/src/content/docs/setup/configuration/commerce-configuration.mdx
+++ b/src/content/docs/setup/configuration/commerce-configuration.mdx
@@ -55,9 +55,9 @@ The required configuration depends on the type of Commerce application that you 
 
 <TabItem label="Adobe Commerce">
 
-The following example shows the boilerplate `config.json` to configure a storefront connected to Adobe Commerce on Cloud infrastructure or on-premises project.
+This boilerplate `config.json` for Adobe Commerce requires correct values for your Commerce environment.
 
-```json
+```json title="config.json" showLineNumbers collapse={20-32} ins={"1":4} ins={"2":5} ins={"3":8} ins={"4":11} ins={"5":12} ins={"6":13} ins={"7":14} ins={"8":15} ins={"9":16}
 {
   "public": {
     "default": {
@@ -92,31 +92,27 @@ The following example shows the boilerplate `config.json` to configure a storefr
 }
 ```
 
-:::note
-The properties listed above are all required, with correct values for your Commerce environment.
-:::
-
 Each `key` is described below with links to more details. The `value` for each key is specific to your Commerce instance and can be provided by your Commerce administrator.
 
 <Callouts>
 
-1. **commerce-endpoint:** (read-only) Services GraphQL endpoint optimized for Catalog Service, Live Search, and Product Recommendations. See [Catalog Service](https://experienceleague.adobe.com/en/docs/commerce/catalog-service/installation#access-the-service) for details.
-
 1. **commerce-core-endpoint:** (read/write) Core GraphQL endpoint for a variety of queries and mutations. See [Adobe Commerce GraphQL API](https://developer.adobe.com/commerce/webapi/graphql/reference/) for details.
+
+1. **commerce-endpoint:** (read-only) Services GraphQL endpoint optimized for Catalog Service, Live Search, and Product Recommendations. See [Catalog Service](https://experienceleague.adobe.com/en/docs/commerce/catalog-service/installation#access-the-service) for details.
 
 1. **headers.all.Store:** Determines the store view to connect to, for Core requests. See [Core GraphQL Headers documentation](https://developer.adobe.com/commerce/webapi/graphql/usage/headers/) for details.
 
-1. **headers.cs.Magento-Environment-Id:** Connects the storefront to the cloud instance that serves it. See [Cloud Environment overview](https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/project/overview#environment-overview) for details.
-
-1. **headers.cs.Magento-Website-Code:** Determines the website to connect to. See [Step 2: Create websites](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/multi-sites/ms-admin#step-2-create-websites) for details.
+1. **headers.cs.Magento-Customer-group:** Determines product discounts and tax classes. See [Customer groups](https://experienceleague.adobe.com/en/docs/commerce-admin/customers/customer-groups) and the [Create Customer Groups](https://experienceleague.adobe.com/en/docs/commerce-learn/tutorials/customers/customer-groups) video for details.
 
 1. **headers.cs.Magento-Store-Code:** Determines the store to connect to. See [Step 3: Create stores](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/multi-sites/ms-admin#step-3-create-stores) for details.
 
 1. **headers.cs.Magento-Store-View-Code:** Determines the store view to connect to, for Catalog Service requests. See [Step 4: Create store views](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/multi-sites/ms-admin#step-4-create-store-views) and [Store views](https://experienceleague.adobe.com/en/docs/commerce-admin/stores-sales/site-store/store-views) for details.
 
-1. **headers.cs.Magento-Customer-group:** Determines product discounts and tax classes. See [Customer groups](https://experienceleague.adobe.com/en/docs/commerce-admin/customers/customer-groups) and the [Create Customer Groups](https://experienceleague.adobe.com/en/docs/commerce-learn/tutorials/customers/customer-groups) video for details.
+1. **headers.cs.Magento-Website-Code:** Determines the website to connect to. See [Step 2: Create websites](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/multi-sites/ms-admin#step-2-create-websites) for details.
 
 1. **headers.cs.x-api-key:** Provides access to SaaS storefront services (Catalog Service, Live Search, and Product Recommendations). See [Commerce Services Connector](https://experienceleague.adobe.com/en/docs/commerce/user-guides/integration-services/saas) for details.
+
+1. **headers.cs.Magento-Environment-Id:** Connects the storefront to the cloud instance that serves it. See [Cloud Environment overview](https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/project/overview#environment-overview) for details.
 
 </Callouts>
 
@@ -124,9 +120,9 @@ Each `key` is described below with links to more details. The `value` for each k
 
 <TabItem label="Adobe Commerce as a Cloud Service">
 
-This example shows the boilerplate `config.json` to configure a storefront connected to Adobe Commerce as a Cloud Service instance.
+This boilerplate `config.json` for ACCS requires correct values for your Commerce environment.
 
-```json
+```json title="config.json" showLineNumbers collapse={18-36} ins={"1":4} ins={"2":5} ins={"3":8} ins={"4":11} ins={"5":12} ins={"6":13} ins={"7":14} ins={"8":15}
 {
   "public": {
     "default": {
@@ -168,31 +164,21 @@ This example shows the boilerplate `config.json` to configure a storefront conne
 }
 ```
 
-:::note
-The properties listed above are all required, with correct values for your Commerce environment.
-:::
-
 Each `key` is described below with links to more details. The `value` for each key is specific to your Commerce instance and can be provided by your Commerce administrator.
 
 <Callouts>
 
-1. **commerce-endpoint:** (read-only) Services GraphQL endpoint optimized for Catalog Service, Live Search, and Product Recommendations. See [Catalog Service](https://experienceleague.adobe.com/en/docs/commerce/catalog-service/installation#access-the-service) for details.
-
 1. **commerce-core-endpoint:** (read/write) Core GraphQL endpoint for a variety of queries and mutations. See [Adobe Commerce GraphQL API](https://developer.adobe.com/commerce/webapi/graphql/reference/) for details.
 
+1. **commerce-endpoint:** (read-only) Services GraphQL endpoint optimized for Catalog Service, Live Search, and Product Recommendations. See [Catalog Service](https://experienceleague.adobe.com/en/docs/commerce/catalog-service/installation#access-the-service) for details.
+
 1. **headers.all.Store:** Determines the store view to connect to, for Core requests. See [Core GraphQL Headers documentation](https://developer.adobe.com/commerce/webapi/graphql/usage/headers/) for details.
-
-1. **headers.cs.Magento-Environment-Id:** Connects the storefront to the cloud instance that serves it. See [Cloud Environment overview](https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/project/overview#environment-overview) for details.
-
-1. **headers.cs.Magento-Website-Code:** Determines the website to connect to. See [Step 2: Create websites](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/multi-sites/ms-admin#step-2-create-websites) for details.
 
 1. **headers.cs.Magento-Store-Code:** Determines the store to connect to. See [Step 3: Create stores](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/multi-sites/ms-admin#step-3-create-stores) for details.
 
 1. **headers.cs.Magento-Store-View-Code:** Determines the store view to connect to, for Catalog Service requests. See [Step 4: Create store views](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/multi-sites/ms-admin#step-4-create-store-views) and [Store views](https://experienceleague.adobe.com/en/docs/commerce-admin/stores-sales/site-store/store-views) for details.
 
-1. **headers.cs.Magento-Customer-group:** Determines product discounts and tax classes. See [Customer groups](https://experienceleague.adobe.com/en/docs/commerce-admin/customers/customer-groups) and the [Create Customer Groups](https://experienceleague.adobe.com/en/docs/commerce-learn/tutorials/customers/customer-groups) video for details.
-
-1. **headers.cs.x-api-key:** Provides access to SaaS storefront services (Catalog Service, Live Search, and Product Recommendations). See [Commerce Services Connector](https://experienceleague.adobe.com/en/docs/commerce/user-guides/integration-services/saas) for details.
+1. **headers.cs.Magento-Website-Code:** Determines the website to connect to. See [Step 2: Create websites](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/multi-sites/ms-admin#step-2-create-websites) for details.
 
 </Callouts>
 
@@ -200,9 +186,9 @@ Each `key` is described below with links to more details. The `value` for each k
 
 <TabItem label="Adobe Commerce Optmizer">
 
-This example shows the boilerplate `config.json` to configure a storefront connected to Adobe Commerce Optimizer instance.
+This boilerplate `config.json` for ACO requires correct values for your Commerce environment.
 
-```json
+```json title="config.json" showLineNumbers collapse={15-36} ins={"1":4} ins={"2":5} ins={"3":8} ins={"4":11} ins={"5":12} ins={"6":13} ins={"7":14} ins={"8":15}
 {
   "public": {
     "default": {
@@ -242,23 +228,21 @@ This example shows the boilerplate `config.json` to configure a storefront conne
   }
 }
 ```
-:::note
-The properties listed above are all required, with correct values for your Commerce environment.
-:::
 
 Each `key` is described below with links to more details. The `value` for each key is specific to your Commerce instance and can be provided by your Commerce administrator.
 
  <Callouts>
+1. **commerce-core-endpoint:** (read/write) Use the same GraphQL endpoint provided in `commerce-endpoint`.
 
 1. **commerce-endpoint:** (read-only) Services GraphQL endpoint optimized for Catalog and Merchandising services powered by Catalog views and policies. See [Merchandising Services Developer Guide](https://developer.adobe.com/commerce/services/optimizer/) for details.
 
-1. **commerce-core-endpoint:** (read/write) Use the same GraphQL endpoint provided in `commerce-endpoint`.
-
-1. **headers.all.Store:**
+1. **headers.all.Store:** Determines the store view to connect to, for Core requests. See [Core GraphQL Headers documentation](https://developer.adobe.com/commerce/webapi/graphql/usage/headers/) for details.
 
 1. **headers.cs.AC-View-Id:** Required. The ID for the catalog view that products will be sold through. For example, in the automotive industry, the catalog view could be dealers. In the manufacturing industry, the view could be a manufacturing location for suppliers. See the catalog view configuration in the Adobe Commerce Optimizer UI to get the ID associated with the Ch the correct value.You can view the list of available catalog view and associated ids from the Adobe Commerce Optimizer UI.
 
 1. **headers.cs.AC-Price-Book-Id:** Optional. Defines how prices are calculated for a specific catalog view. Supply this value if the merchant uses price books to calculate product price schedules. See [Price Books](https://developer.adobe.com/commerce/services/optimizer/data-ingestion/#operation/deletePrices) in the _Merchandising Services Developer Guide_.
+
+1. **headers.cs.AC-Source-Locale:** Optional. The locale of the source store. 
 
 </Callouts>
 

--- a/src/content/docs/setup/configuration/commerce-configuration.mdx
+++ b/src/content/docs/setup/configuration/commerce-configuration.mdx
@@ -246,7 +246,7 @@ Each `key` is described below with links to more details. The `value` for each k
 
 1. **headers.cs.AC-Price-Book-Id:** (Optional) Price book ID for custom pricing calculations. See [Price Books](https://developer.adobe.com/commerce/services/optimizer/data-ingestion/#price-books-and-prices) for details.
 
-1. **headers.cs.AC-Policy-*:** (Optional) Policy trigger for filtering products by attributes, for example, `AC-Policy-Brand:Cruz`. See [Policies](https://experienceleague.adobe.com/en/docs/commerce/optimizer/setup/policies) for details.
+1. **headers.cs.AC-Policy-*:** (Optional) Policy trigger for filtering products by attribute, for example, `AC-Policy-Brand:Cruz`. See [Policies](https://experienceleague.adobe.com/en/docs/commerce/optimizer/setup/policies) for details.
 
 </Callouts>
 

--- a/src/content/docs/setup/configuration/commerce-configuration.mdx
+++ b/src/content/docs/setup/configuration/commerce-configuration.mdx
@@ -16,9 +16,9 @@ When implementing your own project, you must update the configuration values wit
 - The header values specific to your Adobe Commerce Catalog Services environment.
 - The Adobe Commerce and Catalog Service GraphQL endpoint that you configured as part of the [content delivery network (CDN) setup](/setup/configuration/content-delivery-network/).
 
-When you [set up your storefront](/get-started/) using the boilerplate code, the template repo provided you with a `demo-config.json` file in the root folder. This file contains the environment values for a Commerce backend including GraphQl endpoints and headers.
+If you [set up your storefront](/get-started/) using the boilerplate code, the template repo provided you with a `demo-config.json` file in the root folder. This file contains the environment values for a Commerce backend including GraphQl endpoints and headers.
 
-If you set up your site using the [Site Creator Tool](https://da.live/app/adobe-commerce/storefront-tools/tools/site-creator/site-creator) that automates the site creation process, you can review and update the `config.json` file after the process completes.
+If you set up your site using the [Site Creator Tool](https://da.live/app/adobe-commerce/storefront-tools/tools/site-creator/site-creator) that automates the site creation process, the `config.json` file is created for you in the GitHub repository created for the boilerplate code. You can review and update the default values in the `config.json` file after the process completes.
 
 ## Vocabulary
 

--- a/src/content/docs/setup/configuration/commerce-configuration.mdx
+++ b/src/content/docs/setup/configuration/commerce-configuration.mdx
@@ -12,11 +12,13 @@ import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 
 In this section, you'll learn how Commerce blocks in your storefront connect to a Commerce backend using values from either your site's [public config](https://www.aem.live/docs/admin.html#schema/PublicConfig) or a [config.json](https://github.com/hlxsites/aem-boilerplate-commerce/blob/main/demo-config.json) file in your code repo.
 
-In the [Create your storefront tutorial](/get-started/), the template repo provided you a `demo-config.json` file in the root folder. This file contains the environment values for a Commerce backend including GraphQl endpoints and headers.
-
 When implementing your own project, you must update the configuration values with:
 - The header values specific to your Adobe Commerce Catalog Services environment.
 - The Adobe Commerce and Catalog Service GraphQL endpoint that you configured as part of the [content delivery network (CDN) setup](/setup/configuration/content-delivery-network/).
+
+When you [set up your storefront](/get-started/) using the boilerplate code, the template repo provided you with a `demo-config.json` file in the root folder. This file contains the environment values for a Commerce backend including GraphQl endpoints and headers.
+
+If you set up your site using the [Site Creator Tool](https://da.live/app/adobe-commerce/storefront-tools/tools/site-creator/site-creator) that automates the site creation process, you can review and update the `config.json` file after the process completes.
 
 ## Vocabulary
 
@@ -146,7 +148,7 @@ This boilerplate `config.json` for Adobe Commerce as a Cloud Service requires co
         "store-code": "main_website_store",
         "store-id": "main_website_store",
         "store-name": "Default Store View",
-        "store-url": "https://coresaas-subgraph-external:8000/{{instanceID/",
+        "store-url": "https://coresaas-subgraph-external:8000/{{instanceID}}/",
         "store-view-code": "default",
         "store-view-id": "default",
         "store-view-name": "Default Store View",

--- a/src/content/docs/setup/configuration/commerce-configuration.mdx
+++ b/src/content/docs/setup/configuration/commerce-configuration.mdx
@@ -96,11 +96,11 @@ Each `key` is described below with links to more details. The `value` for each k
 
 <Callouts>
 
-1. **commerce-core-endpoint:** (read/write) Core GraphQL endpoint for a variety of queries and mutations. See [Adobe Commerce GraphQL API](https://developer.adobe.com/commerce/webapi/graphql/reference/) for details.
+1. **commerce-core-endpoint:** (read/write) Core GraphQL endpoint for queries and mutations. See [Adobe Commerce GraphQL API](https://developer.adobe.com/commerce/webapi/graphql/reference/) for details.
 
-1. **commerce-endpoint:** (read-only) Services GraphQL endpoint optimized for Catalog Service, Live Search, and Product Recommendations. See [Catalog Service](https://experienceleague.adobe.com/en/docs/commerce/catalog-service/installation#access-the-service) for details.
+1. **commerce-endpoint:** (read-only) Services GraphQL endpoint for Catalog Service, Live Search, and Product Recommendations. See [Catalog Service](https://experienceleague.adobe.com/en/docs/commerce/catalog-service/installation#access-the-service) for details.
 
-1. **headers.all.Store:** Determines the store view to connect to, for Core requests. See [Core GraphQL Headers documentation](https://developer.adobe.com/commerce/webapi/graphql/usage/headers/) for details.
+1. **headers.all.Store:** Store view code for Core GraphQL requests. See [GraphQL Headers](https://developer.adobe.com/commerce/webapi/graphql/usage/headers/) for details.
 
 1. **headers.cs.Magento-Customer-group:** Determines product discounts and tax classes. See [Customer groups](https://experienceleague.adobe.com/en/docs/commerce-admin/customers/customer-groups) and the [Create Customer Groups](https://experienceleague.adobe.com/en/docs/commerce-learn/tutorials/customers/customer-groups) video for details.
 
@@ -110,7 +110,7 @@ Each `key` is described below with links to more details. The `value` for each k
 
 1. **headers.cs.Magento-Website-Code:** Determines the website to connect to. See [Step 2: Create websites](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/multi-sites/ms-admin#step-2-create-websites) for details.
 
-1. **headers.cs.x-api-key:** Provides access to SaaS storefront services (Catalog Service, Live Search, and Product Recommendations). See [Commerce Services Connector](https://experienceleague.adobe.com/en/docs/commerce/user-guides/integration-services/saas) for details.
+1. **headers.cs.x-api-key:** API key to access SaaS services (Catalog Service, Live Search, Product Recommendations). See [Commerce Services Connector](https://experienceleague.adobe.com/en/docs/commerce/user-guides/integration-services/saas) for details.
 
 1. **headers.cs.Magento-Environment-Id:** Connects the storefront to the cloud instance that serves it. See [Cloud Environment overview](https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/project/overview#environment-overview) for details.
 
@@ -120,14 +120,14 @@ Each `key` is described below with links to more details. The `value` for each k
 
 <TabItem label="Adobe Commerce as a Cloud Service">
 
-This boilerplate `config.json` for ACCS requires correct values for your Commerce environment.
+This boilerplate `config.json` for Adobe Commerce as a Cloud Service requires correct values for your Commerce environment.
 
-```json title="config.json" showLineNumbers collapse={18-36} ins={"1":4} ins={"2":5} ins={"3":8} ins={"4":11} ins={"5":12} ins={"6":13} ins={"7":14} ins={"8":15}
+```json title="config.json" showLineNumbers collapse={18-36} ins={"1":4} ins={"2":5} ins={"3":8} ins={"4":11} ins={"5":12} ins={"6":13}  ins={"7":13} ins={"8":14}
 {
   "public": {
     "default": {
-      "commerce-core-endpoint": "https://na1-sandbox.api.commerce.adobe.com/{{instanceID}}/graphql",
-      "commerce-endpoint": "https://na1-sandbox.api.commerce.adobe.com/{{instanceID}}/graphql",
+      "commerce-core-endpoint": "https://na1-sandbox.api.commerce.adobe.com/{{tenantID}}/graphql",
+      "commerce-endpoint": "https://na1-sandbox.api.commerce.adobe.com/{{tenantID}}/graphql",
       "headers": {
         "all": {
           "Store": "default"
@@ -168,15 +168,17 @@ Each `key` is described below with links to more details. The `value` for each k
 
 <Callouts>
 
-1. **commerce-core-endpoint:** (read/write) Core GraphQL endpoint for a variety of queries and mutations. See [Adobe Commerce GraphQL API](https://developer.adobe.com/commerce/webapi/graphql/reference/) for details.
+1. **commerce-core-endpoint:** (read/write) GraphQL endpoint for your Cloud Service instance. Replace `{{instanceID}}` with the Instance ID from the Commerce Admin URL. See [Adobe Commerce GraphQL API](https://developer.adobe.com/commerce/webapi/graphql/reference/) for details.
 
-1. **commerce-endpoint:** (read-only) Services GraphQL endpoint optimized for Catalog Service, Live Search, and Product Recommendations. See [Catalog Service](https://experienceleague.adobe.com/en/docs/commerce/catalog-service/installation#access-the-service) for details.
+1. **commerce-endpoint:** (read-only) Services GraphQL endpoint for Catalog Service, Live Search, and Product Recommendations. See [Catalog Service](https://developer.adobe.com/commerce/webapi/graphql/schema/catalog-service/) for details.
 
-1. **headers.all.Store:** Determines the store view to connect to, for Core requests. See [Core GraphQL Headers documentation](https://developer.adobe.com/commerce/webapi/graphql/usage/headers/) for details.
+1. **headers.all.Store:** Determines the store view to connect to, for Commerce requests. See [GraphQL Headers documentation](https://developer.adobe.com/commerce/webapi/graphql/usage/headers/) for details.
 
-1. **headers.cs.Magento-Store-Code:** Determines the store to connect to. See [Step 3: Create stores](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/multi-sites/ms-admin#step-3-create-stores) for details.
+1. **headers.cs.Magento-Customer-Group:** Customer group for pricing and tax calculations. See [Customer groups](https://experienceleague.adobe.com/en/docs/commerce-admin/customers/customer-groups) for details.
 
-1. **headers.cs.Magento-Store-View-Code:** Determines the store view to connect to, for Catalog Service requests. See [Step 4: Create store views](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/multi-sites/ms-admin#step-4-create-store-views) and [Store views](https://experienceleague.adobe.com/en/docs/commerce-admin/stores-sales/site-store/store-views) for details.
+1. **headers.cs.Magento-Store-Code:** Store code identifier. See [Create stores](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/multi-sites/ms-admin#step-3-create-stores) for details.
+
+1. **headers.cs.Magento-Store-View-Code:** Determines the store view connection for Catalog Service requests. See [Step 4: Create store views](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/multi-sites/ms-admin#step-4-create-store-views) and [Store views](https://experienceleague.adobe.com/en/docs/commerce-admin/stores-sales/site-store/store-views) for details.
 
 1. **headers.cs.Magento-Website-Code:** Determines the website to connect to. See [Step 2: Create websites](https://experienceleague.adobe.com/en/docs/commerce-operations/configuration-guide/multi-sites/ms-admin#step-2-create-websites) for details.
 
@@ -184,24 +186,24 @@ Each `key` is described below with links to more details. The `value` for each k
 
 </TabItem>
 
-<TabItem label="Adobe Commerce Optmizer">
+<TabItem label="Adobe Commerce Optimizer">
 
-This boilerplate `config.json` for ACO requires correct values for your Commerce environment.
+This boilerplate `config.json` for Adobe Commerce Optimizer requires correct values for your Commerce environment.
 
-```json title="config.json" showLineNumbers collapse={15-36} ins={"1":4} ins={"2":5} ins={"3":8} ins={"4":11} ins={"5":12} ins={"6":13} ins={"7":14} ins={"8":15}
+```json title="config.json" showLineNumbers collapse={17-38} ins={"1":4} ins={"2":5} ins={"3":8} ins={"4":11} ins={"5":12} ins={"6":13}
 {
   "public": {
     "default": {
-      "commerce-core-endpoint": "https://na1-sandbox.api.commerce.adobe.com/Fwus6kdpvYCmeEdcCX7PZg/graphql",
-      "commerce-endpoint": "https://na1-sandbox.api.commerce.adobe.com/Fwus6kdpvYCmeEdcCX7PZg/graphql",
+      "commerce-core-endpoint": "https://na1-sandbox.api.commerce.adobe.com/{{instanceID}}/graphql",
+      "commerce-endpoint": "https://na1-sandbox.api.commerce.adobe.com/{{instanceID}}/graphql",
       "headers": {
         "all": {
           "Store": "default"
         },
         "cs": {
-          "AC-View-ID": "YOUR_HEADER_VALUE",
-          "AC-Price-Book-ID": "YOUR_HEADER_VALUE",
-          "AC-Source-Locale": "YOUR_HEADER_VALUE"
+          "AC-View-ID": "{{catalogViewUUID}}",
+          "AC-Price-Book-ID": "{{priceBookID}}",            # Optional. Remove if not needed.
+          "AC-Policy-{{attributeTrigger}}": "{{attributeValue}}"  # Optional. Remove this header if not needed.
         }
       },
       "analytics": {
@@ -232,17 +234,19 @@ This boilerplate `config.json` for ACO requires correct values for your Commerce
 Each `key` is described below with links to more details. The `value` for each key is specific to your Commerce instance and can be provided by your Commerce administrator.
 
  <Callouts>
-1. **commerce-core-endpoint:** (read/write) Use the same GraphQL endpoint provided in `commerce-endpoint`.
+1. **commerce-core-endpoint:** (read) Use the same GraphQL endpoint provided in `commerce-endpoint`.
 
-1. **commerce-endpoint:** (read-only) Services GraphQL endpoint optimized for Catalog and Merchandising services powered by Catalog views and policies. See [Merchandising Services Developer Guide](https://developer.adobe.com/commerce/services/optimizer/) for details.
+1. **commerce-endpoint:** (read-only) GraphQL endpoint for Merchandising Services powered by Catalog Views and Policies. This endpoint enables catalog data retrieval for product display, product discovery, and recommendations. Replace the `{{tenant ID}}` with the Instance ID from the Commerce Optimizer URL for your project. See [Merchandising Services Developer Guide](https://developer.adobe.com/commerce/services/optimizer/merchandising-services/) for details.
 
-1. **headers.all.Store:** Determines the store view to connect to, for Core requests. See [Core GraphQL Headers documentation](https://developer.adobe.com/commerce/webapi/graphql/usage/headers/) for details.
+1. **commerce-endpoint:** (read-only) GraphQL endpoint for Merchandising Services with Catalog Views and Policies. Replace `{{instanceID}}` with your Instance ID from the Optimizer admin URL. See [Merchandising Services](https://developer.adobe.com/commerce/services/optimizer/merchandising-services/) for details.
 
-1. **headers.cs.AC-View-Id:** Required. The ID for the catalog view that products will be sold through. For example, in the automotive industry, the catalog view could be dealers. In the manufacturing industry, the view could be a manufacturing location for suppliers. See the catalog view configuration in the Adobe Commerce Optimizer UI to get the ID associated with the Ch the correct value.You can view the list of available catalog view and associated ids from the Adobe Commerce Optimizer UI.
+1. **headers.all.Store:** Keep the default value `"default"` from the template.
 
-1. **headers.cs.AC-Price-Book-Id:** Optional. Defines how prices are calculated for a specific catalog view. Supply this value if the merchant uses price books to calculate product price schedules. See [Price Books](https://developer.adobe.com/commerce/services/optimizer/data-ingestion/#operation/deletePrices) in the _Merchandising Services Developer Guide_.
+1. **headers.cs.AC-View-Id:** (Required) Unique identifier for the catalog view that filters storefront data. See [Catalog Views](https://developer.adobe.com/commerce/services/optimizer/merchandising-services/using-the-api/#headers) for details.
 
-1. **headers.cs.AC-Source-Locale:** Optional. The locale of the source store. 
+1. **headers.cs.AC-Price-Book-Id:** (Optional) Price book ID for custom pricing calculations. See [Price Books](https://developer.adobe.com/commerce/services/optimizer/data-ingestion/#price-books-and-prices) for details.
+
+1. **headers.cs.AC-Policy-*:** (Optional) Policy trigger for filtering products by attributes, for example, `AC-Policy-Brand:Cruz`. See [Policies](https://experienceleague.adobe.com/en/docs/commerce/optimizer/setup/policies) for details.
 
 </Callouts>
 

--- a/src/content/docs/setup/configuration/commerce-configuration.mdx
+++ b/src/content/docs/setup/configuration/commerce-configuration.mdx
@@ -16,7 +16,7 @@ When implementing your own project, you must update the configuration values wit
 - The header values specific to your Adobe Commerce Catalog Services environment.
 - The Adobe Commerce and Catalog Service GraphQL endpoint that you configured as part of the [content delivery network (CDN) setup](/setup/configuration/content-delivery-network/).
 
-If you [set up your storefront](/get-started/) using the boilerplate code, the template repo provided you with a `demo-config.json` file in the root folder. This file contains the environment values for a Commerce backend including GraphQl endpoints and headers.
+When you [set up your storefront](/get-started/) using the boilerplate code, the template repo provides you with a `demo-config.json` file in the root folder. This file contains the environment values for a Commerce backend including GraphQl endpoints and headers.
 
 If you set up your site using the [Site Creator Tool](https://da.live/app/adobe-commerce/storefront-tools/tools/site-creator/site-creator) that automates the site creation process, the `config.json` file is created for you in the GitHub repository created for the boilerplate code. You can review and update the default values in the `config.json` file after the process completes.
 


### PR DESCRIPTION
## Purpose of this pull request

Adds documentation for `config.json` templates for each Commerce backend:  AC, ACCS, and ACO.

- Tabbed interface to review config for each flavor
- Highlighted code to reference callouts section with description of each key-value pair in the template (Thanks @bdenham )


### Associated JIRA ticket

COMOPT-617


### Staging preview

<!--OPTIONAL Link to staging preview if available-->


## Affected pages

- https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/commerce-configuration/


