### PR TITLE
added product discovery containers index page to resolve link

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -587,7 +587,6 @@ async function config() {
                           { label: 'Discovery styling', link: '/dropins/product-discovery/styles/' },
                           { label: 'Discovery functions', link: '/dropins/product-discovery/functions/' },
                           { label: 'Events', link: '/dropins/product-discovery/events/' },
-                          { label: 'Containers', link: '/dropins/product-discovery/containers/' },
                           { label: 'Dictionary', link: '/dropins/product-discovery/dictionary/' },
                           { label: 'Discovery dictionary', link: '/dropins/product-discovery/dictionary/' },
                           { label: 'Discovery slots', link: '/dropins/product-discovery/slots/' },
@@ -595,6 +594,7 @@ async function config() {
                             label: 'Product Discovery containers',
                             collapsed: false,
                             items: [
+                              { label: 'Overview', link: '/dropins/product-discovery/containers/' },
                               { label: 'SearchResults', link: '/dropins/product-discovery/containers/search-results/' },
                               { label: 'Facets', link: '/dropins/product-discovery/containers/facets/' },
                               { label: 'SortBy', link: '/dropins/product-discovery/containers/sort-by/' },

--- a/src/content/docs/dropins/product-discovery/containers/index.mdx
+++ b/src/content/docs/dropins/product-discovery/containers/index.mdx
@@ -6,7 +6,14 @@ description: Learn about the Product Discovery containers available for building
 import CardGrid from '@components/CardGrid.astro';
 import LinkCard from '@components/LinkCard.astro';
 
-Product Discovery containers display search results, category listings, and product listing pages. These event-driven components react to search events: SearchResults displays products, Facets filters results, SortBy sorts products, and Pagination navigates pages. Each container responds to the Product Discovery API, keeping the UI in sync as customers search, filter, sort, and browse.
+Product Discovery containers display search results, category listings, and product listing pages. These event-driven components react to these search events:
+
+- **SearchResults** displays products
+- **Facets** filters results
+- **SortBy** sorts products
+- **Pagination** navigates pages
+
+Each container responds to the Product Discovery API, keeping the UI in sync as customers search, filter, sort, and browse.
 
 <CardGrid columns={2}>
   <LinkCard

--- a/src/content/docs/dropins/product-discovery/containers/index.mdx
+++ b/src/content/docs/dropins/product-discovery/containers/index.mdx
@@ -1,0 +1,45 @@
+---
+title: Product Discovery containers
+description: Learn about the Product Discovery containers available for building search and product listing experiences.
+---
+
+import CardGrid from '@components/CardGrid.astro';
+import LinkCard from '@components/LinkCard.astro';
+
+Product Discovery containers display and manage product search results, category listings, and product listing pages. These event-driven components work together to build search experiences: SearchResults displays products, Facets provides filtering, SortBy offers sorting options, and Pagination navigates through results. Each container reacts to search events from the Product Discovery API, keeping the UI synchronized as customers search, filter, sort, and browse products.
+
+<CardGrid columns={2}>
+  <LinkCard
+    noborder
+    icon='document'
+    title="SearchResults"
+    description="Display product search results with configurable layouts and product information."
+    link="/dropins/product-discovery/containers/search-results/"
+    rightIcon="right-arrow"
+  />
+  <LinkCard
+    noborder
+    icon='document'
+    title="Facets"
+    description="Provide filtering options for customers to refine search results by attributes and categories."
+    link="/dropins/product-discovery/containers/facets/"
+    rightIcon="right-arrow"
+  />
+  <LinkCard
+    noborder
+    icon='document'
+    title="SortBy"
+    description="Enable customers to sort product results by price, name, relevance, and other criteria."
+    link="/dropins/product-discovery/containers/sort-by/"
+    rightIcon="right-arrow"
+  />
+  <LinkCard
+    noborder
+    icon='document'
+    title="Pagination"
+    description="Navigate through multiple pages of product results with customizable pagination controls."
+    link="/dropins/product-discovery/containers/pagination/"
+    rightIcon="right-arrow"
+  />
+</CardGrid>
+

--- a/src/content/docs/dropins/product-discovery/containers/index.mdx
+++ b/src/content/docs/dropins/product-discovery/containers/index.mdx
@@ -6,7 +6,7 @@ description: Learn about the Product Discovery containers available for building
 import CardGrid from '@components/CardGrid.astro';
 import LinkCard from '@components/LinkCard.astro';
 
-Product Discovery containers display and manage product search results, category listings, and product listing pages. These event-driven components work together to build search experiences: SearchResults displays products, Facets provides filtering, SortBy offers sorting options, and Pagination navigates through results. Each container reacts to search events from the Product Discovery API, keeping the UI synchronized as customers search, filter, sort, and browse products.
+Product Discovery containers display search results, category listings, and product listing pages. These event-driven components react to search events: SearchResults displays products, Facets filters results, SortBy sorts products, and Pagination navigates pages. Each container responds to the Product Discovery API, keeping the UI in sync as customers search, filter, sort, and browse.
 
 <CardGrid columns={2}>
   <LinkCard


### PR DESCRIPTION
## Fix Product Discovery containers navigation and add overview page

Fixes a 403 error for `/dropins/product-discovery/containers/` by creating an index page and updating navigation.

### Changes

**Created containers overview page** (`/dropins/product-discovery/containers/index.mdx`)
- New index page with introduction to Product Discovery containers
- CardGrid layout with links to all 4 containers: SearchResults, Facets, SortBy, and Pagination
- Explains how containers work together as event-driven components

**Updated navigation** (`astro.config.mjs`)
- Removed duplicate "Containers" link that pointed to non-existent page
- Added "Overview" as first item in "Product Discovery containers" subsection
- Navigation now properly links to new index page

### Result
- `/dropins/product-discovery/containers/` now displays overview page instead of 404
- Consistent with other drop-in documentation patterns
- Clearer navigation structure for Product Discovery containers