### PR TITLE
add links to config generator to configuration page

### DIFF
--- a/src/content/docs/setup/configuration/commerce-configuration.mdx
+++ b/src/content/docs/setup/configuration/commerce-configuration.mdx
@@ -20,6 +20,10 @@ If you [set up your storefront](/get-started/) using the boilerplate code, the t
 
 If you set up your site using the [Site Creator Tool](https://da.live/app/adobe-commerce/storefront-tools/tools/site-creator/site-creator) that automates the site creation process, the `config.json` file is created for you in the GitHub repository created for the boilerplate code. You can review and update the default values in the `config.json` file after the process completes.
 
+:::note
+**Need help configuring your Commerce backend?** Use the [Config Generator tool](https://da.live/app/adobe-commerce/storefront-tools/tools/config-generator/config-generator) to automatically generate the appropriate configuration structure for your Adobe Commerce, Adobe Commerce as a Cloud Service, or Adobe Commerce Optimizer backend. The tool will attempt to detect your backend type and generate the correct configuration, though human validation and confirmation may be required.
+:::
+
 ## Vocabulary
 
 <Vocabulary>
@@ -49,7 +53,7 @@ The `getHeaders` function is a helper function which takes a storefront scope (l
 
 ## Examples
 
-You can find the configuration file in your code repo at either `/config.json` or `/demo-config.json`. The file provides a template with the `keys` and `values` to configure the connection to the Commerce backend.
+You can find the configuration file in your code repo at either `/config.json` or `/demo-config.json`, or use the [Config Generator tool](https://da.live/app/adobe-commerce/storefront-tools/tools/config-generator/config-generator) to automatically generate the appropriate configuration for your backend. The file provides a template with the `keys` and `values` to configure the connection to the Commerce backend.
 
 The required configuration depends on the type of Commerce application that you are connecting to. Select the tabs below to review the available templates.
 

--- a/src/content/docs/setup/configuration/commerce-configuration.mdx
+++ b/src/content/docs/setup/configuration/commerce-configuration.mdx
@@ -21,7 +21,7 @@ If you [set up your storefront](/get-started/) using the boilerplate code, the t
 If you set up your site using the [Site Creator Tool](https://da.live/app/adobe-commerce/storefront-tools/tools/site-creator/site-creator) that automates the site creation process, the `config.json` file is created for you in the GitHub repository created for the boilerplate code. You can review and update the default values in the `config.json` file after the process completes.
 
 :::note
-**Need help configuring your Commerce backend?** Use the [Config Generator tool](https://da.live/app/adobe-commerce/storefront-tools/tools/config-generator/config-generator) to automatically generate the appropriate configuration structure for your Adobe Commerce, Adobe Commerce as a Cloud Service, or Adobe Commerce Optimizer backend. The tool will attempt to detect your backend type and generate the correct configuration, though human validation and confirmation may be required.
+**Need help configuring your Commerce backend?** Use the [Config Generator tool](https://da.live/app/adobe-commerce/storefront-tools/tools/config-generator/config-generator) to automatically generate the appropriate configuration structure for your Adobe Commerce, Adobe Commerce as a Cloud Service, or Adobe Commerce Optimizer backend. The tool will detect your backend type and generate the correct configuration, though you should validate and confirm the results.
 :::
 
 ## Vocabulary


### PR DESCRIPTION
While we had a link to the config generator app on another page (create-storefront), the configuration page did not have a link to the generator. That's easy - let's add it :)

Added here:

<img width="1006" height="665" alt="image" src="https://github.com/user-attachments/assets/8a2b7c8d-3a05-4dac-b768-45eca9a35d5a" />


And here: 

<img width="902" height="135" alt="image" src="https://github.com/user-attachments/assets/01810aea-52cd-4e5a-86f4-f6df2c16884c" />
