### PR TITLE
COMDOX-1399: Remark base paths in Link components

### DIFF
--- a/src/components/Link.astro
+++ b/src/components/Link.astro
@@ -1,6 +1,7 @@
 ---
 import { Icons } from "@components/overrides/Icons";
 import Icon from "@components/overrides/Icon.astro";
+import { setBasePath } from "@utils/basePath";
 
 interface Props {
   href: string;
@@ -13,7 +14,7 @@ const isExternal = href?.startsWith("https://");
 ---
 
 <a
-  href={href}
+  href={isExternal ? href : setBasePath(href)}
   target={isExternal ? "_blank" : "_self"}
   rel={isExternal ? "noopener noreferrer" : undefined}
 >


### PR DESCRIPTION
## Purpose of this pull request

Links that start with `/` must have the `VITE_PROD_BASE_PATH` prepended when built for production. We do this for vanilla markdown links using the custom [`remarkBasePathLinks`](https://github.com/commerce-docs/microsite-commerce-storefront/blob/develop/src/plugins/remarkBasePathLinks.js) plugin. For manual `<a>` links, we do this by preprocessing the `href` attribute using the [`setBasePath`](https://github.com/commerce-docs/microsite-commerce-storefront/blob/00eda6caf957ac07b63b87c56e15b54a14a08db6/src/utils/basePath.ts#L12-L17) helper, for example, here:

https://github.com/commerce-docs/microsite-commerce-storefront/blob/00eda6caf957ac07b63b87c56e15b54a14a08db6/src/components/LinkCard.astro#L53-L56

We don't yet do this for the `Link` component. As a result, all links created with the `Link` component that start with `/` are currently broken. As far as I can tell, there are only three affected links:

- "URL rewrite" on https://experienceleague.adobe.com/developer/commerce/storefront/dropins/payment-services/installation/ ([see source](https://github.com/commerce-docs/microsite-commerce-storefront/blob/00eda6caf957ac07b63b87c56e15b54a14a08db6/src/content/docs/dropins/payment-services/installation.mdx?plain=1#L59))
- "Storefront configuration" (1) on https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/aem-prerender/#installation-and-configuration ([see source](https://github.com/commerce-docs/microsite-commerce-storefront/blob/00eda6caf957ac07b63b87c56e15b54a14a08db6/src/content/docs/setup/configuration/aem-prerender.mdx?plain=1#L256))
- "Storefront configuration" (2) on https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/aem-prerender/#installation-and-configuration ([see source](https://github.com/commerce-docs/microsite-commerce-storefront/blob/00eda6caf957ac07b63b87c56e15b54a14a08db6/src/content/docs/setup/configuration/aem-prerender.mdx?plain=1#L272))

This pull request proposes to prepend the `VITE_PROD_BASE_PATH` to the `href` attribute in the `Link` component, just like we do for similar components, like `LinkCard` or `Badge`.

### Associated JIRA ticket
Fixes https://jira.corp.adobe.com/browse/COMDOX-1399

### ~Staging~ Local preview

Tested locally using
```
npm run build:prod-fast
npm run preview:prod-fast
```

| Before | After |
|--------|-------|
| <img width="1571" height="1042" alt="comdox-1399-before" src="https://github.com/user-attachments/assets/c09c2a2c-ed81-4a42-af72-f8ca17aa9fb1" /> | <img width="1572" height="1039" alt="comdox-1399-after" src="https://github.com/user-attachments/assets/e1e15885-afbe-47b8-aecf-488a3cdebcd8" /> |

## Affected pages

- https://experienceleague.adobe.com/developer/commerce/storefront/dropins/payment-services/installation/
- https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/aem-prerender/

## Links to source code

N/A
