### PR TITLE
Sidebar and overview updates

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -278,27 +278,28 @@ async function config() {
                       },
                     ],
                   },
-                  // ---------- DROP-INS (B2C) ----------
+                  // ---------- DROP-INS Overview ----------
                   {
-                    label: 'Drop-ins for B2C',
+                    label: 'Drop-ins overview',
                     collapsed: true,
                     items: [
-                      {
-                        label: 'Drop-ins overview',
-                        collapsed: true,
-                        items: [
-                          { label: 'Overview', link: '/dropins/all/introduction/' },
-                          { label: 'Creating', link: '/dropins/all/creating/' },
-                          { label: 'Installing', link: '/dropins/all/installing/' },
-                          { label: 'Branding', link: '/dropins/all/branding/' },
-                          { label: 'Styling', link: '/dropins/all/styling/' },
-                          { label: 'Labeling', link: '/dropins/all/labeling/' },
-                          { label: 'Linking', link: '/dropins/all/linking/' },
-                          { label: 'Slots', link: '/dropins/all/slots/' },
-                          { label: 'Layouts', link: '/dropins/all/layouts/' },
-                          { label: 'Extending', link: '/dropins/all/extending/' },
-                        ],
-                      },
+                      { label: 'Overview', link: '/dropins/all/introduction/' },
+                      { label: 'Creating', link: '/dropins/all/creating/' },
+                      { label: 'Installing', link: '/dropins/all/installing/' },
+                      { label: 'Branding', link: '/dropins/all/branding/' },
+                      { label: 'Styling', link: '/dropins/all/styling/' },
+                      { label: 'Labeling', link: '/dropins/all/labeling/' },
+                      { label: 'Linking', link: '/dropins/all/linking/' },
+                      { label: 'Slots', link: '/dropins/all/slots/' },
+                      { label: 'Layouts', link: '/dropins/all/layouts/' },
+                      { label: 'Extending', link: '/dropins/all/extending/' },
+                    ],
+                  },
+                  // ---------- DROP-INS (B2C) ----------
+                  {
+                    label: 'Drop-ins',
+                    collapsed: true,
+                    items: [
                       {
                         label: 'Cart',
                         collapsed: true,

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -219,8 +219,8 @@ async function config() {
                     collapsed: false,
                     items: [
                       { label: 'Overview', link: '/get-started/' },
-                      { label: 'Learn the architecture', link: '/setup/discovery/architecture/' },
                       { label: 'Create a storefront', link: '/get-started/create-storefront' },
+                      { label: 'Learn the architecture', link: '/setup/discovery/architecture/' },
                       { label: 'Explore the boilerplate', link: '/get-started/boilerplate-project/' },
                       { label: 'Run Lighthouse audits', link: '/get-started/run-lighthouse/' },
                     ],
@@ -245,6 +245,18 @@ async function config() {
                         ],
                       },
                       {
+                        label: 'Advanced setup',
+                        collapsed: true,
+                        items: [
+                          { label: 'Multistore setup', link: '/setup/configuration/multistore-setup/' },
+                          {
+                            label: 'Luma Bridge',
+                            collapsed: true,
+                            items: [{ label: 'Introduction to Luma Bridge', link: '/setup/discovery/luma-bridge/' }],
+                          },
+                        ],
+                      },
+                      {
                         label: 'Compatibility package',
                         collapsed: true,
                         items: [
@@ -266,19 +278,6 @@ async function config() {
                       },
                     ],
                   },
-                  {
-                    label: 'Integrations',
-                    collapsed: true,
-                    items: [
-                      { label: 'Multistore setup', link: '/setup/configuration/multistore-setup/' },
-                      {
-                        label: 'Luma Bridge',
-                        collapsed: true,
-                        items: [{ label: 'Introduction to Luma Bridge', link: '/setup/discovery/luma-bridge/' }],
-                      },
-                    ],
-                  },
-
                   // ---------- DROP-INS (B2C) ----------
                   {
                     label: 'Drop-ins for B2C',

--- a/src/content/docs/dropins/all/slots.mdx
+++ b/src/content/docs/dropins/all/slots.mdx
@@ -1,6 +1,6 @@
 ---
-title: Understanding slots
-description: Learn about slots and how to use them to customize drop-in components.
+title: Using drop-in slots
+description: Learn how to use drop-in slots to customize drop-in components.
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';
@@ -12,7 +12,7 @@ import { Steps } from '@astrojs/starlight/components';
 import Tasks from '@components/Tasks.astro';
 import Task from '@components/Task.astro';
 
-Using slots provides the deepest level of customization. Slots are built-in extension points in the drop-in. A slot provides a place in the drop-in component to add your own UI components and functions. This architecture makes it easy to change the default look, layout, and behavior. Let's learn how it works.
+Using slots provides the deepest level of customization for drop-in components. Slots are built-in extension points in the drop-in. A slot provides a place in the drop-in component to add your own UI components and functions. This architecture makes it easy to change the default look, layout, and behavior. Let's learn how slots work.
 
 ## Big Picture
 


### PR DESCRIPTION
This pull request reorganizes the sidebar a bit more to improve navigation, especially around advanced setup and drop-in components.

### Documentation sidebar restructuring

* Moved "Multistore setup" and "Luma Bridge" out of the "Integrations" section and into the new "Advanced setup" group, removing the now-unnecessary "Integrations" section.

### Content and language improvements

* Updated the title and description in `slots.mdx` for clarity, changing "Understanding slots" to "Using drop-in slots" and refining the description.