### PR TITLE
Add a browser-compatibility page

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -222,6 +222,7 @@ async function config() {
                       { label: 'Overview', link: '/get-started/' },
                       { label: 'Create a storefront', link: '/get-started/create-storefront' },
                       { label: 'Learn the architecture', link: '/setup/discovery/architecture/' },
+                      { label: 'Browser compatibility', link: '/get-started/browser-compatibility/' },
                       { label: 'Explore the boilerplate', link: '/get-started/boilerplate-project/' },
                       { label: 'Run Lighthouse audits', link: '/get-started/run-lighthouse/' },
                     ],

--- a/src/components/OptionsTable.astro
+++ b/src/components/OptionsTable.astro
@@ -10,7 +10,7 @@ const { options, compact = false, centerColumns = [] } = Astro.props;
 
 if (!options || options.length === 0) {
   throw new Error(
-    "OptionsTable: 'options' prop is required and should not be empty.",
+    "OptionsTable: 'options' prop is required and should not be empty."
   );
 }
 
@@ -18,7 +18,7 @@ const [headers, ...rows] = options;
 
 if (!headers || headers.length === 0) {
   throw new Error(
-    "OptionsTable: 'options' prop should have at least one row for headers.",
+    "OptionsTable: 'options' prop should have at least one row for headers."
   );
 }
 
@@ -166,7 +166,6 @@ const newRows = rows.map((row) => {
 
   th.headerCell {
     border: none;
-    padding: 2rem 3rem 0 0;
     font-weight: 600;
     white-space: nowrap;
   }

--- a/src/content/docs/get-started/browser-compatibility.mdx
+++ b/src/content/docs/get-started/browser-compatibility.mdx
@@ -1,0 +1,72 @@
+---
+title: Browser compatibility
+description: Learn about the supported browsers and devices for Adobe Commerce storefronts on Edge Delivery Services.
+---
+
+import { Steps } from '@astrojs/starlight/components';
+import TableWrapper from '@components/TableWrapper.astro';
+import Link from '@components/Link.astro';
+
+This page provides information about browser and device compatibility for Adobe Commerce storefronts on Edge Delivery Services.
+
+## Which boilerplate suite do I have?
+
+Browser support is tied to specific boilerplate suite versions. To determine which suite you're using, check your `package.json` file for the `@dropins/tools` version:
+
+   - **Suite 4 (October 14, 2025)**: `@dropins/tools@~1.4.0`
+   - **Suite 3 (August 12, 2025)**: `@dropins/tools@1.3.0`
+   - **Suite 2 (June 25, 2025)**: `@dropins/tools@0.42.0`
+
+
+## Browser support by suite
+
+### Desktop browsers
+
+<TableWrapper nowrap={[0]}>
+
+| Browser | Suite 4 (Oct 2025) | Suite 2 & 3 (Jun-Aug 2025) |
+|---------|-------------------|---------------------------|
+| Chrome  | 105 - 141         | 98 - 136                  |
+| Edge    | 105 - 141         | 98 - 136                  |
+| Safari  | 16 - 18.4         | 16 - 18.4                 |
+| Firefox | 110 - 143         | 108 - 138                 |
+| Opera   | 92 - 122          | 85 - 118                  |
+
+</TableWrapper>
+
+### Mobile browsers
+
+<TableWrapper nowrap={[0, 1]}>
+
+| Platform | Browser          | Suite 4 (Oct 2025) | Suite 2 & 3 (Jun-Aug 2025) |
+|----------|------------------|-------------------|---------------------------|
+| Android  | Chrome           | 141               | 136                       |
+| Android  | Edge             | 141               | 136                       |
+| Android  | Firefox          | 143               | 138                       |
+| Android  | Samsung Internet | 28                | 26                        |
+| Android  | UC Browser       | Not Supported     | Not Supported             |
+| iOS 16+  | Safari           | Default supported version | Default supported version |
+| iOS 16+  | Chrome           | Default supported version | Default supported version |
+
+</TableWrapper>
+
+## Known issues
+
+- **Chrome >= 100 < 105, Firefox >= 108 < 110, Opera < 92**: The product listing page loads in a single product column and does not support responsiveness.
+
+## Test URL
+
+You can test browser compatibility using the Commerce boilerplate test site: <Link href="https://main--aem-boilerplate-commerce--hlxsites.aem.live/" text="https://main--aem-boilerplate-commerce--hlxsites.aem.live/" />
+
+## Browser testing recommendations
+
+When testing your storefront, we recommend:
+
+<Steps>
+1. Testing on the minimum supported version of each major browser
+2. Testing on the latest version of each major browser
+3. Testing on both desktop and mobile devices
+4. Paying special attention to responsive behavior across different screen sizes
+5. Validating that product listing pages display correctly with multiple columns where supported
+</Steps>
+

--- a/src/content/docs/get-started/browser-compatibility.mdx
+++ b/src/content/docs/get-started/browser-compatibility.mdx
@@ -56,7 +56,7 @@ Browser support is tied to specific boilerplate suite versions. To determine whi
 
 ## Test URL
 
-You can test browser compatibility using the Commerce boilerplate test site: <Link href="https://main--aem-boilerplate-commerce--hlxsites.aem.live/" text="https://main--aem-boilerplate-commerce--hlxsites.aem.live/" />
+You can test browser compatibility using the Commerce boilerplate test site: <Link href="https://www.aemshop.net/" text="https://www.aemshop.net/" />
 
 ## Browser testing recommendations
 

--- a/src/content/docs/get-started/browser-compatibility.mdx
+++ b/src/content/docs/get-started/browser-compatibility.mdx
@@ -52,7 +52,11 @@ Browser support is tied to specific boilerplate suite versions. To determine whi
 
 ## Known issues
 
-- **Chrome >= 100 < 105, Firefox >= 108 < 110, Opera < 92**: The product listing page loads in a single product column and does not support responsiveness.
+For the following browsers, the product listing page loads in a single product column and does not support responsiveness:
+
+- Chrome: 100 - 104
+- Firefox: 108 and 109
+- Opera: 91 or less
 
 ## Test URL
 
@@ -62,11 +66,9 @@ You can test browser compatibility using the Commerce boilerplate test site: <Li
 
 When testing your storefront, we recommend:
 
-<Steps>
-1. Testing on the minimum supported version of each major browser
-2. Testing on the latest version of each major browser
-3. Testing on both desktop and mobile devices
-4. Paying special attention to responsive behavior across different screen sizes
-5. Validating that product listing pages display correctly with multiple columns where supported
-</Steps>
+- Testing on the minimum supported version of each major browser
+- Testing on the latest version of each major browser
+- Testing on both desktop and mobile devices
+- Paying special attention to responsive behavior across different screen sizes
+- Validating the product listing pages display correctly with multiple columns
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a browser-compatibility page for the Boilerplate. 

## Staged Preview

https://commerce-docs.github.io/microsite-commerce-storefront/get-started/browser-compatibility/

None. Slack channel request.

### Associated JIRA ticket

None. Slack channel request.

## Affected pages

New page to be accessed here: /get-started/browser-compatibility/

## Links to source

https://wiki.corp.adobe.com/pages/viewpage.action?pageId=3523343465

