### PR TITLE
Restore B2B Checkout documentation from PR #540 #517

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -760,6 +760,21 @@ async function config() {
                     items: [
                       { label: 'Overview', link: '/dropins-b2b/' },
                       {
+                        label: 'Checkout',
+                        collapsed: true,
+                        items: [
+                          { label: 'Overview', link: '/dropins-b2b/checkout/' },
+                          {
+                            label: 'Containers',
+                            collapsed: false,
+                            items: [
+                              { label: 'PaymentOnAccount', link: '/dropins-b2b/checkout/containers/payment-on-account/' },
+                              { label: 'PurchaseOrder', link: '/dropins-b2b/checkout/containers/purchase-order/' },
+                            ],
+                          },
+                        ],
+                      },
+                      {
                         label: 'Company Management',
                         collapsed: true,
                         items: [

--- a/src/content/docs/dropins-b2b/checkout/containers/payment-on-account.mdx
+++ b/src/content/docs/dropins-b2b/checkout/containers/payment-on-account.mdx
@@ -6,23 +6,23 @@ description: Configure the PaymentOnAccount container to display the payment on 
 import { Aside } from '@astrojs/starlight/components';
 import TableWrapper from '@components/TableWrapper.astro';
 
-The `PaymentOnAccount` container captures a reference number and displays the company credit limit with warnings when exceeded. The container is rendered automatically when **Payment On Account** is the selected payment method.
+The `PaymentOnAccount` container displays a simple form that allows commercial customers who are part of a company to make purchases up to the credit limit specified in their profile by using a reference number, typically a Purchase Order (PO). It also displays the available company credit and a warning when the credit is exceeded.
 
-## Configuration
+This container is displayed automatically when the selected payment method of the active cart or negotiable quote is **Payment On Account**. You can customize this behavior by using the **Methods** slot of the [PaymentMethods container](/dropins/checkout/containers/payment-methods/).
 
-<Aside type="note">
-Shares configuration with `PurchaseOrder` but automatically displays company credit limits and warnings.
-</Aside>
+This container is intended to be used as a slot of the [PaymentMethods container](/dropins/checkout/containers/payment-methods/), but it can also be rendered independently.
+
+## PaymentOnAccount configuration
 
 The `PaymentOnAccount` container provides the following configuration options:
 
-<TableWrapper nowrap={[0, 1]}>
+<TableWrapper nowrap={[0]}>
 
 | Parameter | Type | Req? | Description |
 |---|---|---|---|
-| `initialReferenceNumber` | `string` | No | Sets the initial value for the purchase order reference number input field. |
-| `onReferenceNumberChange` | `function` | No | Callback when the reference number input field changes. |
-| `onReferenceNumberBlur` | `function` | No | Callback when the reference number input field loses focus. |
+| `initialReferenceNumber` | `string` | No | Initial value for the purchase order reference number input field. |
+| `onReferenceNumberChange` | `function` | No | A function that is called when the reference number input field changes. |
+| `onReferenceNumberBlur` | `function` | No | A callback function that is called when the reference number input field loses focus. |
 
 </TableWrapper>
 
@@ -33,7 +33,7 @@ These configuration options implement the `PaymentOnAccountProps` interface:
 The `PaymentOnAccount` container receives an object as a parameter that implements the `PaymentOnAccountProps` interface with the following properties:
 
 ```ts
-export interface PaymentOnAccountProps extends HTMLAttributes<HTMLDivElement> {
+export interface PaymentOnAccountProps extends HTMLAttributes<HTMLFormElement> {
   initialReferenceNumber?: string;
   onReferenceNumberChange?: (referenceNumber: string) => void;
   onReferenceNumberBlur?: (referenceNumber: string) => void;

--- a/src/content/docs/dropins-b2b/checkout/containers/payment-on-account.mdx
+++ b/src/content/docs/dropins-b2b/checkout/containers/payment-on-account.mdx
@@ -16,7 +16,7 @@ This container is intended to be used as a slot of the [PaymentMethods container
 
 The `PaymentOnAccount` container provides the following configuration options:
 
-<TableWrapper nowrap={[0]}>
+<TableWrapper nowrap={[0, 1]}>
 
 | Parameter | Type | Req? | Description |
 |---|---|---|---|

--- a/src/content/docs/dropins-b2b/checkout/containers/payment-on-account.mdx
+++ b/src/content/docs/dropins-b2b/checkout/containers/payment-on-account.mdx
@@ -1,0 +1,61 @@
+---
+title: PaymentOnAccount container
+description: Configure the PaymentOnAccount container to display the payment on account form during checkout.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import TableWrapper from '@components/TableWrapper.astro';
+
+The `PaymentOnAccount` container captures a reference number and displays the company credit limit with warnings when exceeded. The container is rendered automatically when **Payment On Account** is the selected payment method.
+
+## Configuration
+
+<Aside type="note">
+Shares configuration with `PurchaseOrder` but automatically displays company credit limits and warnings.
+</Aside>
+
+The `PaymentOnAccount` container provides the following configuration options:
+
+<TableWrapper nowrap={[0, 1]}>
+
+| Parameter | Type | Req? | Description |
+|---|---|---|---|
+| `initialReferenceNumber` | `string` | No | Sets the initial value for the purchase order reference number input field. |
+| `onReferenceNumberChange` | `function` | No | Callback when the reference number input field changes. |
+| `onReferenceNumberBlur` | `function` | No | Callback when the reference number input field loses focus. |
+
+</TableWrapper>
+
+These configuration options implement the `PaymentOnAccountProps` interface:
+
+### PaymentOnAccountProps interface
+
+The `PaymentOnAccount` container receives an object as a parameter that implements the `PaymentOnAccountProps` interface with the following properties:
+
+```ts
+export interface PaymentOnAccountProps extends HTMLAttributes<HTMLDivElement> {
+  initialReferenceNumber?: string;
+  onReferenceNumberChange?: (referenceNumber: string) => void;
+  onReferenceNumberBlur?: (referenceNumber: string) => void;
+}
+```
+
+- Set the `initialReferenceNumber` property to the initial value you want to display in the reference number input field.
+- The `onReferenceNumberChange` property is a handler that is called when the reference number input field changes.
+- The `onReferenceNumberBlur` property is a handler that is called when the reference number input field loses focus.
+
+## Example
+
+The following example renders the `PaymentOnAccount` container on a checkout page.
+
+```ts
+import * as checkoutApi from '@dropins/storefront-checkout/api.js';
+import PaymentOnAccount from '@dropins/storefront-checkout/containers/PaymentOnAccount.js';
+import { render as CheckoutProvider } from '@dropins/storefront-checkout/render.js';
+
+CheckoutProvider.render(PaymentOnAccount, {
+  onReferenceNumberChange: (referenceNumber) => {
+    // Handle reference number change
+  },
+})($paymentOnAccount),
+```

--- a/src/content/docs/dropins-b2b/checkout/containers/purchase-order.mdx
+++ b/src/content/docs/dropins-b2b/checkout/containers/purchase-order.mdx
@@ -6,23 +6,23 @@ description: Configure the PurchaseOrder container to display the purchase order
 import { Aside } from '@astrojs/starlight/components';
 import TableWrapper from '@components/TableWrapper.astro';
 
-The `PurchaseOrder` container captures a Purchase Order reference number for tracking. The container is rendered automatically when **Purchase Order** is the selected payment method.
+The `PurchaseOrder` container displays a simple form that allows commercial customers to reference a PO (Purchase Order).
 
-## Configuration
+This container is displayed automatically when the selected payment method of the active cart or negotiable quote is **Purchase Order**. You can customize this behavior by using the **Methods** slot of the [PaymentMethods container](/dropins/checkout/containers/payment-methods/).
 
-<Aside type="note">
-Shares configuration with `PaymentOnAccount` but captures the reference number only.
-</Aside>
+This container is intended to be used as a slot of the [PaymentMethods container](/dropins/checkout/containers/payment-methods/), but it can also be rendered independently.
+
+## PurchaseOrder configuration
 
 The `PurchaseOrder` container provides the following configuration options:
 
-<TableWrapper nowrap={[0, 1]}>
+<TableWrapper nowrap={[0]}>
 
 | Parameter | Type | Req? | Description |
 |---|---|---|---|
-| `initialReferenceNumber` | `string` | No | Sets the initial value for the purchase order reference number input field. |
-| `onReferenceNumberChange` | `function` | No | Callback when the reference number input field changes. |
-| `onReferenceNumberBlur` | `function` | No | Callback when the reference number input field loses focus. |
+| `initialReferenceNumber` | `string` | No | Initial value for the purchase order reference number input field. |
+| `onReferenceNumberChange` | `function` | No | A function that is called when the reference number input field changes. |
+| `onReferenceNumberBlur` | `function` | No | A callback function that is called when the reference number input field loses focus. |
 
 </TableWrapper>
 

--- a/src/content/docs/dropins-b2b/checkout/containers/purchase-order.mdx
+++ b/src/content/docs/dropins-b2b/checkout/containers/purchase-order.mdx
@@ -16,7 +16,7 @@ This container is intended to be used as a slot of the [PaymentMethods container
 
 The `PurchaseOrder` container provides the following configuration options:
 
-<TableWrapper nowrap={[0]}>
+<TableWrapper nowrap={[0, 1]}>
 
 | Parameter | Type | Req? | Description |
 |---|---|---|---|

--- a/src/content/docs/dropins-b2b/checkout/containers/purchase-order.mdx
+++ b/src/content/docs/dropins-b2b/checkout/containers/purchase-order.mdx
@@ -1,0 +1,61 @@
+---
+title: PurchaseOrder container
+description: Configure the PurchaseOrder container to display the purchase order form during checkout.
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import TableWrapper from '@components/TableWrapper.astro';
+
+The `PurchaseOrder` container captures a Purchase Order reference number for tracking. The container is rendered automatically when **Purchase Order** is the selected payment method.
+
+## Configuration
+
+<Aside type="note">
+Shares configuration with `PaymentOnAccount` but captures the reference number only.
+</Aside>
+
+The `PurchaseOrder` container provides the following configuration options:
+
+<TableWrapper nowrap={[0, 1]}>
+
+| Parameter | Type | Req? | Description |
+|---|---|---|---|
+| `initialReferenceNumber` | `string` | No | Sets the initial value for the purchase order reference number input field. |
+| `onReferenceNumberChange` | `function` | No | Callback when the reference number input field changes. |
+| `onReferenceNumberBlur` | `function` | No | Callback when the reference number input field loses focus. |
+
+</TableWrapper>
+
+These configuration options implement the `PurchaseOrderProps` interface:
+
+### PurchaseOrderProps interface
+
+The `PurchaseOrder` container receives an object as a parameter that implements the `PurchaseOrderProps` interface with the following properties:
+
+```ts
+export interface PurchaseOrderProps extends HTMLAttributes<HTMLFormElement> {
+  initialReferenceNumber?: string;
+  onReferenceNumberChange?: (referenceNumber: string) => void;
+  onReferenceNumberBlur?: (referenceNumber: string) => void;
+}
+```
+
+- Set the `initialReferenceNumber` property to the initial value you want to display in the reference number input field.
+- The `onReferenceNumberChange` property is a handler that is called when the reference number input field changes.
+- The `onReferenceNumberBlur` property is a handler that is called when the reference number input field loses focus.
+
+## Example
+
+The following example renders the `PurchaseOrder` container on a checkout page.
+
+```ts
+import * as checkoutApi from '@dropins/storefront-checkout/api.js';
+import PurchaseOrder from '@dropins/storefront-checkout/containers/PurchaseOrder.js';
+import { render as CheckoutProvider } from '@dropins/storefront-checkout/render.js';
+
+CheckoutProvider.render(PurchaseOrder, {
+  onReferenceNumberChange: (referenceNumber) => {
+    // Handle reference number change
+  },
+})($purchaseOrder),
+```

--- a/src/content/docs/dropins-b2b/checkout/index.mdx
+++ b/src/content/docs/dropins-b2b/checkout/index.mdx
@@ -1,0 +1,49 @@
+---
+title: Checkout overview
+description: Learn about the B2B-specific payment method containers for the Checkout drop-in.
+sidebar:
+  order: 1
+---
+
+import { Badge } from '@astrojs/starlight/components';
+import { Aside } from '@astrojs/starlight/components';
+import Link from '@components/Link.astro';
+import TableWrapper from '@components/TableWrapper.astro';
+
+The Checkout drop-in provides complete checkout functionality for both B2C and B2B storefronts. This section documents the B2B-specific payment method containers that extend the base Checkout drop-in with enterprise purchasing capabilities.
+
+<Aside type="note">
+The Checkout drop-in is a unified component that works for both B2C and B2B scenarios. For complete Checkout documentation including initialization, functions, events, and all containers, see the <Link href="https://experienceleague.adobe.com/developer/commerce/storefront/dropins/checkout/" text="Checkout drop-in overview" />.
+</Aside>
+
+## Supported Commerce features
+
+The B2B payment method containers support the following Adobe Commerce features:
+
+<TableWrapper nowrap={[0, 1]}>
+
+| Feature | Status |
+| ------- | ------ |
+| Payment on Account with credit limits | <Badge text="Supported" variant="tip" /> |
+| Purchase Order reference numbers | <Badge text="Supported" variant="tip" /> |
+| Company credit display | <Badge text="Supported" variant="tip" /> |
+| Credit limit warnings | <Badge text="Supported" variant="tip" /> |
+| Form validation | <Badge text="Supported" variant="tip" /> |
+| Negotiable quote checkout | <Badge text="Supported" variant="tip" /> |
+
+</TableWrapper>
+
+## B2B payment methods
+
+The Checkout drop-in includes specialized payment method containers designed for B2B purchasing workflows:
+
+<TableWrapper nowrap={[0]}>
+
+| Container | Description |
+|-----------|-------------|
+| [PaymentOnAccount](/dropins-b2b/checkout/containers/payment-on-account/) | Enables company buyers to make purchases up to their approved credit limit using a reference number (typically a Purchase Order). Displays available company credit and warnings when the credit limit is exceeded. |
+| [PurchaseOrder](/dropins-b2b/checkout/containers/purchase-order/) | Enables company buyers to reference a Purchase Order number during checkout for internal tracking and approval workflows. |
+
+</TableWrapper>
+
+These payment method containers are automatically displayed when the corresponding payment method is selected during checkout. They can be customized using the **Methods** slot of the [PaymentMethods container](/dropins/checkout/containers/payment-methods/).

--- a/src/content/docs/dropins-b2b/index.mdx
+++ b/src/content/docs/dropins-b2b/index.mdx
@@ -1,0 +1,19 @@
+---
+title: Overview
+description: Explore Adobe Commerce B2B drop-in components for building enterprise storefronts with company management, purchasing workflows, and collaborative commerce functionality.
+sidebar:
+  label: Overview
+  order: 1
+---
+
+import TableWrapper from '@components/TableWrapper.astro';
+
+Drop-ins for B2B are pre-built, customizable UI components that provide complete B2B commerce functionality for your storefront. Each drop-in handles specific B2B capabilities, from managing company accounts and organizational structures to handling purchase orders and negotiable quotes.
+
+<TableWrapper nowrap={[0]}>
+
+| Item | Description |
+|------|-------------|
+| [Checkout overview](/dropins-b2b/checkout/) | Provides B2B-specific payment method containers for Payment on Account and Purchase Order, enabling company buyers to make purchases using approved credit limits and reference numbers. |
+
+</TableWrapper>

--- a/src/content/docs/dropins/checkout/functions.mdx
+++ b/src/content/docs/dropins/checkout/functions.mdx
@@ -23,49 +23,56 @@ The Checkout drop-in provides API functions that enable you to programmatically 
 
 | Function | Description |
 | --- | --- |
-| [`authenticateCustomer`](#authenticatecustomer) | API function for the drop-in.. |
-| [`estimateShippingMethods`](#estimateshippingmethods) | Calls the `estimateShippingMethods` mutation.. |
+| [`authenticateCustomer`](#authenticatecustomer) | Updates the checkout state when customer authentication status changes. |
+| [`estimateShippingMethods`](#estimateshippingmethods) | Estimates available shipping methods for a given address. |
 | [`getCart`](#getcart) | Retrieves the current cart's checkout data from Adobe Commerce. |
 | [`getCheckoutAgreements`](#getcheckoutagreements) | Returns a list with the available checkout agreements. |
-| [`getCompanyCredit`](#getcompanycredit) | API function for the drop-in.. |
-| [`getCustomer`](#getcustomer) | API function for the drop-in.. |
+| [`getCompanyCredit`](#getcompanycredit) | Retrieves company credit information for B2B customers. |
+| [`getCustomer`](#getcustomer) | Retrieves the authenticated customer's basic information. |
 | [`getNegotiableQuote`](#getnegotiablequote) | Retrieves a negotiable quote for B2B customers. |
-| [`getStoreConfig`](#getstoreconfig) | The `storeConfig` query defines information about a store's configuration. |
-| [`getStoreConfigCache`](#getstoreconfigcache) | API function for the drop-in.. |
-| [`initializeCheckout`](#initializecheckout) | API function for the drop-in.. |
-| [`isEmailAvailable`](#isemailavailable) | Calls the `isEmailAvailable` query.. |
-| [`resetCheckout`](#resetcheckout) | API function for the drop-in.. |
-| [`setBillingAddress`](#setbillingaddress) | Calls the `setBillingAddressOnCart` mutation.. |
-| [`setGuestEmailOnCart`](#setguestemailoncart) | Calls the `setGuestEmailOnCart` mutation.. |
-| [`setPaymentMethod`](#setpaymentmethod) | Calls the `setPaymentMethodOnCart` mutation.. |
-| [`setShippingAddress`](#setshippingaddress) | Calls the `setShippingAddressesOnCart` mutation.. |
+| [`getStoreConfig`](#getstoreconfig) | Retrieves store configuration information. |
+| [`getStoreConfigCache`](#getstoreconfigcache) | Retrieves cached store configuration information. |
+| [`initializeCheckout`](#initializecheckout) | Initializes the checkout state with cart or quote data. |
+| [`isEmailAvailable`](#isemailavailable) | Checks if an email address is available for registration. |
+| [`resetCheckout`](#resetcheckout) | Resets the checkout state to its initial values. |
+| [`setBillingAddress`](#setbillingaddress) | Sets the billing address on the cart. |
+| [`setGuestEmailOnCart`](#setguestemailoncart) | Sets the email address for guest checkout. |
+| [`setPaymentMethod`](#setpaymentmethod) | Sets the payment method on the cart. |
+| [`setShippingAddress`](#setshippingaddress) | Sets the shipping address on the cart. |
 | [`setShippingMethods`](#setshippingmethods) | Sets one or more shipping methods on the cart. |
-| [`synchronizeCheckout`](#synchronizecheckout) | API function for the drop-in.. |
+| [`synchronizeCheckout`](#synchronizecheckout) | Synchronizes the checkout state with updated cart data. |
 
 </TableWrapper>
 
 ## authenticateCustomer
 
-### Signature
+The `authenticateCustomer` function updates the checkout state when the customer's authentication status changes. This function is typically called after a customer signs in or signs out during the checkout process to refresh cart data and available options.
 
 ```typescript
 function authenticateCustomer(authenticated = false): Promise<any>
 ```
 
-### Parameters
-
 <TableWrapper nowrap={[0,1]}>
 
-| Parameter | Type | Required | Description |
+| Parameter | Type | Req? | Description |
 |---|---|---|---|
+| `authenticated` | `boolean` | No | A boolean indicating whether the user has been authenticated. Defaults to `false`. |
 
 </TableWrapper>
+
+### Events
+
+Does not emit any drop-in events.
+
+### Returns
+
+Returns updated checkout data reflecting the customer's authentication status.
 
 ---
 
 ## estimateShippingMethods
 
-The `estimateShippingMethods` function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/mutations/estimate-shipping-methods`/" text="estimateShippingMethods" /> mutation.
+The `estimateShippingMethods` function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/estimate-shipping-methods/" text="estimateShippingMethods" /> mutation.
 
 ```ts
 const estimateShippingMethods = async (
@@ -123,6 +130,8 @@ Returns an array of [`CheckoutAgreement`](#checkoutagreement) objects.
 
 ## getCompanyCredit
 
+The `getCompanyCredit` function retrieves the company credit information for B2B customers. This includes the available credit balance and whether the current cart exceeds the credit limit. The function is used to display credit information and validate purchases against credit limits for Payment on Account transactions.
+
 ```ts
 const getCompanyCredit = async (): Promise<CompanyCredit | null>
 ```
@@ -133,9 +142,11 @@ Does not emit any drop-in events.
 
 ### Returns
 
-Returns [`CompanyCredit`](#companycredit) or `null`.
+Returns a [`CompanyCredit`](#companycredit) object containing the available credit balance and limit status, or `null` if company credit is not available or the user is not a B2B customer.
 
 ## getCustomer
+
+The `getCustomer` function retrieves the authenticated customer's basic information including first name, last name, and email address. This information is used to pre-populate checkout forms and display personalized content during the checkout process.
 
 ```ts
 const getCustomer = async (): Promise<Customer | null>
@@ -147,11 +158,15 @@ Does not emit any drop-in events.
 
 ### Returns
 
-Returns [`Customer`](#customer) or `null`.
+Returns a [`Customer`](#customer) object with the customer's name and email, or `null` if the user is not authenticated or customer data is unavailable.
 
 ## getNegotiableQuote
 
-The `getNegotiableQuote` function retrieves a negotiable quote for B2B customers. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/queries/negotiable-quote`/" text="negotiableQuote" /> query.
+The `getNegotiableQuote` function retrieves a negotiable quote for B2B customers. This function is used in the B2B checkout flow to fetch quote details including negotiated pricing, shipping addresses, and quote status. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/b2b/negotiable-quote/queries/quote/" text="negotiableQuote" /> query.
+
+<Aside type="note">
+This function is primarily used when the `features.b2b.quotes` option is enabled during [initialization](/dropins/checkout/initialization/#enabling-b2b-features). When enabled, the checkout flow uses quote data instead of standard cart data.
+</Aside>
 
 ```ts
 const getNegotiableQuote = async (
@@ -173,7 +188,7 @@ Does not emit any drop-in events.
 
 ### Returns
 
-Returns `void`.
+Returns the negotiable quote data including cart items, pricing, shipping addresses, and quote-specific information such as quote status and negotiated terms.
 
 ## getStoreConfig
 
@@ -193,6 +208,8 @@ Returns `void`.
 
 ## getStoreConfigCache
 
+The `getStoreConfigCache` function retrieves cached store configuration information. This is an optimized version of `getStoreConfig` that returns previously fetched configuration data without making a new GraphQL request, improving performance during checkout.
+
 ```ts
 const getStoreConfigCache = async (): any
 ```
@@ -203,31 +220,37 @@ Does not emit any drop-in events.
 
 ### Returns
 
-Returns `void`.
+Returns the cached store configuration object, or undefined if no configuration has been cached yet.
 
 ## initializeCheckout
 
-### Signature
+The `initializeCheckout` function initializes the checkout state with cart or quote data. This function is called when the checkout page loads to set up the initial state. For B2B quote checkouts, it can accept quote data directly; otherwise, it retrieves cart data from internal state.
 
 ```typescript
 function initializeCheckout(input: InitializeInput): Promise<any>
 ```
 
-### Parameters
-
 <TableWrapper nowrap={[0,1]}>
 
-| Parameter | Type | Required | Description |
+| Parameter | Type | Req? | Description |
 |---|---|---|---|
-| `input` | `InitializeInput` | Yes |  |
+| `input` | `InitializeInput` | Yes | The cart or quote data to initialize the checkout process, or null to retrieve the cart from internal state. |
 
 </TableWrapper>
+
+### Events
+
+Emits the [`checkout/initialized`](/dropins/checkout/events/#checkoutinitialized-emits-and-listens) event after successfully initializing the checkout state.
+
+### Returns
+
+Returns the initialized checkout data including cart items, addresses, and selected payment/shipping methods.
 
 ---
 
 ## isEmailAvailable
 
-The `isEmailAvailable` function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/queries/is-email-available`/" text="isEmailAvailable" /> query.
+The `isEmailAvailable` function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/queries/is-email-available/" text="isEmailAvailable" /> query.
 
 ```ts
 const isEmailAvailable = async (
@@ -253,21 +276,23 @@ Returns [`EmailAvailability`](#emailavailability).
 
 ## resetCheckout
 
+The `resetCheckout` function resets the checkout state to its initial values. This clears all selected options, form data, and cached information, effectively starting the checkout process from scratch. This is useful when a cart is emptied or when the user needs to restart checkout.
+
 ```ts
 const resetCheckout = async (): any
 ```
 
 ### Events
 
-Emits the [`checkout/updated`](/dropins/checkout/events/#checkoutupdated-emits-and-listens) event.
+Emits the [`checkout/updated`](/dropins/checkout/events/#checkoutupdated-emits-and-listens) event after resetting the state.
 
 ### Returns
 
-Returns `void`.
+Returns the reset checkout state with default values.
 
 ## setBillingAddress
 
-The `setBillingAddress` function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/mutations/set-billing-address-on-cart`/" text="setBillingAddressOnCart" /> mutation.
+The `setBillingAddress` function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/set-billing-address/" text="setBillingAddressOnCart" /> mutation.
 
 ```ts
 const setBillingAddress = async (
@@ -293,7 +318,7 @@ Returns `void`.
 
 ## setGuestEmailOnCart
 
-The `setGuestEmailOnCart` function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/mutations/set-guest-email-on-cart`/" text="setGuestEmailOnCart" /> mutation.
+The `setGuestEmailOnCart` function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/set-guest-email/" text="setGuestEmailOnCart" /> mutation.
 
 ```ts
 const setGuestEmailOnCart = async (
@@ -319,7 +344,7 @@ Returns `void`.
 
 ## setPaymentMethod
 
-The `setPaymentMethod` function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/mutations/set-payment-method-on-cart`/" text="setPaymentMethodOnCart" /> mutation.
+The `setPaymentMethod` function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/set-payment-method/" text="setPaymentMethodOnCart" /> mutation.
 
 ```ts
 const setPaymentMethod = async (
@@ -345,7 +370,7 @@ Returns `void`.
 
 ## setShippingAddress
 
-The `setShippingAddress` function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/mutations/set-shipping-addresses-on-cart`/" text="setShippingAddressesOnCart" /> mutation.
+The `setShippingAddress` function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/set-shipping-address/" text="setShippingAddressesOnCart" /> mutation.
 
 ```ts
 const setShippingAddress = async (
@@ -371,7 +396,7 @@ Returns `void`.
 
 ## setShippingMethods
 
-The `setShippingMethods` function sets one or more shipping methods on the cart. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/mutations/set-shipping-methods-on-cart`/" text="setShippingMethodsOnCart" /> mutation.
+The `setShippingMethods` function sets one or more shipping methods on the cart. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/set-shipping-method/" text="setShippingMethodsOnCart" /> mutation.
 
 ```ts
 const setShippingMethods = async (
@@ -397,21 +422,27 @@ Returns `void`.
 
 ## synchronizeCheckout
 
-### Signature
+The `synchronizeCheckout` function synchronizes the checkout state with updated cart data. This function is called when cart contents change (items added/removed, quantities updated, addresses modified) to ensure the checkout UI reflects the latest cart state.
 
 ```typescript
 function synchronizeCheckout(data: SynchronizeInput): Promise<any>
 ```
 
-### Parameters
-
 <TableWrapper nowrap={[0,1]}>
 
-| Parameter | Type | Required | Description |
+| Parameter | Type | Req? | Description |
 |---|---|---|---|
-| `data` | `SynchronizeInput` | Yes |  |
+| `data` | `SynchronizeInput` | Yes | The cart data to synchronize with the checkout state, or null to retrieve the cart from internal state. |
 
 </TableWrapper>
+
+### Events
+
+Emits the [`checkout/updated`](/dropins/checkout/events/#checkoutupdated-emits-and-listens) event after successfully synchronizing the state.
+
+### Returns
+
+Returns the synchronized checkout data with the latest cart information.
 
 ---
 

--- a/src/content/docs/dropins/checkout/initialization.mdx
+++ b/src/content/docs/dropins/checkout/initialization.mdx
@@ -118,26 +118,110 @@ await initializers.mountImmediately(initialize, { models });
 
 ## Drop-in configuration
 
-The **Checkout initializer** configures the checkout flow, payment processing, shipping options, and order placement. Use initialization to customize checkout behavior, integrate payment providers, and transform checkout data models to match your storefront requirements.
+The **Checkout initializer** provides drop-in-specific configuration options to customize the checkout experience beyond language and model customization.
+
+### Configuring default behaviors
+
+The `defaults` option controls checkout behaviors such as billing address and shipping method selection:
 
 ```javascript title="scripts/initializers/checkout.js"
 import { initializers } from '@dropins/tools/initializer.js';
 import { initialize } from '@dropins/storefront-checkout';
 
 await initializers.mountImmediately(initialize, {
-  defaults: {},
-  shipping: {},
-  features: {},
-  langDefinitions: {},
-  models: {},
+  defaults: {
+    // Set billing address to match shipping address by default
+    isBillToShipping: true,
+    // Pre-select the first available shipping method
+    selectedShippingMethod: (methods) => methods.length > 0 ? methods[0] : null,
+  },
 });
 ```
 
-<Aside type="note">
-Refer to the [Configuration options](#configuration-options) table for detailed descriptions of each option.
-</Aside>
+#### Default options
 
+- **isBillToShipping**: When `true`, automatically uses the shipping address as the billing address. When `false` (default), displays a separate billing address form.
+- **selectedShippingMethod**: A selector function that receives an array of available shipping methods and returns the method to pre-select. Return `null` for no pre-selection.
 
+### Filtering shipping methods
+
+The `shipping` option allows you to filter which shipping methods are available to customers:
+
+```javascript title="scripts/initializers/checkout.js"
+import { initializers } from '@dropins/tools/initializer.js';
+import { initialize } from '@dropins/storefront-checkout';
+
+await initializers.mountImmediately(initialize, {
+  shipping: {
+    // Only show ground shipping options
+    filterOptions: (method) => method.carrier.code === 'flatrate',
+  },
+});
+```
+
+The `filterOptions` function receives each shipping method and returns `true` to show it or `false` to hide it.
+
+### Enabling B2B features
+
+The `features` option enables B2B-specific functionality such as negotiable quote checkout:
+
+```javascript title="scripts/initializers/checkout.js"
+import { initializers } from '@dropins/tools/initializer.js';
+import { initialize } from '@dropins/storefront-checkout';
+import { rootLink, detectPageType } from '../commerce.js';
+
+const pageType = detectPageType();
+
+await initializers.mountImmediately(initialize, {
+  features: {
+    b2b: {
+      // Enable quote checkout for B2B pages
+      quotes: pageType === 'B2B Checkout',
+      // Redirect to login page for guest users
+      routeLogin: () => rootLink('/customer/login'),
+    },
+  },
+});
+```
+
+#### B2B feature options
+
+- **quotes**: When `true`, enables negotiable quote checkout functionality for B2B customers. This displays quote-specific information and uses the [`getNegotiableQuote`](/dropins/checkout/functions/#getnegotiablequote) function instead of standard cart operations.
+- **routeLogin**: A function that returns the login page URL. Called when unauthenticated users need to sign in during checkout.
+
+### Complete configuration example
+
+The following example shows all drop-in-specific configuration options together:
+
+```javascript title="scripts/initializers/checkout.js"
+import { initializers } from '@dropins/tools/initializer.js';
+import { initialize } from '@dropins/storefront-checkout';
+import { rootLink, detectPageType } from '../commerce.js';
+
+const pageType = detectPageType();
+
+await initializers.mountImmediately(initialize, {
+  defaults: {
+    isBillToShipping: true,
+    selectedShippingMethod: (methods) => methods.length > 0 ? methods[0] : null,
+  },
+  shipping: {
+    filterOptions: (method) => method.carrier.code === 'flatrate',
+  },
+  features: {
+    b2b: {
+      quotes: pageType === 'B2B Checkout',
+      routeLogin: () => rootLink('/customer/login'),
+    },
+  },
+  langDefinitions: {
+    default: {
+      'Checkout': 'Complete Purchase',
+    },
+  },
+  models: {},
+});
+```
 
 ## Configuration types
 


### PR DESCRIPTION
Restores the B2B Checkout payment method container documentation that was previously merged but accidentally removed:

Container Documentation (PR #540):
- src/content/docs/dropins-b2b/checkout/containers/payment-on-account.mdx
- src/content/docs/dropins-b2b/checkout/containers/purchase-order.mdx

Supporting Infrastructure:
- src/content/docs/dropins-b2b/checkout/index.mdx (B2B Checkout overview)
- src/content/docs/dropins-b2b/index.mdx (B2B drop-ins overview)
- astro.config.mjs (sidebar navigation for B2B Checkout)

Note: PR #517 changes (getNegotiableQuote function and B2B initialization options) are already present in the releases/b2b-nov-release branch.


