### PR TITLE
PAY-6260: Update Apple Pay documentation with PDP integration and examples

### DIFF
--- a/src/content/docs/dropins/payment-services/containers/apple-pay.mdx
+++ b/src/content/docs/dropins/payment-services/containers/apple-pay.mdx
@@ -19,7 +19,6 @@ The `ApplePay` container provides the following configuration options:
     ['location', 'string', 'Yes', 'Location where the Apple Pay button is to be rendered. Must be either "CHECKOUT" or "PRODUCT_DETAIL".'],
     ['getCartId', 'function', 'Maybe', 'Required if createCart not provided. Should return a promise that resolves to the shopper\'s cart ID.'],
     ['createCart', 'object', 'Maybe', 'Required if getCartId not provided. Should have a getCartItems function that returns a list with the cart items to purchase. The list must contain at least one cart item.'],
-    ['isVirtualCart', 'boolean', 'Yes', 'Whether the cart contains only virtual/downloadable products.'],
     ['onButtonClick', 'function', 'No', 'Called when the user clicks the Apple Pay button. The callback receives a "showPaymentSheet" function as its only argument that must be called to begin the Apple Pay session and show the payment sheet. If no "onButtonClick" handler is provided, the Apple Pay session will begin and the payment sheet will show on click, always.'],
     ['onSuccess', 'function', 'No', 'Called when the payment flow finishes successfully. If the function returns a promise, the promise will be awaited before marking the payment as "completed successfully" in the Apple Pay sheet. If the promise rejects, the payment will be marked as "failed" in the Apple Pay sheet and the error will be propagated to the "onError" callback, if provided.'],
     ['onError', 'function', 'No', 'Called when the payment flow was aborted due to an error. The function receives a single argument, {message: string}, containing the reason of error.'],
@@ -41,7 +40,6 @@ if (cart) {
   PaymentServices.render(ApplePay, {
     location: PaymentLocation.CHECKOUT,
     getCartId: async () => cart.id,
-    isVirtualCart: cart.isVirtual,
     onSuccess: () => orderApi.placeOrder(cart.id),
     onError: (error) => { console.error(error) },
   })($content);
@@ -69,7 +67,6 @@ if (cart) {
           quantity: 1,
         },
       ]),
-    isVirtualCart: cart.isVirtual,
     onButtonClick: (showPaymentSheet) => showPaymentSheet(),
     onSuccess: () => orderApi.placeOrder(cart.id),
     onError: (error) => { console.error(error) },

--- a/src/content/docs/dropins/payment-services/containers/apple-pay.mdx
+++ b/src/content/docs/dropins/payment-services/containers/apple-pay.mdx
@@ -16,7 +16,9 @@ The `ApplePay` container provides the following configuration options:
   compact
   options={[
     ['Option', 'Type', 'Req?', 'Description'],
-    ['getCartId', 'function', 'Yes', 'Should return a promise that resolves to the shopper`s cart ID.'],
+    ['location', 'string', 'Yes', 'Location where the Apple Pay button is to be rendered. Must be either "CHECKOUT" or "PRODUCT_DETAIL".'],
+    ['getCartId', 'function', 'Maybe', 'Required if createCart not provided. Should return a promise that resolves to the shopper\'s cart ID.'],
+    ['createCart', 'object', 'Maybe', 'Required if getCartId not provided. Should have a getCartItems function that returns a list with the cart items to purchase. The list must contain at least one cart item.'],
     ['isVirtualCart', 'boolean', 'Yes', 'Whether the cart contains only virtual/downloadable products.'],
     ['onButtonClick', 'function', 'No', 'Called when the user clicks the Apple Pay button. The callback receives a "showPaymentSheet" function as its only argument that must be called to begin the Apple Pay session and show the payment sheet. If no "onButtonClick" handler is provided, the Apple Pay session will begin and the payment sheet will show on click, always.'],
     ['onSuccess', 'function', 'No', 'Called when the payment flow finishes successfully. If the function returns a promise, the promise will be awaited before marking the payment as "completed successfully" in the Apple Pay sheet. If the promise rejects, the payment will be marked as "failed" in the Apple Pay sheet and the error will be propagated to the "onError" callback, if provided.'],
@@ -24,20 +26,51 @@ The `ApplePay` container provides the following configuration options:
   ]}
 />
 
-## Example
+## Checkout page example
 
 ```js
 import ApplePay from '@dropins/storefront-payment-services/containers/ApplePay.js';
 import { render as PaymentServices } from '@dropins/storefront-payment-services/render.js';
 import * as orderApi from '@dropins/storefront-order/api.js';
+import { PaymentLocation } from '@dropins/storefront-payment-services/api.js';
 
 const cart = events.lastPayload('checkout/initialized');
 
 if (cart) {
   const $content = document.createElement('div');
   PaymentServices.render(ApplePay, {
+    location: PaymentLocation.CHECKOUT,
     getCartId: async () => cart.id,
     isVirtualCart: cart.isVirtual,
+    onSuccess: () => orderApi.placeOrder(cart.id),
+    onError: (error) => { console.error(error) },
+  })($content);
+}
+```
+
+## Product details page example
+
+```js
+import ApplePay from '@dropins/storefront-payment-services/containers/ApplePay.js';
+import { render as PaymentServices } from '@dropins/storefront-payment-services/render.js';
+import * as orderApi from '@dropins/storefront-order/api.js';
+import { PaymentLocation } from '@dropins/storefront-payment-services/api.js';
+
+const cart = events.lastPayload('pdp/values');
+
+if (cart) {
+  const $content = document.createElement('div');
+  PaymentServices.render(ApplePay, {
+    location: PaymentLocation.PRODUCT_DETAIL,
+    createCart: {
+    getCartItems: async () => ([},
+        {
+          sku: cart.sku,
+          quantity: 1,
+        },
+      ]),
+    isVirtualCart: cart.isVirtual,
+    onButtonClick: (showPaymentSheet) => showPaymentSheet(),
     onSuccess: () => orderApi.placeOrder(cart.id),
     onError: (error) => { console.error(error) },
   })($content);


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds the necessary documentation to be able to serve Apple Pay in the PDP page as well as some updated that also involve Apple Pay in the Checkout page.

### Associated JIRA ticket
https://jira.corp.adobe.com/browse/PAY-6260

## Affected pages

- https://experienceleague.adobe.com/developer/commerce/storefront/dropins/payment-services/containers/apple-pay/ *

 _* Will be posted once the 2.x Dropin version is released_

## Links to source code
Payment Services dropin: [PAY-6260: Add PDP support to Apple Pay container]( https://github.com/adobe-commerce/storefront-payment-services/pull/14)
AEM-Boilerplate (still WIP): [PAY-6150-david-1 branch](https://github.com/hlxsites/aem-boilerplate-commerce/tree/PAY-6150-david-1
)
