### PR TITLE
Correct SCP version

### DIFF
--- a/src/content/docs/releases/changelog.mdx
+++ b/src/content/docs/releases/changelog.mdx
@@ -315,7 +315,7 @@ import ChangelogEntry from '@components/changelog/ChangelogEntry.astro';
 
     <ChangelogEntry
       date="2025-08-12"
-      title="Storefront Compatibility Package v4.8.5, v4.7.9"
+      title="Storefront Compatibility Package v4.8.6, v4.7.9"
       components={['Storefront Compatibility Package']}
     >
       The Storefront Compatibility Package has been updated to include the following changes:


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the version of the SCP to 4.8.6. 

### Associated JIRA ticket

<!--OPTIONAL Add link to JIRA ticket associated with update.-->


### Staging preview

<!--OPTIONAL Link to staging preview if available-->


## Affected pages

<!-- REQUIRED List the affected pages on experienceleague.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to source code

<!--OPTIONAL Link to any associated source code PRs related to update-->

