### PR TITLE
Add product discovery container redirects

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -114,7 +114,11 @@ async function config() {
       '/dropins/all/eventbus': `${basePath}/sdk/reference/events`,
       '/dropins/other/recommendations': `${basePath}/dropins/recommendations`,
       '/dropins/other/search': `${basePath}/dropins/product-discovery`,
-      '/dropins/all/localizing': `${basePath}/dropins/all/labeling`
+      '/dropins/all/localizing': `${basePath}/dropins/all/labeling`,
+      '/dropins/product-discovery/containers/search-bar-results': `${basePath}/dropins/product-discovery/containers/search-results`,
+      '/dropins/product-discovery/containers/search-bar-input': `${basePath}/dropins/product-discovery/containers/search-results`,
+      '/dropins/product-discovery/containers/results-info': `${basePath}/dropins/product-discovery/containers/search-results`,
+      '/dropins/product-discovery/containers/product-list': `${basePath}/dropins/product-discovery/containers/search-results`
     },
     integrations: [
       starlight({


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds redirects for the deleted containers in the Product Discovery drop-in.

### Testing

Pull the branch and run the following deleted page links:
- http://localhost:4322/developer/commerce/storefront/dropins/product-discovery/containers/search-bar-results/
- http://localhost:4322/developer/commerce/storefront/dropins/product-discovery/containers/search-bar-input/
- http://localhost:4322/developer/commerce/storefront/dropins/product-discovery/containers/results-info/
- http://localhost:4322/developer/commerce/storefront/dropins/product-discovery/containers/product-list/

## Affected pages

- /dropins/product-discovery/containers/search-bar-results/
- /dropins/product-discovery/containers/search-bar-input/
- /dropins/product-discovery/containers/results-info/
- /dropins/product-discovery/containers/product-list/
