### PR TITLE
Update link for styling drop-in components

### DIFF
--- a/src/content/docs/dropins/order/styles.mdx
+++ b/src/content/docs/dropins/order/styles.mdx
@@ -27,7 +27,7 @@ import shippingStatusCard from './files/shipping-status-card.css?raw';
 
 The CSS classes for each UI component that provides the order drop-in component with its UI are provided here. Override these classes and add new classes to customize the look and feel of your cart to match your specific style requirements.
 
-[Styling drop-in components](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/styling/) describes how to inspect the drop-in component in your browser's developer tools to discover the BEM class names to be extended.
+[Styling drop-in components](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/all/styling/) describes how to inspect the drop-in component in your browser's developer tools to discover the BEM class names to be extended.
 
 ## Example CSS overrides
 

--- a/src/content/docs/dropins/product-discovery/styles.mdx
+++ b/src/content/docs/dropins/product-discovery/styles.mdx
@@ -13,7 +13,7 @@ import searchAlertMessage from './files/alert-message.css?raw';
 
 The CSS classes for each UI component that provides the product discovery drop-in component with its UI are provided here. Override these classes and add new classes to customize the look and feel of your product discovery components to match your specific style requirements.
 
-[Styling drop-in components](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/styling/) describes how to inspect the drop-in component in your browser's developer tools to discover the BEM class names to be extended.
+[Styling drop-in components](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/all/styling/) describes how to inspect the drop-in component in your browser's developer tools to discover the BEM class names to be extended.
 
 
 ## Example CSS overrides


### PR DESCRIPTION

## Purpose of this pull request

- Fix broken link:  https://experienceleague.adobe.com/developer/commerce/storefront/dropins/styling/

- Change to: Updated URL:  https://experienceleague.adobe.com/developer/commerce/storefront/dropins/all/styling/

