### PR TITLE
INTERNAL: Mark Apple Pay as supported and order payment methods

### DIFF
--- a/src/content/docs/dropins/payment-services/index.mdx
+++ b/src/content/docs/dropins/payment-services/index.mdx
@@ -11,13 +11,13 @@ The Payment Services drop-in component renders the credit card form and the Appl
 
 The following table provides an overview of the Payment Services payment methods that the Payment Services drop-in supports. The "Payment method code" column lists the `PaymentMethodCode` enum value for each method:
 
-| Payment method    | Payment method code          | Status                                     |
-|-------------------|------------------------------|--------------------------------------------|
-| Apple Pay         | `APPLE_PAY`                  | <Badge text="Roadmap" variant="caution" /> |
-| Credit/debit card | `CREDIT_CARD`                | <Badge text="Supported" variant="tip" />   |
-| Google Pay        | `GOOGLE_PAY`                 | <Badge text="Roadmap" variant="caution" /> |
-| PayPal Fastlane   | `FASTLANE`                   | <Badge text="Roadmap" variant="caution" /> |
-| PayPal buttons    | `SMART_BUTTONS`              | <Badge text="Roadmap" variant="caution" /> |
+| Payment method    | Payment method code | Status                                     |
+|-------------------|---------------------|--------------------------------------------|
+| Apple Pay         | `APPLE_PAY`         | <Badge text="Supported" variant="tip" />   |
+| Credit/debit card | `CREDIT_CARD`       | <Badge text="Supported" variant="tip" />   |
+| Google Pay        | `GOOGLE_PAY`        | <Badge text="Roadmap" variant="caution" /> |
+| PayPal Fastlane   | `FASTLANE`          | <Badge text="Roadmap" variant="caution" /> |
+| PayPal buttons    | `SMART_BUTTONS`     | <Badge text="Roadmap" variant="caution" /> |
 
 Use the `PaymentMethodCode` enum from the API import:
 
@@ -29,9 +29,9 @@ import { PaymentMethodCode } from '@dropins/storefront-payment-services/api.js';
 
 The Payment Services drop-in component provides two containers:
 
-- **Credit card container:** The `CreditCard` container renders a form where shoppers enter their card details to place an order with a credit or debit card.
-
 - **Apple Pay container:** The `ApplePay` container renders an Apple Pay button that shoppers on Apple devices can use to place an order.
+
+- **Credit card container:** The `CreditCard` container renders a form where shoppers enter their card details to place an order with a credit or debit card.
 
 ## Additional resources
 


### PR DESCRIPTION
## Purpose of this pull request

We recently added a table of supported payment methods in `develop` (https://github.com/commerce-docs/microsite-commerce-storefront/pull/509).

After merging `develop` into this `PAY-dropin-v2` branch, this pull request updates the Apple Pay payment method status from "Roadmap" to "Supported".

Also, it proposes reordering the "Apple Pay container" and "Credit card container" in "Payment Services overview" to match the (alphabetical) order of the corresponding page links in the navbar.

<img width="1263" height="850" alt="image" src="https://github.com/user-attachments/assets/551b74c4-e6ba-496f-ac7a-a9fcb0beca76" />

### Associated JIRA ticket

N/A


### Staging preview

N/A


## Affected pages

https://experienceleague.adobe.com/developer/commerce/storefront/dropins/payment-services/

## Links to source code

N/A

