### PR TITLE
PAY-6281: Document ApplePay container active & disabled props

### DIFF
--- a/src/content/docs/dropins/payment-services/containers/apple-pay.mdx
+++ b/src/content/docs/dropins/payment-services/containers/apple-pay.mdx
@@ -21,8 +21,8 @@ The `ApplePay` container provides the following configuration options:
     ['createCart', 'object', 'Maybe', 'Required if "getCartId" not provided. The object should define a single "getCartItems" property, which should be a function that returns a list of cart items to purchase. The list must contain at least one cart item. Cart items must be provided as objects with, at minimum, an "sku" (string) and a "quantity" (number). See "Cart item object" section for more information.'],
     ['onSuccess', 'function', 'No', 'Called when the payment flow finishes successfully. If the function returns a promise, the promise will be awaited before marking the payment as "completed successfully" in the Apple Pay sheet. If the promise rejects, the payment will be marked as "failed" in the Apple Pay sheet and the error will be propagated to the "onError" callback, if provided.'],
     ['onError', 'function', 'No', 'Called when the payment flow was aborted due to an error. The function receives a single argument, {message: string}, containing the reason of error.'],
-    ['active', 'boolean', 'No', 'Whether the button is active. Set this to "false" to hide the Apple Pay button (default: true).'],
-    ['disabled', 'boolean', 'No', 'Whether the button is disabled. Set this to "true" to disable the Apple Pay button (default: false).'],
+    ['active', 'boolean', 'No', 'Whether the button is active. Set this to false to hide the Apple Pay button (default: true).'],
+    ['disabled', 'boolean', 'No', 'Whether the button is disabled. Set this to true to disable the Apple Pay button (default: false).'],
   ]}
 />
 

--- a/src/content/docs/dropins/payment-services/containers/apple-pay.mdx
+++ b/src/content/docs/dropins/payment-services/containers/apple-pay.mdx
@@ -21,8 +21,8 @@ The `ApplePay` container provides the following configuration options:
     ['createCart', 'object', 'Maybe', 'Required if "getCartId" not provided. The object should define a single "getCartItems" property, which should be a function that returns a list of cart items to purchase. The list must contain at least one cart item. Cart items must be provided as objects with, at minimum, an "sku" (string) and a "quantity" (number). See "Cart item object" section for more information.'],
     ['onSuccess', 'function', 'No', 'Called when the payment flow finishes successfully. If the function returns a promise, the promise will be awaited before marking the payment as "completed successfully" in the Apple Pay sheet. If the promise rejects, the payment will be marked as "failed" in the Apple Pay sheet and the error will be propagated to the "onError" callback, if provided.'],
     ['onError', 'function', 'No', 'Called when the payment flow was aborted due to an error. The function receives a single argument, {message: string}, containing the reason of error.'],
-    ['active', 'boolean', 'No', 'Activates/deactivates the container (default value is true).'],
-    ['disabled', 'boolean', 'No', 'Disables the Apple Pay button.'],
+    ['active', 'boolean', 'No', 'Whether the button is active. Set this to "false" to hide the Apple Pay button (default: true).'],
+    ['disabled', 'boolean', 'No', 'Whether the button is disabled. Set this to "true" to disable the Apple Pay button (default: false).'],
   ]}
 />
 

--- a/src/content/docs/dropins/payment-services/containers/apple-pay.mdx
+++ b/src/content/docs/dropins/payment-services/containers/apple-pay.mdx
@@ -21,6 +21,8 @@ The `ApplePay` container provides the following configuration options:
     ['createCart', 'object', 'Maybe', 'Required if "getCartId" not provided. The object should define a single "getCartItems" property, which should be a function that returns a list of cart items to purchase. The list must contain at least one cart item. Cart items must be provided as objects with, at minimum, an "sku" (string) and a "quantity" (number). See "Cart item object" section for more information.'],
     ['onSuccess', 'function', 'No', 'Called when the payment flow finishes successfully. If the function returns a promise, the promise will be awaited before marking the payment as "completed successfully" in the Apple Pay sheet. If the promise rejects, the payment will be marked as "failed" in the Apple Pay sheet and the error will be propagated to the "onError" callback, if provided.'],
     ['onError', 'function', 'No', 'Called when the payment flow was aborted due to an error. The function receives a single argument, {message: string}, containing the reason of error.'],
+    ['active', 'boolean', 'No', 'Activates/deactivates the container (default value is true).'],
+    ['disabled', 'boolean', 'No', 'Disables the Apple Pay button.'],
   ]}
 />
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request documents the `active` and `disabled` properties, which we recently added to the `ApplePay` container of the Payment Services drop-in.

The documentation is copy-pasted from the Checkout drop-in's [`PlaceOrder` container](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/checkout/containers/place-order/), which has the same properties:
<img width="1621" height="1126" alt="image" src="https://github.com/user-attachments/assets/8c64380c-c8b3-4f43-91af-7e537787c041" />

### Associated JIRA ticket

https://jira.corp.adobe.com/browse/PAY-6281


### Staging preview

<!--OPTIONAL Link to staging preview if available-->


## Affected pages

N/A (page does not exist yet)


## Links to source code

https://github.com/adobe-commerce/storefront-payment-services/pull/16

