### PR TITLE
fixed versions for commerce blocks in merchant docs

### DIFF
--- a/scripts/@generate-merchant-block-docs.js
+++ b/scripts/@generate-merchant-block-docs.js
@@ -690,9 +690,25 @@ function extractCommerceBlocks(boilerplatePath) {
 // ============================================================================
 
 /**
- * Get boilerplate version from git tag
+ * Get boilerplate version from package.json
+ * This provides a consistent semantic version (e.g., 4.0.1) rather than
+ * git tags which may be descriptive (e.g., "fix-headers")
  */
 function getBoilerplateVersion(boilerplatePath) {
+    try {
+        // Primary: Use package.json version (semantic versioning)
+        const packageJsonPath = join(boilerplatePath, 'package.json');
+        if (existsSync(packageJsonPath)) {
+            const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
+            if (packageJson.version) {
+                return packageJson.version;
+            }
+        }
+    } catch (error) {
+        console.warn('  ⚠️  Could not read package.json version');
+    }
+
+    // Fallback: Try git tag (only if package.json fails)
     try {
         const tag = execSync('git describe --tags --abbrev=0', {
             cwd: boilerplatePath,
@@ -700,17 +716,7 @@ function getBoilerplateVersion(boilerplatePath) {
         }).trim();
         // Remove 'v' prefix if present
         return tag.replace(/^v/, '');
-    } catch (error) {
-        // Fallback: try to get from package.json
-        try {
-            const packageJsonPath = join(boilerplatePath, 'package.json');
-            if (existsSync(packageJsonPath)) {
-                const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf8'));
-                return packageJson.version || 'latest';
-            }
-        } catch {
-            return 'latest';
-        }
+    } catch {
         return 'latest';
     }
 }
@@ -719,7 +725,7 @@ function getBoilerplateVersion(boilerplatePath) {
  * Mapping of blocks to their setup/tutorial guides
  */
 const setupGuideMapping = {
-    'product-recommendations': '/merchants/get-started/product-recommendations/'
+    'product-recommendations': '/merchants/commerce-blocks/product-recommendations/'
 };
 
 /**
@@ -757,7 +763,7 @@ Before using this block, see the [${block.displayName} setup guide](${setupGuide
     }
 
     content += `<div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: ${boilerplateVersion}</strong>
+<strong>Boilerplate version: ${boilerplateVersion}</strong>
 </div>
 
 `;

--- a/src/content/docs/merchants/blocks/commerce-account-header.mdx
+++ b/src/content/docs/merchants/blocks/commerce-account-header.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Configure the customer account header navigation. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Document authoring configuration

--- a/src/content/docs/merchants/blocks/commerce-account-sidebar.mdx
+++ b/src/content/docs/merchants/blocks/commerce-account-sidebar.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Configure the account sidebar block for your store. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Section metadata

--- a/src/content/docs/merchants/blocks/commerce-addresses.mdx
+++ b/src/content/docs/merchants/blocks/commerce-addresses.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Set up customer address management. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Page metadata

--- a/src/content/docs/merchants/blocks/commerce-cart.mdx
+++ b/src/content/docs/merchants/blocks/commerce-cart.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Configure the shopping cart page to display product details, pricing, and checkout options. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Page metadata

--- a/src/content/docs/merchants/blocks/commerce-checkout.mdx
+++ b/src/content/docs/merchants/blocks/commerce-checkout.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Set up the checkout flow including shipping, payment, and order review. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Page metadata

--- a/src/content/docs/merchants/blocks/commerce-confirm-account.mdx
+++ b/src/content/docs/merchants/blocks/commerce-confirm-account.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Configure the confirm account block for your store. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Section metadata

--- a/src/content/docs/merchants/blocks/commerce-create-account.mdx
+++ b/src/content/docs/merchants/blocks/commerce-create-account.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Configure the account registration page. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Page metadata

--- a/src/content/docs/merchants/blocks/commerce-create-password.mdx
+++ b/src/content/docs/merchants/blocks/commerce-create-password.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Configure the create password block for your store. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Section metadata

--- a/src/content/docs/merchants/blocks/commerce-create-return.mdx
+++ b/src/content/docs/merchants/blocks/commerce-create-return.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Configure the create return block for your store. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Section metadata

--- a/src/content/docs/merchants/blocks/commerce-customer-details.mdx
+++ b/src/content/docs/merchants/blocks/commerce-customer-details.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Configure the customer details block for your store. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Section metadata

--- a/src/content/docs/merchants/blocks/commerce-customer-information.mdx
+++ b/src/content/docs/merchants/blocks/commerce-customer-information.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Configure the customer information block for your store. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Section metadata

--- a/src/content/docs/merchants/blocks/commerce-forgot-password.mdx
+++ b/src/content/docs/merchants/blocks/commerce-forgot-password.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Configure the forgot password block for your store. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Section metadata

--- a/src/content/docs/merchants/blocks/commerce-gift-options.mdx
+++ b/src/content/docs/merchants/blocks/commerce-gift-options.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Configure the gift options block for your store. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Section metadata

--- a/src/content/docs/merchants/blocks/commerce-login.mdx
+++ b/src/content/docs/merchants/blocks/commerce-login.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Customize the customer login page. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Page metadata

--- a/src/content/docs/merchants/blocks/commerce-mini-cart.mdx
+++ b/src/content/docs/merchants/blocks/commerce-mini-cart.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Configure the mini-cart dropdown that appears in your site header. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Document authoring configuration

--- a/src/content/docs/merchants/blocks/commerce-order-cost-summary.mdx
+++ b/src/content/docs/merchants/blocks/commerce-order-cost-summary.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Configure the order cost summary block for your store. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Section metadata

--- a/src/content/docs/merchants/blocks/commerce-order-header.mdx
+++ b/src/content/docs/merchants/blocks/commerce-order-header.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Configure the order header block for your store. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Section metadata

--- a/src/content/docs/merchants/blocks/commerce-order-product-list.mdx
+++ b/src/content/docs/merchants/blocks/commerce-order-product-list.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Configure the order product list block for your store. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Section metadata

--- a/src/content/docs/merchants/blocks/commerce-order-returns.mdx
+++ b/src/content/docs/merchants/blocks/commerce-order-returns.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Configure the order returns block for your store. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Section metadata

--- a/src/content/docs/merchants/blocks/commerce-order-status.mdx
+++ b/src/content/docs/merchants/blocks/commerce-order-status.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Configure the order status block for your store. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Section metadata

--- a/src/content/docs/merchants/blocks/commerce-orders-list.mdx
+++ b/src/content/docs/merchants/blocks/commerce-orders-list.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Configure the customer order history page. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Document authoring configuration

--- a/src/content/docs/merchants/blocks/commerce-return-header.mdx
+++ b/src/content/docs/merchants/blocks/commerce-return-header.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Configure the return header block for your store. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Section metadata

--- a/src/content/docs/merchants/blocks/commerce-returns-list.mdx
+++ b/src/content/docs/merchants/blocks/commerce-returns-list.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Configure the returns list block for your store. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Document authoring configuration

--- a/src/content/docs/merchants/blocks/commerce-search-order.mdx
+++ b/src/content/docs/merchants/blocks/commerce-search-order.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Configure the search order block for your store. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Section metadata

--- a/src/content/docs/merchants/blocks/commerce-shipping-status.mdx
+++ b/src/content/docs/merchants/blocks/commerce-shipping-status.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Configure the shipping status block for your store. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Section metadata

--- a/src/content/docs/merchants/blocks/commerce-wishlist.mdx
+++ b/src/content/docs/merchants/blocks/commerce-wishlist.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Set up the wishlist feature for customer saved items. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Document authoring configuration

--- a/src/content/docs/merchants/blocks/product-details.mdx
+++ b/src/content/docs/merchants/blocks/product-details.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Customize the product detail page layout and information display. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Document authoring configuration

--- a/src/content/docs/merchants/blocks/product-list-page.mdx
+++ b/src/content/docs/merchants/blocks/product-list-page.mdx
@@ -10,7 +10,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Configure product listing pages and category views. This block integrates with Adobe Commerce to provide a seamless shopping experience for your customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Document authoring configuration

--- a/src/content/docs/merchants/blocks/product-recommendations.mdx
+++ b/src/content/docs/merchants/blocks/product-recommendations.mdx
@@ -14,7 +14,7 @@ Before using this block, see the [Product Recommendations setup guide](/merchant
 :::
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: fix-headers</strong>
+<strong>Boilerplate version: 4.0.1</strong>
 </div>
 
 ## Document authoring configuration


### PR DESCRIPTION
## Commerce Block Version Display Improvements

This PR fixes version display issues in the commerce block documentation and corrects a broken link.

### Changes

**Version Number Fix**
- Modified `getBoilerplateVersion()` to use `package.json` as the primary source
- Commerce blocks now display semantic version `4.0.1` instead of git tag name `fix-headers`
- Git tags used as a fallback only if `package.json` is unavailable

**Version Label Clarification**
- Changed label from "Version:" to "Boilerplate version:"
- Makes it clear the version refers to the boilerplate release, not individual blocks
- More accurate and merchant-friendly

**Broken Link Fix**
- Updated setup guide link for product recommendations block
- Changed from `/merchants/get-started/product-recommendations/` to `/merchants/commerce-blocks/product-recommendations/`

### Impact

- All 29 commerce block pages now display: **Boilerplate version: 4.0.1**
- Merchants can easily understand which boilerplate version the documentation covers
- All internal links validated and passing

### Files Changed

- `scripts/@generate-merchant-block-docs.js`
- All generated files in `src/content/docs/merchants/blocks/*.mdx`