### PR TITLE
Fix external assets link

### DIFF
--- a/src/content/docs/merchants/quick-start/create-content.mdx
+++ b/src/content/docs/merchants/quick-start/create-content.mdx
@@ -7,6 +7,7 @@ import { Steps } from '@astrojs/starlight/components';
 import Diagram from '@components/Diagram.astro';
 import PDFViewer from '@components/PDFViewer.astro';
 import Callouts from '@components/Callouts.astro';
+import Link from '@components/Link.astro';
 
 **Commerce Storefront** is included with Adobe Commerce as a Cloud Service and Adobe Commerce Optimizer. It is designed to streamline both the technical and editorial workflows for creating and maintaining the content for your commerce storefronts. 
 
@@ -38,7 +39,7 @@ The **Commerce Storefront** is a collection of tools and technologies from Adobe
 
 DA.live (Document Authoring) is the content management system (CMS) you use to build you storefront site. It is where you create and manage your storefront's pages, blocks, and assets. DA.live provides a collaborative environment for content teams to create and structure site content, manage translations, and control publishing workflows. It integrates with Visual Editor for in-context editing and with Edge Delivery Services for fast, reliable content delivery. DA.live supports versioning, localization, and the features required to manage multiple commerce storefronts.
 
-Learn more about DA.live in the [DA.live tutorial](https://www.aem.live/developer/da-tutorial).
+Learn more about DA.live in the <Link href="https://www.aem.live/developer/da-tutorial" text="DA.live tutorial" />.
 
 ### Visual Editor
 
@@ -46,13 +47,13 @@ The Visual Editor is a powerful visual editing tool that enables business users 
 
 Learn how to use the Visual Editor in the [Using the Visual Editor](/merchants/quick-start/visual-editor/) topic.
 
-For more information about the Universal Editor, see [Universal Editor authoring](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/sites/authoring/universal-editor/authoring).
+For more information about the Universal Editor, see <Link href="https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/sites/authoring/universal-editor/authoring" text="Universal Editor authoring" />.
 
 ### Digital Assets Management
 
 The digital assets management (DAM) tool, powered by Adobe Experience Manager Assets, provides access to editorial assets like images, videos, and other media used on content pages and product enrichments. The DAM tools integrate with DA.live and Visual Editor for seamless media content management and asset selection. It works with Edge Delivery Services to deliver optimized assets globally.
 
-For more information about AEM Assets, see [Publishing pages with AEM Assets](https://www.aem.live/docs/universal-editor-assets) and [AEM Assets overview](https://experienceleague.adobe.com/en/docs/experience-manager-assets/content/home.html).
+For more information about AEM Assets, see <Link href="https://www.aem.live/docs/universal-editor-assets" text="Publishing pages with AEM Assets" /> and <Link href="https://www.aem.live/docs/media" text="AEM Assets overview" />.
 
 ### Content and Commerce blocks
 
@@ -60,13 +61,13 @@ Blocks are a foundational concept for adding form and function to page sections.
 
 Learn how to use the Content and Commerce blocks in the [Content and Commerce blocks](/merchants/quick-start/content-commerce-blocks/) topic.
 
-For more information about content blocks, see the [Block Collection](https://www.aem.live/developer/block-collection) topic.
+For more information about content blocks, see the <Link href="https://www.aem.live/developer/block-collection" text="Block Collection" /> topic.
 
 ### Edge Delivery Services
 
 Edge Delivery Services is a fast, scalable platform for delivering your storefront's content and assets to customers. It leverages a global content delivery network (CDN) to ensure that pages, images, and other resources load quickly, no matter where your customers are located. By serving content from the edge (geographically distributed servers closer to your customers), we reduce latency and improve site performance, which is critical for both user experience and SEO. Edge Delivery Services is tightly integrated with the Commerce Storefront ecosystem, ensuring seamless deployment and updates to your customer's storefront experience.
 
-Learn more about Edge Delivery Services in the [Edge Delivery Services Overview](https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/edge-delivery/overview) topic.
+Learn more about Edge Delivery Services in the <Link href="https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/edge-delivery/overview" text="Edge Delivery Services Overview" /> topic.
 
 ## Summary
 


### PR DESCRIPTION
## Purpose of this pull request

Fixed AEM Assets overview (corrected URL to `https://www.aem.live/docs/media`).

Converted all 6 external links to use the `Link` component with proper `text` attributes, ensuring they display with external link icons and open in new tabs.

- Verified all links resolve without 404 errors

**Files changed:**
- `src/content/docs/merchants/quick-start/create-content.mdx`

