### PR TITLE
Add AC-Source-Locale header back to Optimizer config

### DIFF
--- a/src/content/docs/get-started/index.mdx
+++ b/src/content/docs/get-started/index.mdx
@@ -195,8 +195,8 @@ Edge Delivery Services requires site configuration details to know what to rende
 
 </Steps>
 
-<Aside type="note" title="Config Service Approach">
-After you have created your storefront, you can migrate the configuration to use the Configuration Service which supports advanced    use cases like repoless configuration and overlays. For more information, see the [Configuration Service]   (https://www.aem.live/docs/config-service-setup) documentation.
+<Aside type="note" title="Migrate to the Storefront Configuration Service">
+After you have created your storefront, you can migrate the configuration to use the Configuration Service which supports advanced use cases like repoless configuration and overlays. For more information, see the [Configuration Service](https://www.aem.live/docs/config-service-setup) documentation.
 </Aside>
 
 </Task>

--- a/src/content/docs/setup/configuration/commerce-configuration.mdx
+++ b/src/content/docs/setup/configuration/commerce-configuration.mdx
@@ -203,7 +203,8 @@ This boilerplate `config.json` for Adobe Commerce Optimizer requires correct val
           "Store": "default"
         },
         "cs": {
-          "AC-View-ID": "{{catalogViewUUID}}",
+          "AC-View-ID": "{{catalogViewID}}",
+          "AC-Source-Locale": "en-US",
           "AC-Price-Book-ID": "{{priceBookID}}",            # Optional. Remove if not needed.
           "AC-Policy-{{attributeTrigger}}": "{{attributeValue}}"  # Optional. Remove this header if not needed.
         }


### PR DESCRIPTION
## Purpose of this pull request

Adds the `AC-Source-Locale` header back to Optimizer config.json template.

When COMOPT-1021 is fixed, this header might not be needed.

cc: @sirugh 


### Associated JIRA ticket

[COMOPT-1021](https://jira.corp.adobe.com/browse/COMOPT-1021)


### Staging preview



## Affected pages

https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/commerce-configuration/

## Links to source code

<!--OPTIONAL Link to any associated source code PRs related to update-->

