### PR TITLE
Auth dropin customer permission roles

### DIFF
--- a/src/content/docs/dropins/checkout/tutorials/validate-shipping-address.mdx
+++ b/src/content/docs/dropins/checkout/tutorials/validate-shipping-address.mdx
@@ -62,9 +62,11 @@ const handlePlaceOrder = async ({ cartId, code }) => {
           if (selection === 'suggested') {
             await checkoutApi.setShippingAddress({ address });
             const latest = events.lastPayload('checkout/updated');
-            // Unmount shipping address form and render again with latest checkout data
-            unmountContainer(CONTAINERS.SHIPPING_ADDRESS_FORM);
-            await renderAddressForm($shippingForm, shippingFormRef, latest, placeOrder, 'shipping');
+            // Update the shipping form with the suggested address
+            shippingForm.setProps((prevProps) => ({
+              ...prevProps,
+              inputsDefaultValueSet: address,
+            }));
           } else {
             // Place order
             await orderApi.placeOrder(cartId);

--- a/src/content/docs/dropins/user-auth/initialization.mdx
+++ b/src/content/docs/dropins/user-auth/initialization.mdx
@@ -27,8 +27,8 @@ The following table describes the configuration options available for the **User
 |---|---|---|---|
 | `langDefinitions` | [`LangDefinitions`](#langdefinitions) | No | Language definitions for internationalization (i18n). Override dictionary keys for localization or branding. |
 | `models` | [`Record<string, any>`](#models) | No | Custom data models for type transformations. Extend or modify default models with custom fields and transformers. |
-| `authHeaderConfig` | [`authHeaderConfig`](#authheaderconfig) | No | Configures authentication header format for API requests including custom header names and token prefix format (e.g., 'Bearer', 'Token'). |
-| `customerPermissionRoles` | `boolean` | No | When `true`, fetches and caches customer role-based permissions during initialization and on auth state changes. Useful for B2B gating. Default: `false`. |
+| `authHeaderConfig` | [`authHeaderConfig`](#authheaderconfig) | No | Configures authentication header format for API requests including custom header names and token prefix format (for example, 'Bearer', 'Token'). |
+| `customerPermissionRoles` | `boolean` | No | Fetches and caches customer role-based permissions during initialization and on authentication state changes when set to \`true\`. Useful for B2B feature gating. |
 
 </TableWrapper>
 
@@ -141,7 +141,7 @@ The following TypeScript definitions show the structure of each configuration ob
 
 ### authHeaderConfig
 
-Configures authentication header format for API requests including custom header names and token prefix format (e.g., 'Bearer', 'Token').
+Configures authentication header format for API requests including custom header names and token prefix format (for example, 'Bearer', 'Token').
 
 ```typescript
 authHeaderConfig?: {
@@ -189,7 +189,7 @@ customerPermissionRoles?: boolean;
 import { events } from '@adobe-commerce/event-bus';
 
 events.on('auth/permissions', (permissions) => {
-  // gate UI/actions based on permissions
+  // Gate UI or actions based on permissions
 });
 ```
 

--- a/src/content/docs/dropins/user-auth/initialization.mdx
+++ b/src/content/docs/dropins/user-auth/initialization.mdx
@@ -28,7 +28,7 @@ The following table describes the configuration options available for the **User
 | `langDefinitions` | [`LangDefinitions`](#langdefinitions) | No | Language definitions for internationalization (i18n). Override dictionary keys for localization or branding. |
 | `models` | [`Record<string, any>`](#models) | No | Custom data models for type transformations. Extend or modify default models with custom fields and transformers. |
 | `authHeaderConfig` | [`authHeaderConfig`](#authheaderconfig) | No | Configures authentication header format for API requests including custom header names and token prefix format (e.g., 'Bearer', 'Token'). |
-| `customerPermissionRoles` | `boolean` | No | Configuration for customerPermissionRoles. |
+| `customerPermissionRoles` | `boolean` | No | When `true`, fetches and caches customer role-based permissions during initialization and on auth state changes. Useful for B2B gating. Default: `false`. |
 
 </TableWrapper>
 
@@ -46,7 +46,7 @@ await initializers.mountImmediately(initialize, {
   models: {}, // Uses default data models
   // Drop-in-specific defaults:
   // authHeaderConfig: undefined // See configuration options below
-  // customerPermissionRoles: undefined // See configuration options below
+  // customerPermissionRoles: false // Enable to fetch role-based permissions
 });
 ```
 
@@ -170,6 +170,27 @@ Maps model names to transformer functions. Each transformer receives data from G
 models?: {
   [modelName: string]: Model<any>;
 };
+```
+
+### customerPermissionRoles
+
+Enables retrieval of customer role-based permissions.
+
+- When enabled, the drop-in fetches permissions on initialization (if a token is present) and on authentication state changes.
+- Permissions are cached and emitted via the `auth/permissions` event for other components or drop-ins to consume.
+- Default: `false`.
+
+```typescript
+customerPermissionRoles?: boolean;
+```
+
+```javascript
+// Example: consuming emitted permissions
+import { events } from '@adobe-commerce/event-bus';
+
+events.on('auth/permissions', (permissions) => {
+  // gate UI/actions based on permissions
+});
 ```
 
 


### PR DESCRIPTION
## Purpose of this pull request

- Add documentation for `customerPermissionRoles` initialization property from **user-auth** drop-in.
- Update implementation code for address validation tutorial from the **checkout** drop-in.

### Associated JIRA ticket

https://jira.corp.adobe.com/browse/USF-3384

### Staging preview

<!--OPTIONAL Link to staging preview if available-->
N/A

## Affected pages

<!-- REQUIRED List the affected pages on experienceleague.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://experienceleague.adobe.com/developer/commerce/storefront/dropins/user-auth/initialization/
- https://experienceleague.adobe.com/developer/commerce/storefront/dropins/checkout/tutorials/validate-shipping-address/

## Links to source code

<!--OPTIONAL Link to any associated source code PRs related to update-->
N/A

