### PR TITLE
Add a topic for updating the boilerplate

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -216,13 +216,14 @@ async function config() {
                 icon: 'seti:json',
                 items: [
                   {
-                    label: 'Quick start',
+                    label: 'Essentials',
                     collapsed: false,
                     items: [
                       { label: 'Overview', link: '/get-started/' },
                       { label: 'Create a storefront', link: '/get-started/create-storefront' },
                       { label: 'Learn the architecture', link: '/setup/discovery/architecture/' },
                       { label: 'Explore the boilerplate', link: '/get-started/boilerplate-project/' },
+                      { label: 'Update the boilerplate', link: '/get-started/update-boilerplate/' },
                       { label: 'Run Lighthouse audits', link: '/get-started/run-lighthouse/' },
                     ],
                   },

--- a/src/content/docs/get-started/update-boilerplate.mdx
+++ b/src/content/docs/get-started/update-boilerplate.mdx
@@ -56,24 +56,28 @@ Automated scripts that run after NPM package installation to copy updated commer
 
 ## Understanding the upgrade landscape
 
+Upgrading is ongoing, not a one-time task. Regular, small updates are generally safer and easier to manage than infrequent, large upgrades.
+
 ### What gets updated
 
 Most of your storefront's critical commerce logic is now delivered through NPM packages, making upgrades significantly easier and more reliable. Upgrades typically involve these main areas:
 
-**Drop-in Components:** NPM packages containing the core commerce functionality
+**Drop-in components:** NPM packages containing the core commerce functionality, including the following:
 
 - `@dropins/storefront-account`
 - `@dropins/storefront-auth`
 - `@dropins/storefront-cart`
 - `@dropins/storefront-checkout`
 - `@dropins/storefront-order`
+- `@dropins/storefront-payment-services`
 - `@dropins/storefront-pdp`
+- `@dropins/storefront-personalization`
 - `@dropins/storefront-product-discovery`
 - `@dropins/storefront-recommendations`
 - `@dropins/storefront-wishlist`
-- `@dropins/storefront-personalization`
-- `@dropins/storefront-payment-services`
 - `@dropins/tools`
+
+{/* TODO: Update this topic by including B2B drop-ins when they are released in Jan 2026. See issue #701 for more details. */}
 
 **Boilerplate Integration Layer:** storefront-level files that integrate drop-ins
 
@@ -81,11 +85,11 @@ Most of your storefront's critical commerce logic is now delivered through NPM p
 
 | File | Purpose | Update Frequency | Typical Changes |
 |------|---------|------------------|-----------------|
+| `blocks/*` | Block integration folders | Frequent | Drop-in integration JS and CSS. Rare updates to non-drop-in block examples (cards, accordion, etc) sourced from other boilerplates |
 | `scripts/aem.js` | Core AEM functionality | Very Rare | Core platform improvements |
-| `scripts/scripts.js` | Page loading, block decoration, and global site functionality | Very Rare | Performance optimizations, new global features |
 | `scripts/commerce.js` | Commerce-specific integration and utilities | Rare | Integration improvements, new utility functions |
 | `scripts/initializers/*` | Drop-in initialization scripts | Moderate | New drop-in integrations, configuration updates |
-| `blocks/*` | Block integration folders | Frequent | Drop-in integration JS and CSS. Rare updates to non-drop-in block examples (cards, accordion, etc) sourced from other boilerplates |
+| `scripts/scripts.js` | Page loading, block decoration, and global site functionality | Very Rare | Performance optimizations, new global features |
 
 </TableWrapper>
 
@@ -526,8 +530,3 @@ When drop-in updates introduce breaking changes:
 - <Link href="https://github.com/hlxsites/aem-boilerplate-commerce" text="Commerce Boilerplate Repository" />: Source code and latest updates
 - [Release Notes](/releases/): Track major changes and updates
 - <Link href="https://github.com/hlxsites/aem-boilerplate-commerce/releases" text="Boilerplate Releases" />: GitHub releases and version history
-
-<Aside type="note">
-Upgrading is ongoing, not a one-time task. Regular, small updates are generally safer and easier to manage than infrequent, large upgrades.
-</Aside>
-

--- a/src/content/docs/get-started/update-boilerplate.mdx
+++ b/src/content/docs/get-started/update-boilerplate.mdx
@@ -159,7 +159,7 @@ Test all commerce functionality:
 Review the release notes for any integration changes that may affect your implementation.
 
 <Aside type="caution" title="For Major Version Updates">
-When upgrading drop-in packages across major versions (e.g., from 1.x to 2.x), perform more thorough testing as these updates may include breaking changes. Pay particular attention to:
+When upgrading drop-in packages across major versions (for example, from 1.x to 2.x), perform more thorough testing as these updates may include breaking changes. Pay particular attention to:
 
 - Any custom integrations you've built around the drop-in components
 - API interfaces you're using

--- a/src/content/docs/get-started/update-boilerplate.mdx
+++ b/src/content/docs/get-started/update-boilerplate.mdx
@@ -35,7 +35,7 @@ This guide shows you how to upgrade your storefront while preserving your custom
 <Vocabulary columns={2}>
 
 ### Drop-in components
-NPM packages containing the core commerce functionality such as cart, checkout, product details, and user authentication.
+NPM packages containing the core Commerce functionality such as cart, checkout, product details, and user authentication.
 
 ### Integration layer
 Storefront-level files that integrate drop-ins with your site, including initialization scripts and block implementations.
@@ -50,7 +50,7 @@ The process of manually choosing and merging specific changes from the upstream 
 Updates that require modifications to your existing code, typically found in major version releases.
 
 ### Post-install scripts
-Automated scripts that run after NPM package installation to copy updated commerce logic to your local project.
+Automated scripts that run after NPM package installation to copy updated Commerce logic to your local project.
 
 </Vocabulary>
 
@@ -60,9 +60,9 @@ Upgrading is ongoing, not a one-time task. Regular, small updates are generally 
 
 ### What gets updated
 
-Most of your storefront's critical commerce logic is now delivered through NPM packages, making upgrades significantly easier and more reliable. Upgrades typically involve these main areas:
+Most of your storefront's critical Commerce logic is now delivered through NPM packages, making upgrades significantly easier and more reliable. Upgrades typically involve these main areas:
 
-**Drop-in components:** NPM packages containing the core commerce functionality, including the following:
+**Drop-in components:** NPM packages containing the core Commerce functionality, including the following:
 
 - `@dropins/storefront-account`
 - `@dropins/storefront-auth`
@@ -95,13 +95,13 @@ Most of your storefront's critical commerce logic is now delivered through NPM p
 
 ### Why upgrades are now easier
 
-The Commerce Boilerplate team moved most of the complex commerce logic into NPM-distributed drop-in packages, providing key advantages:
+The Commerce Boilerplate team moved most of the complex Commerce logic into NPM-distributed drop-in packages, providing key advantages:
 
-- **Most logic is packaged**: Core commerce functionality, business rules, and complex state management are delivered through NPM packages
+- **Most logic is packaged**: Core Commerce functionality, business rules, and complex state management are delivered through NPM packages
 - **Simplified storefront code**: Your project primarily contains integration code, styling, and configuration
 - **Standard NPM upgrades**: Most updates can be applied using standard `npm install` commands
 - **Reduced conflicts**: Fewer files in your project means fewer merge conflicts when updating
-- **Consistent behavior**: All storefronts benefit from the same tested, optimized commerce logic
+- **Consistent behavior**: All storefronts benefit from the same tested, optimized Commerce logic
 
 ## Upgrade strategies
 
@@ -111,12 +111,12 @@ The Commerce Boilerplate team moved most of the complex commerce logic into NPM-
 ### NPM package updates
 
 <Aside type="tip" title="Recommended for most cases">
-Most commerce logic lives in NPM packages, so this approach handles upgrades with minimal risk.
+Most Commerce logic lives in NPM packages, so this approach handles upgrades with minimal risk.
 </Aside>
 
 #### Step 1: Update drop-in components
 
-Most of your commerce functionality improvements come through these package updates:
+Most of your Commerce functionality improvements come through these package updates:
 
 Check your current versions:
 
@@ -139,7 +139,7 @@ npm update @dropins/storefront-*
 ```
 
 <Aside type="note">
-The boilerplate's postinstall and postupdate scripts automatically copy updated commerce logic from `node_modules` to `scripts/__dropins__` for Edge Delivery Services.
+The boilerplate's postinstall and postupdate scripts automatically copy updated Commerce logic from `node_modules` to `scripts/__dropins__` for Edge Delivery Services.
 </Aside>
 
 #### Step 2: Test your storefront
@@ -152,7 +152,7 @@ Start your local development environment:
 npm start
 ```
 
-Test all commerce functionality:
+Test all Commerce functionality:
 
 - Product detail pages
 - Shopping cart operations
@@ -173,10 +173,10 @@ When upgrading drop-in packages across major versions (for example, from 1.x to 
 Test edge cases and error scenarios in addition to the standard user flows.
 </Aside>
 
-To help automate this testing process, consider implementing end-to-end testing in your project using tools like Cypress. These tools can simulate real user interactions across your commerce flows, automatically catching regressions that manual testing might miss. Focus your automated tests on critical user journeys like product browsing, cart management, and checkout completion.
+To help automate this testing process, consider implementing end-to-end testing in your project using tools like Cypress. These tools can simulate real user interactions across your Commerce flows, automatically catching regressions that manual testing might miss. Focus your automated tests on critical user journeys like product browsing, cart management, and checkout completion.
 
 <Aside type="note">
-Most commerce logic updates require no additional code changes to your storefront because the 
+Most Commerce logic updates require no additional code changes to your storefront because the 
 complex functionality is delivered through the NPM packages.
 </Aside>
 
@@ -232,7 +232,7 @@ When you need integration layer improvements or new features that require change
    </Aside>
 
    <Aside type="note">
-   Since most complex commerce logic is now in NPM packages, boilerplate updates typically involve integration layer improvements rather than core functionality changes.
+   Since most complex Commerce logic is now in NPM packages, boilerplate updates typically involve integration layer improvements rather than core functionality changes.
    </Aside>
 
 4. **Apply selected changes**
@@ -261,36 +261,36 @@ When you need integration layer improvements or new features that require change
 ## Special considerations for early-adopter projects
 
 <Aside type="caution">
-If you scaffolded your project before mid-2025, you may have encountered a major architectural change: commerce logic moved from `scripts.js` to `scripts/commerce.js`. This shift affects your update scope but uses the same methods above.
+If you scaffolded your project before mid-2025, you may have encountered a major architectural change: Commerce logic moved from `scripts.js` to `scripts/commerce.js`. This shift affects your update scope but uses the same methods above.
 </Aside>
 
 ### Understanding the architectural change
 
 The major refactoring (PR #567) reorganized the boilerplate architecture with two significant improvements:
 
-**1. Separation of AEM and commerce logic:**
+**1. Separation of AEM and Commerce logic:**
 
 - `scripts/scripts.js` - Core AEM functionality, aligned with the upstream AEM Boilerplate
 - `scripts/commerce.js` - Commerce-specific integration and utility logic
 
-**2. Core commerce logic migration to NPM packages:**
+**2. Core Commerce logic migration to NPM packages:**
 
-- Complex commerce functionality moved to `@dropins/tools` and other drop-in packages
+- Complex Commerce functionality moved to `@dropins/tools` and other drop-in packages
 - Functions previously embedded in your integration code are now abstracted to reusable, versioned, and upgradable libraries
 - The Commerce Boilerplate is now focused on pure integration code that you own
 
-**Before the refactoring:** In early versions of the Commerce Boilerplate, all logic lived in `scripts/scripts.js` where commerce business logic was mixed with integration code. Core commerce functions were embedded directly in your project files, making it difficult to upgrade commerce functionality without encountering code conflicts during merges.
+**Before the refactoring:** In early versions of the Commerce Boilerplate, all logic lived in `scripts/scripts.js` where Commerce business logic was mixed with integration code. Core Commerce functions were embedded directly in your project files, making it difficult to upgrade Commerce functionality without encountering code conflicts during merges.
 
-**After the refactoring:** The architecture now separates concerns more effectively. Core commerce logic lives in NPM packages that are easily upgradable, while the boilerplate contains minimal integration code that results in fewer merge conflicts. This creates clear boundaries between platform logic and your customizations, allowing future updates to focus on integration patterns rather than business logic.
+**After the refactoring:** The architecture now separates concerns more effectively. Core Commerce logic lives in NPM packages that are easily upgradable, while the boilerplate contains minimal integration code that results in fewer merge conflicts. This creates clear boundaries between platform logic and your customizations, allowing future updates to focus on integration patterns rather than business logic.
 
-This architectural shift means that complex commerce operations, utility functions, and business rules that you may have seen in your early boilerplate files are now delivered through NPM packages, making them upgradable without touching your project code.
+This architectural shift means that complex Commerce operations, utility functions, and business rules that you may have seen in your early boilerplate files are now delivered through NPM packages, making them upgradable without touching your project code.
 
 ### Adapting your update approach
 
 If you have an early-adopter project, your updates will need a broader scope to account for architectural changes.
 
 When reviewing updates, pay attention to the main scripts file (`scripts/scripts.js`) and 
-the commerce integration layer (`scripts/commerce.js`). Both have changed significantly. Be sure to preserve your custom business logic while adopting the improved structural foundation 
+the Commerce integration layer (`scripts/commerce.js`). Both have changed significantly. Be sure to preserve your custom business logic while adopting the improved structural foundation 
 that the upstream changes provide.
 
 The migration process requires more careful consideration than typical updates since you're not just incorporating new features, but potentially restructuring how your existing customizations integrate with the boilerplate's core functionality.
@@ -305,19 +305,19 @@ During Step 4 (apply selective changes), you may need to migrate your customizat
 
 **Block import updates**
 
-- Update imports from `../../scripts/scripts.js` to `../../scripts/commerce.js` for commerce utilities
+- Update imports from `../../scripts/scripts.js` to `../../scripts/commerce.js` for Commerce utilities
 - Verify that custom utilities are still available or replace with package utilities
 
 **Integration pattern updates**
 
 - Review if custom functions can be replaced with utilities from `@dropins/tools` package
-- Update integrations to use new patterns for commerce-specific functionality
+- Update integrations to use new patterns for Commerce-specific functionality
 
 During Step 5 (testing), pay special attention to:
 
-- Custom blocks that import commerce utilities
-- Third-party integrations that depend on commerce functions
-- Custom analytics implementations that hook into commerce events
+- Custom blocks that import Commerce utilities
+- Third-party integrations that depend on Commerce functions
+- Custom analytics implementations that hook into Commerce events
 - Any custom business logic that was mixed with platform code
 
 ### Benefits of architectural alignment

--- a/src/content/docs/get-started/update-boilerplate.mdx
+++ b/src/content/docs/get-started/update-boilerplate.mdx
@@ -1,0 +1,533 @@
+---
+title: Update the boilerplate
+description: Learn how to upgrade your existing Adobe Commerce storefront to incorporate the latest features, security updates, and performance improvements.
+sidebar:
+  order: 4
+---
+
+import Vocabulary from '@components/Vocabulary.astro';
+import Diagram from '@components/Diagram.astro';
+import Aside from '@components/Aside.astro';
+import Callouts from '@components/Callouts.astro';
+import { Steps } from '@astrojs/starlight/components';
+import Tasks from '@components/Tasks.astro';
+import Task from '@components/Task.astro';
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+import Options from '@components/Options.astro';
+import Option from '@components/Option.astro';
+import Link from '@components/Link.astro';
+import TableWrapper from '@components/TableWrapper.astro';
+
+Upgrade your Adobe Commerce storefront to get the latest features, security updates, and performance improvements from the Commerce Boilerplate.
+
+## Overview
+
+When you initially scaffold your Commerce storefront from the Commerce Boilerplate, you create a snapshot of the boilerplate at that point in time. As Adobe continues to improve the boilerplate with new features, bug fixes, and performance optimizations, your existing project won't automatically receive these updates.
+
+<Aside type="note">
+If you created your project by forking the Commerce Boilerplate repository (rather than using the "generate from template" or site creator approach), you may have an easier upgrade path since you can leverage Git's merge capabilities to pull upstream changes.
+</Aside>
+
+This guide shows you how to upgrade your storefront while preserving your customizations.
+
+## Vocabulary
+
+<Vocabulary columns={2}>
+
+### Drop-in components
+NPM packages containing the core commerce functionality such as cart, checkout, product details, and user authentication.
+
+### Integration layer
+Storefront-level files that integrate drop-ins with your site, including initialization scripts and block implementations.
+
+### Upstream
+The original Commerce Boilerplate repository from which your project was created.
+
+### Selective updates
+The process of manually choosing and merging specific changes from the upstream boilerplate into your project.
+
+### Breaking changes
+Updates that require modifications to your existing code, typically found in major version releases.
+
+### Post-install scripts
+Automated scripts that run after NPM package installation to copy updated commerce logic to your local project.
+
+</Vocabulary>
+
+## Understanding the upgrade landscape
+
+### What gets updated
+
+Most of your storefront's critical commerce logic is now delivered through NPM packages, making upgrades significantly easier and more reliable. Upgrades typically involve these main areas:
+
+**Drop-in Components:** NPM packages containing the core commerce functionality
+
+- `@dropins/storefront-account`
+- `@dropins/storefront-auth`
+- `@dropins/storefront-cart`
+- `@dropins/storefront-checkout`
+- `@dropins/storefront-order`
+- `@dropins/storefront-pdp`
+- `@dropins/storefront-product-discovery`
+- `@dropins/storefront-recommendations`
+- `@dropins/storefront-wishlist`
+- `@dropins/storefront-personalization`
+- `@dropins/storefront-payment-services`
+- `@dropins/tools`
+
+**Boilerplate Integration Layer:** storefront-level files that integrate drop-ins
+
+<TableWrapper nowrap={[0, 2]}>
+
+| File | Purpose | Update Frequency | Typical Changes |
+|------|---------|------------------|-----------------|
+| `scripts/aem.js` | Core AEM functionality | Very Rare | Core platform improvements |
+| `scripts/scripts.js` | Page loading, block decoration, and global site functionality | Very Rare | Performance optimizations, new global features |
+| `scripts/commerce.js` | Commerce-specific integration and utilities | Rare | Integration improvements, new utility functions |
+| `scripts/initializers/*` | Drop-in initialization scripts | Moderate | New drop-in integrations, configuration updates |
+| `blocks/*` | Block integration folders | Frequent | Drop-in integration JS and CSS. Rare updates to non-drop-in block examples (cards, accordion, etc) sourced from other boilerplates |
+
+</TableWrapper>
+
+### Why upgrades are now easier
+
+The Commerce Boilerplate team moved most of the complex commerce logic into NPM-distributed drop-in packages, providing key advantages:
+
+- **Most logic is packaged**: Core commerce functionality, business rules, and complex state management are delivered through NPM packages
+- **Simplified storefront code**: Your project primarily contains integration code, styling, and configuration
+- **Standard NPM upgrades**: Most updates can be applied using standard `npm install` commands
+- **Reduced conflicts**: Fewer files in your project means fewer merge conflicts when updating
+- **Consistent behavior**: All storefronts benefit from the same tested, optimized commerce logic
+
+## Upgrade strategies
+
+<Options label="Strategy">
+<Option>
+
+### NPM package updates
+
+<Aside type="tip" title="Recommended for most cases">
+Most commerce logic lives in NPM packages, so this approach handles upgrades with minimal risk.
+</Aside>
+
+#### Step 1: Update drop-in components
+
+Most of your commerce functionality improvements come through these package updates:
+
+Check your current versions:
+
+```bash
+npm list @dropins/storefront-*
+```
+
+Update individual components:
+
+```bash
+npm install @dropins/storefront-cart@latest
+npm install @dropins/storefront-checkout@latest
+# Repeat for other components as needed
+```
+
+Or update all drop-in components at once:
+
+```bash
+npm update @dropins/storefront-*
+```
+
+<Aside type="note">
+The boilerplate's postinstall and postupdate scripts automatically copy updated commerce logic from `node_modules` to `scripts/__dropins__` for Edge Delivery Services.
+</Aside>
+
+#### Step 2: Test your storefront
+
+Since most logic changes are packaged, testing focuses on integration points:
+
+Start your local development environment:
+
+```bash
+npm start
+```
+
+Test all commerce functionality:
+
+- Product detail pages
+- Shopping cart operations
+- Checkout flow
+- User account features
+- Search and navigation
+
+Review the release notes for any integration changes that may affect your implementation.
+
+<Aside type="caution" title="For Major Version Updates">
+When upgrading drop-in packages across major versions (e.g., from 1.x to 2.x), perform more thorough testing as these updates may include breaking changes. Pay particular attention to:
+
+- Any custom integrations you've built around the drop-in components
+- API interfaces you're using
+- Configuration settings that may have changed
+- Custom styling or event handlers you've added
+
+Test edge cases and error scenarios in addition to the standard user flows.
+</Aside>
+
+To help automate this testing process, consider implementing end-to-end testing in your project using tools like Cypress. These tools can simulate real user interactions across your commerce flows, automatically catching regressions that manual testing might miss. Focus your automated tests on critical user journeys like product browsing, cart management, and checkout completion.
+
+<Aside type="note">
+Most commerce logic updates require no additional code changes to your storefront because the 
+complex functionality is delivered through the NPM packages.
+</Aside>
+
+</Option>
+
+<Option>
+
+### Selective boilerplate updates
+
+When you need integration layer improvements or new features that require changes to your storefront's integration code, selectively merge changes from the upstream boilerplate repository.
+
+<Steps>
+
+1. **Set up upstream remote**
+
+   Add the boilerplate repository as an upstream remote:
+
+   ```bash
+   git remote add upstream https://github.com/hlxsites/aem-boilerplate-commerce.git
+   git fetch upstream
+   ```
+
+2. **Review available updates**
+
+   Compare your current branch with the latest boilerplate to understand what changes are available.
+
+   For detailed instructions on reviewing upstream changes, see <Link href="https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork" text="GitHub's guide on syncing a fork" /> and <Link href="https://docs.github.com/en/pull-requests/committing-changes-to-your-project/viewing-and-comparing-commits/comparing-commits" text="comparing commits" />.
+
+   Focus your review on key files like `scripts/commerce.js` and the `scripts/initializers/` directory where most Commerce-specific updates occur.
+
+3. **Identify changes to include**
+
+   Focus on these integration layer improvements:
+
+   **Commerce Integration Layer (`scripts/commerce.js`)**
+   - Enhanced drop-in initialization patterns
+   - New configuration utilities
+   - Performance optimizations
+   - Bug fixes in integration logic
+
+   **Initializers (`scripts/initializers/`)**
+   - Updated drop-in initialization patterns
+   - New feature integrations
+   - Improved error handling
+
+   **Block Integration Updates (`blocks/` directory)**
+   - Enhanced drop-in integration patterns
+   - Accessibility improvements
+   - Bug fixes in block-level integration
+
+   <Aside type="tip">
+   Each Commerce block now includes a README file that describes the block's purpose and functionality. These README files are particularly helpful when diffing changes, as they provide a summary of what has changed in the block before you examine the code.
+   </Aside>
+
+   <Aside type="note">
+   Since most complex commerce logic is now in NPM packages, boilerplate updates typically involve integration layer improvements rather than core functionality changes.
+   </Aside>
+
+4. **Apply selected changes**
+
+   Create a branch for your upgrade work to isolate changes and test before merging to main. Use a descriptive name indicating the upgrade with a timeframe or version (e.g., `upgrade-august-2025` or `upgrade-cart-v2.1.0`).
+
+   Once you're on your upgrade branch, you have several options for applying changes from the upstream boilerplate:
+
+   - **Selectively merge** individual files or directories that have updates you want to incorporate. This approach works well when you want to adopt specific improvements without bringing in changes that might conflict with your customizations.
+   - **Cherry-pick** specific commits from the upstream repository if you want to apply only particular features or fixes. This gives you granular control over what changes to include and helps avoid introducing unwanted modifications.
+
+   For each change you apply, commit it with a clear message describing what upstream improvement you're incorporating. This creates a clean history that makes it easy to understand what was updated and why, which will be valuable for future upgrades and troubleshooting.
+
+5. **Resolve integration points and test**
+
+   - Resolve any conflicts in integration code, preserving your customizations
+   - Test thoroughly in your development environment
+   - Run your test suite if available
+   - Deploy to a staging environment for comprehensive testing
+
+</Steps>
+
+</Option>
+</Options>
+
+## Special considerations for early-adopter projects
+
+<Aside type="caution">
+If you scaffolded your project before mid-2025, you may have encountered a major architectural change: commerce logic moved from `scripts.js` to `scripts/commerce.js`. This shift affects your update scope but uses the same methods above.
+</Aside>
+
+### Understanding the architectural change
+
+The major refactoring (PR #567) reorganized the boilerplate architecture with two significant improvements:
+
+**1. Separation of AEM and commerce logic:**
+
+- `scripts/scripts.js` - Core AEM functionality, aligned with the upstream AEM Boilerplate
+- `scripts/commerce.js` - Commerce-specific integration and utility logic
+
+**2. Core commerce logic migration to NPM packages:**
+
+- Complex commerce functionality moved to `@dropins/tools` and other drop-in packages
+- Functions previously embedded in your integration code are now abstracted to reusable, versioned, and upgradable libraries
+- The Commerce Boilerplate is now focused on pure integration code that you own
+
+**Before the refactoring:** In early versions of the Commerce Boilerplate, all logic lived in `scripts/scripts.js` where commerce business logic was mixed with integration code. Core commerce functions were embedded directly in your project files, making it difficult to upgrade commerce functionality without encountering code conflicts during merges.
+
+**After the refactoring:** The architecture now separates concerns more effectively. Core commerce logic lives in NPM packages that are easily upgradable, while the boilerplate contains minimal integration code that results in fewer merge conflicts. This creates clear boundaries between platform logic and your customizations, allowing future updates to focus on integration patterns rather than business logic.
+
+This architectural shift means that complex commerce operations, utility functions, and business rules that you may have seen in your early boilerplate files are now delivered through NPM packages, making them upgradable without touching your project code.
+
+### Adapting your update approach
+
+If you have an early-adopter project, your updates will need a broader scope to account for architectural changes.
+
+When reviewing updates, pay attention to the main scripts file (`scripts/scripts.js`) and 
+the commerce integration layer (`scripts/commerce.js`). Both have changed significantly. Be sure to preserve your custom business logic while adopting the improved structural foundation 
+that the upstream changes provide.
+
+The migration process requires more careful consideration than typical updates since you're not just incorporating new features, but potentially restructuring how your existing customizations integrate with the boilerplate's core functionality.
+
+During Step 4 (apply selective changes), you may need to migrate your customizations:
+
+**Custom functions in the "old" `scripts/scripts.js`**
+
+- Commerce-related customizations should move to `scripts/commerce.js`
+- General AEM functionality should remain in `scripts/scripts.js`
+- Many custom functions may now be available as utilities in `@dropins/tools`
+
+**Block import updates**
+
+- Update imports from `../../scripts/scripts.js` to `../../scripts/commerce.js` for commerce utilities
+- Verify that custom utilities are still available or replace with package utilities
+
+**Integration pattern updates**
+
+- Review if custom functions can be replaced with utilities from `@dropins/tools` package
+- Update integrations to use new patterns for commerce-specific functionality
+
+During Step 5 (testing), pay special attention to:
+
+- Custom blocks that import commerce utilities
+- Third-party integrations that depend on commerce functions
+- Custom analytics implementations that hook into commerce events
+- Any custom business logic that was mixed with platform code
+
+### Benefits of architectural alignment
+
+While early-adopter projects require more comprehensive selective updates, aligning with the new architecture provides significant long-term benefits:
+
+- **Future updates simplified**: Once aligned, future updates will be much easier due to reduced code surface area
+- **Better separation of concerns**: Clear boundaries between platform logic and your customizations
+- **Reduced merge conflicts**: Commerce functionality updates through NPM packages instead of file merges
+- **Access to latest features**: Full compatibility with new drop-in components and features
+- **Enhanced PDP flexibility**: Container-based PDP architecture provides unprecedented customization control
+
+## Product details page architectural evolution
+
+<Aside type="note">
+If your project was scaffolded from early versions of the Commerce Boilerplate before November 27, 2024, the PDP drop-in itself underwent a major evolution from a single-container approach to a fully composable, multi-container architecture. Projects with the slot-based architecture should consider migrating to the container-based approach for better long-term maintainability.
+</Aside>
+
+### Previous architecture (slot-based customization)
+
+Early versions of `@dropins/storefront-pdp` used a single `ProductDetails` container with predefined slots. You could customize by:
+
+- Creating custom slot implementations for different sections of the page
+- Working within the constraints of the single-container structure
+- Limited ability to rearrange or completely replace sections of the PDP
+- Complex styling workarounds to achieve desired layouts
+
+### New architecture (container-based composition)
+
+The latest version breaks down the PDP into independent containers you can compose, style, and replace:
+
+- **ProductHeader** - Product title, SKU, and basic information
+- **ProductPrice** - Pricing display and special price handling
+- **ProductGallery** - Image carousel with flexible configuration
+- **ProductOptions** - Product variants and configuration
+- **ProductQuantity** - Quantity selector
+- **ProductDescription** - Product descriptions and content
+- **ProductAttributes** - Product specifications and metadata
+
+For detailed information about the container-based architecture and implementation patterns, see the [Product Details Drop-in Documentation](/dropins/product-details/). You can also reference the current product-details block implementation in the Commerce Boilerplate for practical examples of the container-based approach.
+
+### Migration benefits for PDP blocks
+
+- **Complete layout control**: Arrange containers in any order within your block structure
+- **Individual container replacement**: Replace entire sections (like gallery or pricing) with custom implementations
+- **Simplified styling**: Style containers independently without complex CSS overrides
+- **Enhanced functionality**: Each container can be configured independently with specific features
+- **Eliminated slot workarounds**: UI customizations that required appending, prepending, or replacing slot content can now be handled directly in the layout structure or by completely replacing containers
+- **Direct data access**: Product data previously available through slot context is now accessible via the event bus (`pdp/data` and `pdp/values`)
+- **Future-proof architecture**: New PDP features delivered as new containers rather than slot modifications
+
+### PDP block migration process
+
+When updating your PDP block from slot-based to container-based:
+
+**1. Update dependencies**
+
+```javascript
+// Old: Single container with slots
+import { ProductDetails } from '@dropins/storefront-pdp/containers/ProductDetails.js';
+
+// New: Multiple independent containers  
+import ProductHeader from '@dropins/storefront-pdp/containers/ProductHeader.js';
+import ProductPrice from '@dropins/storefront-pdp/containers/ProductPrice.js';
+import ProductGallery from '@dropins/storefront-pdp/containers/ProductGallery.js';
+// ... other containers
+```
+
+**2. Replace slot implementations**
+
+You can often remove custom slot implementations entirely—the new containers provide better configuration.
+
+**3. Update block structure**
+
+Replace the single container render with multiple container renders:
+
+```javascript
+// Old: Single render with slot configuration
+await productRenderer.render(ProductDetails, {
+  slots: {
+    Title: (ctx) => Title(ctx, block),
+    Options: (ctx) => Options(ctx, block),
+    // ... other slots
+  }
+})(block);
+
+// New: Multiple container renders
+await pdpRendered.render(ProductHeader, {})($header);
+await pdpRendered.render(ProductPrice, {})($price);  
+await pdpRendered.render(ProductGallery, { controls: 'thumbnailsColumn' })($gallery);
+// ... other containers
+```
+
+**4. Layout restructuring**
+
+Create HTML structure that positions containers where you need them:
+
+```javascript
+<div class="product-details__wrapper">
+  <div class="product-details__header"></div>
+  <div class="product-details__price"></div>
+  <div class="product-details__gallery"></div>
+  <!-- Full control over container placement -->
+</div>
+```
+
+**5. Styling migration**
+
+- Remove complex CSS overrides targeting internal slot structures
+- Style containers directly with cleaner, more maintainable CSS
+- Review any potential class name changes between architectures
+- Handle breakpoints and responsive layout at the block level, as this is now the block's responsibility
+
+## Tracking updates
+
+### Monitor boilerplate changes
+
+Stay informed about boilerplate updates:
+
+- **GitHub watch**: Watch the <Link href="https://github.com/hlxsites/aem-boilerplate-commerce" text="Commerce Boilerplate repository" /> for releases and important changes
+- **Changelog tracking**: Follow issues tagged with the changelog label
+- **Release notes**: Review drop-in component release notes at the [Release Information](/releases/) page
+
+### Version management best practices
+
+**Document your customizations**
+
+- Document all customizations
+- Write clear commit messages
+- Tag storefront releases
+
+**Establish update cadence**
+
+- Review updates monthly or quarterly
+- Schedule major upgrades for low-traffic periods
+- Test in staging
+
+## Troubleshooting common issues
+
+### Post-install script failures
+
+If post-install fails:
+
+- Check Node.js and NPM version compatibility
+- Clear NPM cache: `npm cache clean --force`
+- Remove and reinstall: `rm -rf node_modules package-lock.json && npm install`
+- Check file permissions
+
+### Merge conflicts
+
+When merging updates:
+
+- **Understand the context**: Review both versions
+- **Preserve functionality**: Keep your customizations working
+- **Test thoroughly**: Conflicts signal significant changes
+- **Be selective**: Only merge valuable updates; avoid bringing in features you won't use
+
+### Breaking changes
+
+When drop-in updates introduce breaking changes:
+
+- **Review migration guides**: Check package release notes for migration instructions
+- **Update integrations**: Modify custom code that depends on changed APIs
+- **Test edge cases**: Breaking changes often affect less common use cases
+- **Plan rollback**: Have a rollback plan ready before applying breaking changes
+
+## Best practices
+
+### Development workflow
+
+**Branch strategy**
+
+- Create upgrade branches with descriptive names (e.g., `upgrade-cart-v2.1.0`)
+- Merge upgrades through pull requests with thorough reviews
+
+**Testing approach**
+
+- Cover custom functionality with tests
+- Automate testing where possible
+- Test across devices and browsers
+- Use real product data
+
+**Deployment process**
+
+- Use staging environments that mirror production
+- Deploy during low-traffic periods
+- Monitor key metrics post-deployment
+- Have rollback procedures ready
+
+### Long-term maintenance
+
+**Stay current**
+
+- Update regularly, don't let them pile up
+- Apply security patches promptly
+- Plan major upgrades ahead well in advance
+
+**Customize thoughtfully**
+
+- Minimize modifications to core boilerplate files
+- Use configuration and theming approaches when possible
+- Document the business justification for customizations
+
+## Resources
+
+- [Storefront Developer Tutorial](/get-started/create-storefront/): Comprehensive storefront setup guide
+- [Architecture Guide](/setup/discovery/architecture/): Understanding the technical foundation
+- [Drop-in Components Documentation](/dropins/all/introduction/): Detailed component guides
+- <Link href="https://www.aem.live/docs/" text="AEM Edge Delivery Services" />: Core platform documentation
+- <Link href="https://github.com/hlxsites/aem-boilerplate-commerce" text="Commerce Boilerplate Repository" />: Source code and latest updates
+- [Release Notes](/releases/): Track major changes and updates
+- <Link href="https://github.com/hlxsites/aem-boilerplate-commerce/releases" text="Boilerplate Releases" />: GitHub releases and version history
+
+<Aside type="note">
+Upgrading is ongoing, not a one-time task. Regular, small updates are generally safer and easier to manage than infrequent, large upgrades.
+</Aside>
+


### PR DESCRIPTION
## Purpose of this pull request

This PR:
- Adds a topic for updating scaffolded instances of the Commerce Boilerplate project
- Covers NPM package updates and selective file merging strategies
- Documents the architectural evolution from embedded to packaged logic
- Includes PDP migration guide from slot-based to container-based
- Adds topic entry in the newly named Essentials section, previously the Quick start section

## Source docs

https://wiki.corp.adobe.com/display/EntComm/Upgrading+Existing+Commerce+Storefronts

### Staging preview

https://commerce-docs.github.io/microsite-commerce-storefront/get-started/update-boilerplate/

## Affected pages

**New page**: /developer/commerce/storefront/get-started/update-boilerplate

### Associated JIRA ticket

None.
