### PR TITLE
fixed overview page for getting started section

### DIFF
--- a/src/content/docs/get-started/index.mdx
+++ b/src/content/docs/get-started/index.mdx
@@ -19,7 +19,7 @@ import { Steps } from '@astrojs/starlight/components';
 
 Quick Start provides everything you need to begin building with Adobe Commerce Storefronts, from understanding the architecture to creating your first storefront and optimizing performance.
 
-<CardGrid columns={3}>
+<CardGrid columns={4}>
   <LinkCard
     noborder
     icon='document'
@@ -42,22 +42,6 @@ Quick Start provides everything you need to begin building with Adobe Commerce S
     title="Browser compatibility"
     description="Learn which browsers and versions are supported for optimal storefront performance."
     link="/get-started/browser-compatibility/"
-    rightIcon="right-arrow"
-  />
-  <LinkCard
-    noborder
-    icon='document'
-    title="Explore the boilerplate"
-    description="Learn about the boilerplate project structure and components to understand how everything works together."
-    link="/boilerplate/getting-started/"
-    rightIcon="right-arrow"
-  />
-  <LinkCard
-    noborder
-    icon='document'
-    title="Update the boilerplate"
-    description="Keep your storefront up to date with the latest features and improvements from the boilerplate."
-    link="/boilerplate/updates/"
     rightIcon="right-arrow"
   />
   <LinkCard


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes the inaccurate list of cards on the intro page of the getting started section.

