### PR TITLE
PAY-6182: Adapt docs to Payment Services drop-in V2

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -446,9 +446,11 @@ async function config() {
                       items: [
                         { label: 'Overview', link: '/dropins/payment-services/' },
                         { label: 'Installation', link: '/dropins/payment-services/installation/' },
+                        { label: 'Initialization', link: '/dropins/payment-services/initialization/' },
                         {
                           label: 'Containers', collapsed: true,
                           items: [
+                            { label: 'ApplePay', link: '/dropins/payment-services/containers/apple-pay/' },
                             { label: 'CreditCard', link: '/dropins/payment-services/containers/credit-card/' },
                           ]
                         },

--- a/src/content/docs/dropins/payment-services/containers/apple-pay.mdx
+++ b/src/content/docs/dropins/payment-services/containers/apple-pay.mdx
@@ -1,0 +1,45 @@
+---
+title: ApplePay container
+description: Use the ApplePay container to render an Apple Pay button
+---
+
+import OptionsTable from '@components/OptionsTable.astro';
+import Link from '@components/Link.astro';
+
+The `ApplePay` container renders a button that macOS/iOS users can use to check out using <Link href="https://www.apple.com/apple-pay/" text="Apple Pay" />.
+
+## ApplePay configurations
+
+The `ApplePay` container provides the following configuration options:
+
+<OptionsTable
+  compact
+  options={[
+    ['Option', 'Type', 'Req?', 'Description'],
+    ['getCartId', 'function', 'Yes', 'Should return a promise that resolves to the shopper`s cart ID.'],
+    ['isVirtualCart', 'boolean', 'Yes', 'Whether the cart contains only virtual/downloadable products.'],
+    ['onButtonClick', 'function', 'No', 'Called when the user clicks the Apple Pay button. The callback receives a "showPaymentSheet" function as its only argument that must be called to begin the Apple Pay session and show the payment sheet. If no "onButtonClick" handler is provided, the Apple Pay session will begin and the payment sheet will show on click, always.'],
+    ['onSuccess', 'function', 'No', 'Called when the payment flow finishes successfully. If the function returns a promise, the promise will be awaited before showing marking the payment as "completed successfully" in the Apple Pay sheet. If the promise rejects, the payment will be marked as "failed" in the Apple Pay sheet and the error will be propagated to the "onError" callback, if provided.'],
+    ['onError', 'function', 'No', 'Called when the payment flow was aborted due to an error. The function receives a single argument, {message: string}, containing the reason of error.'],
+  ]}
+/>
+
+## Example
+
+```js
+import ApplePay from '@dropins/storefront-payment-services/containers/ApplePay.js';
+import { render as PaymentServices } from '@dropins/storefront-payment-services/render.js';
+import * as orderApi from '@dropins/storefront-order/api.js';
+
+const cart = events.lastPayload('checkout/initialized');
+
+if (cart) {
+  const $content = document.createElement('div');
+  PaymentServices.render(ApplePay, {
+    getCartId: async () => cart.id,
+    isVirtualCart: cart.isVirtual,
+    onSuccess: () => orderApi.placeOrder(cart.id),
+    onError: (error) => { console.error(error) },
+  })($content);
+}
+```

--- a/src/content/docs/dropins/payment-services/containers/apple-pay.mdx
+++ b/src/content/docs/dropins/payment-services/containers/apple-pay.mdx
@@ -19,7 +19,7 @@ The `ApplePay` container provides the following configuration options:
     ['getCartId', 'function', 'Yes', 'Should return a promise that resolves to the shopper`s cart ID.'],
     ['isVirtualCart', 'boolean', 'Yes', 'Whether the cart contains only virtual/downloadable products.'],
     ['onButtonClick', 'function', 'No', 'Called when the user clicks the Apple Pay button. The callback receives a "showPaymentSheet" function as its only argument that must be called to begin the Apple Pay session and show the payment sheet. If no "onButtonClick" handler is provided, the Apple Pay session will begin and the payment sheet will show on click, always.'],
-    ['onSuccess', 'function', 'No', 'Called when the payment flow finishes successfully. If the function returns a promise, the promise will be awaited before showing marking the payment as "completed successfully" in the Apple Pay sheet. If the promise rejects, the payment will be marked as "failed" in the Apple Pay sheet and the error will be propagated to the "onError" callback, if provided.'],
+    ['onSuccess', 'function', 'No', 'Called when the payment flow finishes successfully. If the function returns a promise, the promise will be awaited before marking the payment as "completed successfully" in the Apple Pay sheet. If the promise rejects, the payment will be marked as "failed" in the Apple Pay sheet and the error will be propagated to the "onError" callback, if provided.'],
     ['onError', 'function', 'No', 'Called when the payment flow was aborted due to an error. The function receives a single argument, {message: string}, containing the reason of error.'],
   ]}
 />

--- a/src/content/docs/dropins/payment-services/containers/credit-card.mdx
+++ b/src/content/docs/dropins/payment-services/containers/credit-card.mdx
@@ -15,9 +15,7 @@ The `CreditCard` container provides the following configuration options:
   compact
   options={[
     ['Option', 'Type', 'Req?', 'Description'],
-    ['apiUrl', 'string', 'Yes', 'The URL to the Adobe Commerce GraphQL endpoint, such as "https://example.com/graphql".'],
     ['getCartId', 'function', 'Yes', 'Should return a promise that resolves to the shopper`s cart ID.'],
-    ['getCustomerToken', 'function', 'Yes', 'The credit card container may send GraphQL requests on behalf of the shopper. This requires GraphQL authorization, which can be performed using authorization tokens or session cookies. For token-based authorization, the "getCustomerToken" function should return a customer token as a string, or null for guest checkouts. For session-based authorization, the "getCustomerToken" property must explicitly be set to "null".'],
     ['creditCardFormRef', 'object', 'Yes', 'Credit card form reference. Initially, { current: null } should be passed. Once rendered, the credit card container will set the "current" property to an { validate: () => boolean; submit: () => Promise<void> } object, which parent containers can use to (programmatically) validate and submit the credit card form.'],
     ['onSuccess', 'function', 'No', 'Called when the payment flow finishes successfully. This function is not passed any arguments.'],
     ['onError', 'function', 'No', 'Called when the payment flow was aborted due to an error. The function receives a single argument, {message: string}, containing the reason of error.'],
@@ -31,24 +29,19 @@ The following example shows how to render and submit a credit card form.
 ```js
 import CreditCard from '@dropins/storefront-payment-services/containers/CreditCard.js';
 import { render as PaymentServices } from '@dropins/storefront-payment-services/render.js';
-import { getUserTokenCookie } from '../../scripts/initializers/index.js';
-import { getConfigValue } from '../../scripts/configs.js';
 
-const commerceCoreEndpoint = await getConfigValue('commerce-core-endpoint');
 const $content = document.createElement('div');
 const creditCardFormRef = { current: null };
 const placeOrderButton = document.getElementById('place-order');
 
 PaymentServices.render(CreditCard, {
-  apiUrl: commerceCoreEndpoint,
-  getCustomerToken: getUserTokenCookie,
-  getCartId: () => 'ozGi7uLI74etDYyMijoI2cla5CmGIBch',
+  getCartId: async () => 'ozGi7uLI74etDYyMijoI2cla5CmGIBch',
   creditCardFormRef: creditCardFormRef,
 })($content);
 
 placeOrderButton.onclick = () => {
   if (creditCardFormRef.current) {
-    if (creditCardFormRef.current.validate() {
+    if (creditCardFormRef.current.validate()) {
       const future = creditCardFormRef.current.submit()
       future.catch(console.error)
     }

--- a/src/content/docs/dropins/payment-services/dictionary.mdx
+++ b/src/content/docs/dropins/payment-services/dictionary.mdx
@@ -3,7 +3,6 @@ title: Payment Services dictionary
 description: Learn how to customize the default dictionary for the Payment Service drop-in component.
 ---
 
-import CodeImport from '@components/CodeImport.astro';
 import CodeInclude from '@components/CodeInclude.astro';
 import dictionary from '@dropins/storefront-payment-services/i18n/en_US.json.d.ts?raw';
 

--- a/src/content/docs/dropins/payment-services/index.mdx
+++ b/src/content/docs/dropins/payment-services/index.mdx
@@ -9,7 +9,7 @@ The Payment Services drop-in component renders the credit card form and the Appl
 
 The Payment Services drop-in component provides two containers:
 
-- **Credit card container**: the [`CreditCard`](/dropins/payment-services/containers/credit-card) container renders a form that shoppers can enter their card details in to place an order using a credit or debit card.
+- **Credit card container:** The `CreditCard` container renders a form where shoppers enter their card details to place an order with a credit or debit card.
 
 - **Apple pay container**: the [`ApplePay`](/dropins/payment-services/containers/apple-pay) container renders an Apple Pay button that shoppers can use on Apple devices to place an order using Apple Pay.
 

--- a/src/content/docs/dropins/payment-services/index.mdx
+++ b/src/content/docs/dropins/payment-services/index.mdx
@@ -3,16 +3,15 @@ title: Payment Services overview
 description: Learn about the features of the Payment Services drop-in component.
 ---
 
-import Link from '@components/Link.astro';
-import List from '@components/List.astro';
-
-The Payment Services drop-in component renders the credit card form, allowing shoppers to efficiently enter their payment details. The drop-in currently supports credit/debit cards only.
+The Payment Services drop-in component renders the credit card form and the apple pay button.
 
 ## Available containers
 
-The Payment Services drop-in component uses one container, `CreditCard`:
+The Payment Services drop-in component provides two containers:
 
-- **Credit card container**: The [`CreditCard`](/dropins/payment-services/containers/credit-card) container is designed to allow placing an order with the credit card details during the checkout process.
+- **Credit card container**: the [`CreditCard`](/dropins/payment-services/containers/credit-card) container renders a form that shoppers can enter their card details in to place an order using a credit or debit card.
+
+- **Apple pay container**: the [`ApplePay`](/dropins/payment-services/containers/apple-pay) container renders an Apple Pay button that shoppers can use on Apple devices to place an order using Apple Pay.
 
 ## Additional resources
 

--- a/src/content/docs/dropins/payment-services/index.mdx
+++ b/src/content/docs/dropins/payment-services/index.mdx
@@ -11,7 +11,7 @@ The Payment Services drop-in component provides two containers:
 
 - **Credit card container:** The `CreditCard` container renders a form where shoppers enter their card details to place an order with a credit or debit card.
 
-- **Apple pay container**: the [`ApplePay`](/dropins/payment-services/containers/apple-pay) container renders an Apple Pay button that shoppers can use on Apple devices to place an order using Apple Pay.
+- **Apple Pay container:** The `ApplePay` container renders an Apple Pay button that shoppers on Apple devices can use to place an order.
 
 ## Additional resources
 

--- a/src/content/docs/dropins/payment-services/index.mdx
+++ b/src/content/docs/dropins/payment-services/index.mdx
@@ -3,7 +3,7 @@ title: Payment Services overview
 description: Learn about the features of the Payment Services drop-in component.
 ---
 
-The Payment Services drop-in component renders the credit card form and the apple pay button.
+The Payment Services drop-in component renders the credit card form and the Apple pay button.
 
 ## Available containers
 

--- a/src/content/docs/dropins/payment-services/initialization.mdx
+++ b/src/content/docs/dropins/payment-services/initialization.mdx
@@ -26,7 +26,7 @@ The Payment Services drop-in initializer is fully asynchronous. Even if mounted 
 
 ## Payment method availability
 
-The Payment Services drop-in will emit a custom `payment-services/method-available` event for every payment method that is determined to be available during the asynchronous initialization process. The event payload is a single string containing the payment method code.
+During asynchronous initialization, the Payment Services drop-in emits a `payment-services/method-available` event for each available payment method. The event payload is a single string containing the payment method code.
 
 ## Example
 

--- a/src/content/docs/dropins/payment-services/initialization.mdx
+++ b/src/content/docs/dropins/payment-services/initialization.mdx
@@ -22,7 +22,7 @@ The Payment Services component initializer accepts the following configuration o
 
 ## Initialization is asynchronous
 
-The Payment Services drop-in initializer is completely asynchronous. Even if mounted immediately, the drop-in will initialize in the background and notify initialization updates through custom events.
+The Payment Services drop-in initializer is fully asynchronous. Even if mounted immediately, it initializes in the background and emits initialization updates via custom events.
 
 ## Payment method availability
 

--- a/src/content/docs/dropins/payment-services/initialization.mdx
+++ b/src/content/docs/dropins/payment-services/initialization.mdx
@@ -1,0 +1,43 @@
+---
+title: Payment Services initialization
+description: Learn about the configuration options for the Payment Services drop-in initializer.
+---
+
+import OptionsTable from '@components/OptionsTable.astro';
+
+The Payment Services drop-in component initializer provides options for setting the backend endpoint and configuring language definitions.
+
+## Configuration options
+
+The Payment Services component initializer accepts the following configuration options:
+
+<OptionsTable
+  options={[
+    ['Option', 'Type', 'Req?', 'Description'],
+    ['apiUrl', 'string', 'Yes', 'The Adobe Commerce GraphQL endpoint URL, such as "https://example.com/graphql".'],
+    ['getCustomerToken', 'function', 'Yes', 'The Payment Services drop-in component may send GraphQL requests on behalf of the shopper. This requires GraphQL authorization, which can be performed using authorization tokens or session cookies. For token-based authorization, the "getCustomerToken" function should return a customer token as a string, or null for guest customers. For session-based authorization, the "getCustomerToken" property must explicitly be set to "null".'],
+    ['langDefinitions', 'object', 'No', 'Provides language definitions for internationalization (i18n).'],
+  ]}
+/>
+
+## Initialization is asynchronous
+
+The Payment Services drop-in initializer is completely asynchronous. Even if mounted immediately, the drop-in will initialize in the background and notify initialization updates through custom events.
+
+## Payment method availability
+
+The Payment Services drop-in will emit a custom `payment-services/method-available` event for every payment method that is determined to be available during the asynchronous initialization process. The event payload is a single string containing the payment method code.
+
+## Example
+
+```javascript
+await initializeDropin(async () => {
+  const coreEndpoint = await getConfigValue('commerce-core-endpoint');
+  const getUserTokenCookie = () => getCookie('auth_dropin_user_token');
+
+  return initializers.mountImmediately(initialize, {
+    apiUrl: coreEndpoint,
+    getCustomerToken: getUserTokenCookie,
+  });
+})();
+```

--- a/src/content/docs/dropins/payment-services/installation.mdx
+++ b/src/content/docs/dropins/payment-services/installation.mdx
@@ -29,7 +29,7 @@ The following steps explain how to register your storefront domain with Apple, w
 
   <Task>
     ### Serve as binary content
-    Add the file to the following path in your storefront repository. Note the added `.bin` extension, which (as of today) is the only way we have in EDS to serve binary content.
+Add the file to the following path in your storefront repository. Note the added `.bin` extension, which is currently the only way we have in EDS to serve binary content.
     ```txt showLineNumbers=false
     /.well-known/apple-developer-merchantid-domain-association.bin
     ```

--- a/src/content/docs/dropins/payment-services/installation.mdx
+++ b/src/content/docs/dropins/payment-services/installation.mdx
@@ -12,7 +12,7 @@ import Tasks from '@components/Tasks.astro';
 This guide explains how to install and configure the Payment Services drop-in component in your storefront.
 
 ## Payment Services extension <Badge tooltip="Applies to Adobe Commerce on Cloud projects (Adobe-managed PaaS infrastructure) and on-premises projects only." text="PaaS only" variant="note" href="https://experienceleague.adobe.com/en/docs/commerce/user-guides/product-solutions" />
-The Payment Services drop-in component requires version <Link href="https://experienceleague.adobe.com/en/docs/commerce/payment-services/release-notes#v2100" text="2.10.0" /> or higher of the Payment Services extension.
+The Payment Services drop-in requires the Payment Services extension version <Link href="https://experienceleague.adobe.com/en/docs/commerce/payment-services/release-notes#v2100" text="2.10.0" /> or higher.
 
 ## Onboard to Payment Services
 Before you can use the Payment Services component on your storefront, you must <Link href="https://experienceleague.adobe.com/en/docs/commerce/payment-services/get-started/onboard" text="onboard" /> to Payment Services in the Adobe Commerce Admin.

--- a/src/content/docs/dropins/payment-services/installation.mdx
+++ b/src/content/docs/dropins/payment-services/installation.mdx
@@ -15,21 +15,21 @@ This guide explains how to install and configure the Payment Services drop-in co
 Before you can use the Payment Services component in your storefront, you must <Link href="https://experienceleague.adobe.com/en/docs/commerce/payment-services/get-started/onboard" text="onboard" /> to Payment Services in the Adobe Commerce Admin.
 
 <Aside type="note" title="Payment Services extension">
-  <Badge tooltip="Applies to Adobe Commerce on Cloud projects (Adobe-managed PaaS infrastructure) and on-premises projects only." text="PaaS only" variant="note" href="https://experienceleague.adobe.com/en/docs/commerce/user-guides/product-solutions" /> The Payment Services drop-in requires the Payment Services extension version <Link href="https://experienceleague.adobe.com/en/docs/commerce/payment-services/release-notes#v2100" text="2.10.0" /> or higher.
+  The Payment Services drop-in requires the Payment Services extension version <Link href="https://experienceleague.adobe.com/en/docs/commerce/payment-services/release-notes#v2100" text="2.10.0" /> or higher. <Badge tooltip="Applies to Adobe Commerce on Cloud projects (Adobe-managed PaaS infrastructure) and on-premises projects only." text="PaaS only" variant="note" href="https://experienceleague.adobe.com/en/docs/commerce/user-guides/product-solutions" />
 </Aside>
 
-## Apple Pay domain verification file <Badge tooltip="Applies to Adobe Commerce as a Cloud Service and Adobe Commerce Optimizer projects only (Adobe-managed SaaS infrastructure)." text="SaaS only" variant="success" href="https://experienceleague.adobe.com/en/docs/commerce/user-guides/product-solutions" />
+## Register your storefront domain with Apple
 The following steps explain how to register your storefront domain with Apple, which is required to use Apple Pay.
 
 <Tasks>
   <Task>
-    ### Download the file
+    ### Download the file <Badge tooltip="Applies to Adobe Commerce as a Cloud Service and Adobe Commerce Optimizer projects only (Adobe-managed SaaS infrastructure)." text="SaaS only" variant="success" href="https://experienceleague.adobe.com/en/docs/commerce/user-guides/product-solutions" />
     Download the Apple Pay domain verification file.
     <Link href="https://paypalobjects.com/devdoc/apple-pay/well-known/apple-developer-merchantid-domain-association" text="Click to download" />.
   </Task>
 
   <Task>
-    ### Serve as binary content
+    ### Serve as binary content <Badge tooltip="Applies to Adobe Commerce as a Cloud Service and Adobe Commerce Optimizer projects only (Adobe-managed SaaS infrastructure)." text="SaaS only" variant="success" href="https://experienceleague.adobe.com/en/docs/commerce/user-guides/product-solutions" />
 Add the file to the following path in your storefront repository. Note the added `.bin` extension, which is currently the only way we have in EDS to serve binary content.
     ```txt showLineNumbers=false
     /.well-known/apple-developer-merchantid-domain-association.bin
@@ -37,20 +37,30 @@ Add the file to the following path in your storefront repository. Note the added
   </Task>
 
   <Task>
-    ### Register sandbox domain
-Add a <Link href="https://www.aem.live/docs/redirects" text="redirect" /> to make the domain verification file accessible at `https://your-sandbox-domain.com/.well-known/apple-developer-merchantid-domain-association`. Once the redirect is in place, contact your sales representative to register the sandbox domain with Apple.
+    ### Set up URL redirect <Badge tooltip="Applies to Adobe Commerce as a Cloud Service and Adobe Commerce Optimizer projects only (Adobe-managed SaaS infrastructure)." text="SaaS only" variant="success" href="https://experienceleague.adobe.com/en/docs/commerce/user-guides/product-solutions" />
+Add a <Link href="https://www.aem.live/docs/redirects" text="redirect" /> to make the domain verification file accessible at `https://your-sandbox-domain.com/.well-known/apple-developer-merchantid-domain-association`.
 
     | Source                                                    | Destination                                                    |
     |-----------------------------------------------------------|----------------------------------------------------------------|
     | .well-known/apple-developer-merchantid-domain-association | /.well-known/apple-developer-merchantid-domain-association.bin |
 
     <Aside type="caution" title="Sandbox only">
-Serving the file via a redirect works for sandbox domain registration, but not for production. In production, the file must be served directly, without a redirect.
+      Serving the file via a redirect works for sandbox domain registration, but not for production. In production, the file [must be served directly](#set-up-production-url-rewrite), without a redirect.
     </Aside>
   </Task>
 
   <Task>
+    ### Register sandbox domain
+Contact your sales representative to register the sandbox domain with Apple.
+  </Task>
+
+  <Task>
+    ### Set up production URL rewrite <Badge tooltip="Applies to Adobe Commerce as a Cloud Service and Adobe Commerce Optimizer projects only (Adobe-managed SaaS infrastructure)." text="SaaS only" variant="success" href="https://experienceleague.adobe.com/en/docs/commerce/user-guides/product-solutions" />
+Set up a <Link href="/setup/configuration/content-delivery-network/#url-rewrites" text="URL rewrite" /> at the CDN level to make the domain verification file directly accessible at https://your-production-domain.com/.well-known/apple-developer-merchantid-domain-association, without redirects.
+  </Task>
+
+  <Task>
     ### Register production domain
-Set up a <Link href="/setup/configuration/content-delivery-network/#url-rewrites" text="URL rewrite" /> at the CDN level to make the domain verification file directly accessible at https://your-production-domain.com/.well-known/apple-developer-merchantid-domain-association, without redirects. After the rewrite is in place, contact your sales representative to register the production domain with Apple.
+Contact your sales representative to register the production domain with Apple.
   </Task>
 </Tasks>

--- a/src/content/docs/dropins/payment-services/installation.mdx
+++ b/src/content/docs/dropins/payment-services/installation.mdx
@@ -18,7 +18,7 @@ The Payment Services drop-in requires the Payment Services extension version <Li
 Before you can use the Payment Services component in your storefront, you must <Link href="https://experienceleague.adobe.com/en/docs/commerce/payment-services/get-started/onboard" text="onboard" /> to Payment Services in the Adobe Commerce Admin.
 
 ## Apple Pay domain verification file <Badge tooltip="Applies to Adobe Commerce as a Cloud Service and Adobe Commerce Optimizer projects only (Adobe-managed SaaS infrastructure)." text="SaaS only" variant="success" href="https://experienceleague.adobe.com/en/docs/commerce/user-guides/product-solutions" />
-The following steps show how to register your storefront domain with Apple, which is required for using Apple Pay.
+The following steps explain how to register your storefront domain with Apple, which is required to use Apple Pay.
 
 <Tasks>
   <Task>

--- a/src/content/docs/dropins/payment-services/installation.mdx
+++ b/src/content/docs/dropins/payment-services/installation.mdx
@@ -9,7 +9,7 @@ import Link from '@components/Link.astro';
 import Task from '@components/Task.astro';
 import Tasks from '@components/Tasks.astro';
 
-This guide will help you install and configure the Payment Services drop-in component in your storefront.
+This guide explains how to install and configure the Payment Services drop-in component in your storefront.
 
 ## Payment Services extension <Badge tooltip="Applies to Adobe Commerce on Cloud projects (Adobe-managed PaaS infrastructure) and on-premises projects only." text="PaaS only" variant="note" href="https://experienceleague.adobe.com/en/docs/commerce/user-guides/product-solutions" />
 The Payment Services drop-in component requires version <Link href="https://experienceleague.adobe.com/en/docs/commerce/payment-services/release-notes#v2100" text="2.10.0" /> or higher of the Payment Services extension.

--- a/src/content/docs/dropins/payment-services/installation.mdx
+++ b/src/content/docs/dropins/payment-services/installation.mdx
@@ -44,7 +44,7 @@ Add a <Link href="https://www.aem.live/docs/redirects" text="redirect" /> to mak
     | .well-known/apple-developer-merchantid-domain-association | /.well-known/apple-developer-merchantid-domain-association.bin |
 
     <Aside type="caution" title="Sandbox only">
-      Serving the file behind a redirect works for sandbox domain registration but not for production. For production, the file must be served directly, without a redirect.
+Serving the file via a redirect works for sandbox domain registration, but not for production. In production, the file must be served directly, without a redirect.
     </Aside>
   </Task>
 

--- a/src/content/docs/dropins/payment-services/installation.mdx
+++ b/src/content/docs/dropins/payment-services/installation.mdx
@@ -37,7 +37,7 @@ Add the file to the following path in your storefront repository. Note the added
 
   <Task>
     ### Register sandbox domain
-    Add a <Link href="https://www.aem.live/docs/redirects" text="redirect" /> to make the domain verification file accessible on https://your-sandbox-domain.com/.well-known/apple-developer-merchantid-domain-association. Once the redirect is in place, contact your sales representative to register the sandbox domain with Apple.
+Add a <Link href="https://www.aem.live/docs/redirects" text="redirect" /> to make the domain verification file accessible at `https://your-sandbox-domain.com/.well-known/apple-developer-merchantid-domain-association`. Once the redirect is in place, contact your sales representative to register the sandbox domain with Apple.
 
     | Source                                                    | Destination                                                    |
     |-----------------------------------------------------------|----------------------------------------------------------------|

--- a/src/content/docs/dropins/payment-services/installation.mdx
+++ b/src/content/docs/dropins/payment-services/installation.mdx
@@ -50,6 +50,6 @@ Serving the file via a redirect works for sandbox domain registration, but not f
 
   <Task>
     ### Register production domain
-    Set up a <Link href="/setup/configuration/content-delivery-network/#url-rewrites" text="URL rewrite" /> at the CDN level to make the domain verification file directly accessible on https://your-production-domain.com/.well-known/apple-developer-merchantid-domain-association, without redirects. Once the URL rewrite is in place, contact your sales representative to register the production domain with Apple.
+Set up a <Link href="/setup/configuration/content-delivery-network/#url-rewrites" text="URL rewrite" /> at the CDN level to make the domain verification file directly accessible at https://your-production-domain.com/.well-known/apple-developer-merchantid-domain-association, without redirects. After the rewrite is in place, contact your sales representative to register the production domain with Apple.
   </Task>
 </Tasks>

--- a/src/content/docs/dropins/payment-services/installation.mdx
+++ b/src/content/docs/dropins/payment-services/installation.mdx
@@ -11,11 +11,12 @@ import Tasks from '@components/Tasks.astro';
 
 This guide explains how to install and configure the Payment Services drop-in component in your storefront.
 
-## Payment Services extension <Badge tooltip="Applies to Adobe Commerce on Cloud projects (Adobe-managed PaaS infrastructure) and on-premises projects only." text="PaaS only" variant="note" href="https://experienceleague.adobe.com/en/docs/commerce/user-guides/product-solutions" />
-The Payment Services drop-in requires the Payment Services extension version <Link href="https://experienceleague.adobe.com/en/docs/commerce/payment-services/release-notes#v2100" text="2.10.0" /> or higher.
-
 ## Onboard to Payment Services
 Before you can use the Payment Services component in your storefront, you must <Link href="https://experienceleague.adobe.com/en/docs/commerce/payment-services/get-started/onboard" text="onboard" /> to Payment Services in the Adobe Commerce Admin.
+
+<Aside type="note" title="Payment Services extension">
+  <Badge tooltip="Applies to Adobe Commerce on Cloud projects (Adobe-managed PaaS infrastructure) and on-premises projects only." text="PaaS only" variant="note" href="https://experienceleague.adobe.com/en/docs/commerce/user-guides/product-solutions" /> The Payment Services drop-in requires the Payment Services extension version <Link href="https://experienceleague.adobe.com/en/docs/commerce/payment-services/release-notes#v2100" text="2.10.0" /> or higher.
+</Aside>
 
 ## Apple Pay domain verification file <Badge tooltip="Applies to Adobe Commerce as a Cloud Service and Adobe Commerce Optimizer projects only (Adobe-managed SaaS infrastructure)." text="SaaS only" variant="success" href="https://experienceleague.adobe.com/en/docs/commerce/user-guides/product-solutions" />
 The following steps explain how to register your storefront domain with Apple, which is required to use Apple Pay.

--- a/src/content/docs/dropins/payment-services/installation.mdx
+++ b/src/content/docs/dropins/payment-services/installation.mdx
@@ -3,16 +3,53 @@ title: Payment Services installation
 description: Learn how to install the Payment Services drop-in component on your site.
 ---
 
-import OptionsTable from '@components/OptionsTable.astro';
+import Aside from '@components/Aside.astro';
+import Badge from '@components/overrides/Badge.astro';
+import Link from '@components/Link.astro';
+import Task from '@components/Task.astro';
+import Tasks from '@components/Tasks.astro';
 
-Before you can use the Payment Services component on your storefront, you must [configure the Services Connector](https://experienceleague.adobe.com/en/docs/commerce-learn/tutorials/admin/adobe-commerce-services/configure-adobe-commerce-services-connector) and [onboard](https://experienceleague.adobe.com/en/docs/commerce/payment-services/get-started/onboard) the Payment Services extension in the Adobe Commerce Admin.
+This guide will help you install and configure the Payment Services drop-in component in your storefront.
 
-:::note
-The Payment Services drop-in component requires the [Payment Services extension](https://experienceleague.adobe.com/en/docs/commerce/payment-services/release-notes#v2100) version 2.10.0 or higher.
-:::
+## Payment Services extension <Badge tooltip="Applies to Adobe Commerce on Cloud projects (Adobe-managed PaaS infrastructure) and on-premises projects only." text="PaaS only" variant="note" href="https://experienceleague.adobe.com/en/docs/commerce/user-guides/product-solutions" />
+The Payment Services drop-in component requires version <Link href="https://experienceleague.adobe.com/en/docs/commerce/payment-services/release-notes#v2100" text="2.10.0" /> or higher of the Payment Services extension.
 
-## Installation
+## Onboard to Payment Services
+Before you can use the Payment Services component on your storefront, you must <Link href="https://experienceleague.adobe.com/en/docs/commerce/payment-services/get-started/onboard" text="onboard" /> to Payment Services in the Adobe Commerce Admin.
 
-The Payment Services component relies on containers from several other drop-in components, you must install and configure those components before you can use the Payment Services component to place an order.
+## Apple Pay domain verification file <Badge tooltip="Applies to Adobe Commerce as a Cloud Service and Adobe Commerce Optimizer projects only (Adobe-managed SaaS infrastructure)." text="SaaS only" variant="success" href="https://experienceleague.adobe.com/en/docs/commerce/user-guides/product-solutions" />
+The following steps show how to register your storefront domain with Apple, which is required for using Apple Pay.
 
-The [Commerce boilerplate template](https://github.com/hlxsites/aem-boilerplate-commerce) includes all of the necessary drop-in components and configurations to help you get started quickly, so Adobe recommends relying on the boilerplate instead of installing, configuring, and integrating the drop-in components individually.
+<Tasks>
+  <Task>
+    ### Download the file
+    Download the Apple Pay domain verification file.
+    <Link href="https://paypalobjects.com/devdoc/apple-pay/well-known/apple-developer-merchantid-domain-association" text="Click to download" />.
+  </Task>
+
+  <Task>
+    ### Serve as binary content
+    Add the file to the following path in your storefront repository. Note the added `.bin` extension, which (as of today) is the only way we have in EDS to serve binary content.
+    ```txt showLineNumbers=false
+    /.well-known/apple-developer-merchantid-domain-association.bin
+    ```
+  </Task>
+
+  <Task>
+    ### Register sandbox domain
+    Add a <Link href="https://www.aem.live/docs/redirects" text="redirect" /> to make the domain verification file accessible on https://your-sandbox-domain.com/.well-known/apple-developer-merchantid-domain-association. Once the redirect is in place, contact your sales representative to register the sandbox domain with Apple.
+
+    | Source                                                    | Destination                                                    |
+    |-----------------------------------------------------------|----------------------------------------------------------------|
+    | .well-known/apple-developer-merchantid-domain-association | /.well-known/apple-developer-merchantid-domain-association.bin |
+
+    <Aside type="caution" title="Sandbox only">
+      Serving the file behind a redirect works for sandbox domain registration but not for production. For production, the file must be served directly, without a redirect.
+    </Aside>
+  </Task>
+
+  <Task>
+    ### Register production domain
+    Set up a <Link href="/setup/configuration/content-delivery-network/#url-rewrites" text="URL rewrite" /> at the CDN level to make the domain verification file directly accessible on https://your-production-domain.com/.well-known/apple-developer-merchantid-domain-association, without redirects. Once the URL rewrite is in place, contact your sales representative to register the production domain with Apple.
+  </Task>
+</Tasks>

--- a/src/content/docs/dropins/payment-services/installation.mdx
+++ b/src/content/docs/dropins/payment-services/installation.mdx
@@ -15,7 +15,7 @@ This guide explains how to install and configure the Payment Services drop-in co
 The Payment Services drop-in requires the Payment Services extension version <Link href="https://experienceleague.adobe.com/en/docs/commerce/payment-services/release-notes#v2100" text="2.10.0" /> or higher.
 
 ## Onboard to Payment Services
-Before you can use the Payment Services component on your storefront, you must <Link href="https://experienceleague.adobe.com/en/docs/commerce/payment-services/get-started/onboard" text="onboard" /> to Payment Services in the Adobe Commerce Admin.
+Before you can use the Payment Services component in your storefront, you must <Link href="https://experienceleague.adobe.com/en/docs/commerce/payment-services/get-started/onboard" text="onboard" /> to Payment Services in the Adobe Commerce Admin.
 
 ## Apple Pay domain verification file <Badge tooltip="Applies to Adobe Commerce as a Cloud Service and Adobe Commerce Optimizer projects only (Adobe-managed SaaS infrastructure)." text="SaaS only" variant="success" href="https://experienceleague.adobe.com/en/docs/commerce/user-guides/product-solutions" />
 The following steps show how to register your storefront domain with Apple, which is required for using Apple Pay.


### PR DESCRIPTION
## Purpose of this pull request

Update Payment Services documentation to include breaking drop-in initialization changes and new Apple Pay container, which is currently available in NPM as a V2-alpha release: https://www.npmjs.com/package/@dropins/storefront-payment-services/v/2.0.0-alpha1.

## Changes

Main changes
- Add `containers/apple-pay/` page to document new apple pay container
- Add `initialization/` page to document new init config & method availability events
- Update installation page to include apple pay domain verification instructions
- Remove `apiUrl` and `getCustomerToken` props from credit card container page
- Add apple pay to payment services overview page (alongside credit card)

Boy-scouting
- Remove unused import (CodeImport) from dictionary.mdx

### Associated JIRA ticket

https://jira.corp.adobe.com/browse/PAY-6182


### Staging preview

Not available.


## Affected pages

- https://experienceleague.adobe.com/developer/commerce/storefront/dropins/payment-services/
- https://experienceleague.adobe.com/developer/commerce/storefront/dropins/payment-services/installation/
- https://experienceleague.adobe.com/developer/commerce/storefront/dropins/payment-services/containers/credit-card/
- https://experienceleague.adobe.com/developer/commerce/storefront/dropins/payment-services/dictionary/ *

_\* will be updated automatically when we release the public version of the npm package_


## Links to source code

- https://github.com/adobe-commerce/storefront-payment-services/pull/5
- https://github.com/adobe-commerce/storefront-payment-services/pull/7
- https://github.com/adobe-commerce/storefront-payment-services/pull/8
