### PR TITLE
PAY-6243: Update onError definition and add errors to dictionary

### DIFF
--- a/src/content/docs/dropins/payment-services/containers/apple-pay.mdx
+++ b/src/content/docs/dropins/payment-services/containers/apple-pay.mdx
@@ -20,13 +20,13 @@ The `ApplePay` container provides the following configuration options:
     ['getCartId', 'function', 'Maybe', 'Required if "createCart" not provided. Should return a promise that resolves to the shopper\'s cart ID.'],
     ['createCart', 'object', 'Maybe', 'Required if "getCartId" not provided. The object should define a single "getCartItems" property, which should be a function that returns a list of cart items to purchase. The list must contain at least one cart item. Cart items must be provided as objects with, at minimum, an "sku" (string) and a "quantity" (number). See "Cart item object" section for more information.'],
     ['onSuccess', 'function', 'No', 'Called when the payment flow finishes successfully. If the function returns a promise, the promise will be awaited before marking the payment as "completed successfully" in the Apple Pay sheet. If the promise rejects, the payment will be marked as "failed" in the Apple Pay sheet and the error will be propagated to the "onError" callback, if provided.'],
-    ['onError', 'function', 'No', 'Called when the payment flow was aborted due to an error. The function receives an object with two properties: {name: string, message: string}, containing the localized error name and message. Both properties are user-facing and can be translated using the "PaymentServices.ApplePay.errors" language definitions *.'],
+    ['onError', 'function', 'No', 'Called when the payment flow was aborted due to an error. The function receives an object with two properties: {name: string, message: string}, containing the localized error name and message. Both properties are user-facing and can be translated using the `PaymentServices.ApplePay.errors` language definitions.'],
     ['hidden', 'boolean', 'No', 'Whether the button is hidden. Set this to true to hide the Apple Pay button (default: false).'],
     ['disabled', 'boolean', 'No', 'Whether the button is disabled. Set this to true to disable the Apple Pay button (default: false).'],
   ]}
 />
 
-_\* See <Link href="/dropins/payment-services/dictionary/" text="Payment Services dictionary" />._
+_* See [Payment Services dictionary](/dropins/payment-services/dictionary/)._
 
 ### Cart item object
 

--- a/src/content/docs/dropins/payment-services/containers/credit-card.mdx
+++ b/src/content/docs/dropins/payment-services/containers/credit-card.mdx
@@ -4,7 +4,6 @@ description: Use the CreditCard container to render a credit card form during ch
 ---
 
 import OptionsTable from '@components/OptionsTable.astro';
-import Link from '@components/Link.astro';
 
 The `CreditCard` container allows a shopper to enter credit card details during the checkout process. You can configure it to manage and display the credit card fields.
 
@@ -19,11 +18,11 @@ The `CreditCard` container provides the following configuration options:
     ['getCartId', 'function', 'Yes', 'Should return a promise that resolves to the shopper`s cart ID.'],
     ['creditCardFormRef', 'object', 'Yes', 'Credit card form reference. Initially, { current: null } should be passed. Once rendered, the credit card container will set the "current" property to an { validate: () => boolean; submit: () => Promise<void> } object, which parent containers can use to (programmatically) validate and submit the credit card form.'],
     ['onSuccess', 'function', 'No', 'Called when the payment flow finishes successfully. This function is not passed any arguments.'],
-    ['onError', 'function', 'No', 'Called when the payment flow was aborted due to an error. The function receives an object with two properties: {name: string, message: string}, containing the localized error name and message. Both properties are user-facing and can be translated using the "PaymentServices.CreditCard.errors" language definitions *.'],
+    ['onError', 'function', 'No', 'Called when the payment flow was aborted due to an error. The function receives an object with two properties: {name: string, message: string}, containing the localized error name and message. Both properties are user-facing and can be translated using the `PaymentServices.ApplePay.errors` language definitions.'],
   ]}
 />
 
-_\* See <Link href="/dropins/payment-services/dictionary/" text="Payment Services dictionary" />._
+_* See [Payment Services dictionary](/dropins/payment-services/dictionary/)._
 
 ## Example
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) updates the onError definitions in ApplePay and CreditCard since the errors can be now localized. As well, adds the localizable errors to the dictionary.

### Associated JIRA ticket
https://jira.corp.adobe.com/browse/PAY-6243

### Staging preview
N/A

## Affected pages
- https://experienceleague.adobe.com/developer/commerce/storefront/dropins/payment-services/containers/credit-card/
- https://experienceleague.adobe.com/dropins/payment-services/containers/apple-pay/ *
- https://experienceleague.adobe.com/developer/commerce/storefront/dropins/payment-services/dictionary/ **

_* to be published in the next dropin release_
_** will be updated automatically when we release the public version of the npm package_

## Links to source code
https://github.com/adobe-commerce/storefront-payment-services/pull/19
