### PR TITLE
PAY-6281: Refactor ApplePay prop from 'active' to 'hidden'

### DIFF
--- a/src/content/docs/dropins/payment-services/containers/apple-pay.mdx
+++ b/src/content/docs/dropins/payment-services/containers/apple-pay.mdx
@@ -21,7 +21,7 @@ The `ApplePay` container provides the following configuration options:
     ['createCart', 'object', 'Maybe', 'Required if "getCartId" not provided. The object should define a single "getCartItems" property, which should be a function that returns a list of cart items to purchase. The list must contain at least one cart item. Cart items must be provided as objects with, at minimum, an "sku" (string) and a "quantity" (number). See "Cart item object" section for more information.'],
     ['onSuccess', 'function', 'No', 'Called when the payment flow finishes successfully. If the function returns a promise, the promise will be awaited before marking the payment as "completed successfully" in the Apple Pay sheet. If the promise rejects, the payment will be marked as "failed" in the Apple Pay sheet and the error will be propagated to the "onError" callback, if provided.'],
     ['onError', 'function', 'No', 'Called when the payment flow was aborted due to an error. The function receives a single argument, {message: string}, containing the reason of error.'],
-    ['active', 'boolean', 'No', 'Whether the button is active. Set this to false to hide the Apple Pay button (default: true).'],
+    ['hidden', 'boolean', 'No', 'Whether the button is hidden. Set this to true to hide the Apple Pay button (default: false).'],
     ['disabled', 'boolean', 'No', 'Whether the button is disabled. Set this to true to disable the Apple Pay button (default: false).'],
   ]}
 />


### PR DESCRIPTION
## Purpose of this pull request

We recently added two props to the `ApplePay` container
* `active` that can be used to hide the button when set to `false`
* `disabled` that can be used to disable the button

This is the same API that the checkout drop-in offers in the checkout `PlaceOrder` container, which also offer both `active` and `disabled` properties ([see documentation](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/checkout/containers/place-order/)).

After syncing with the team, we find that this API is somewhat confusing, and propose renaming the `active` property to `hidden`, which seems more self-explanatory.

### Associated JIRA ticket

https://jira.corp.adobe.com/browse/PAY-6281


### Staging preview

N/A


## Affected pages

N/A

## Links to source code

N/A

