### PR TITLE
Add CORS update to clarify support scope

### DIFF
--- a/src/content/docs/setup/configuration/cors-setup.mdx
+++ b/src/content/docs/setup/configuration/cors-setup.mdx
@@ -53,6 +53,10 @@ To add CORS headers to your Adobe Commerce GraphQL endpoints, you have several o
 - **Third-party module**: Use a community module such as [graycore/magento2-cors](https://github.com/graycoreio/magento2-cors)
 - **Custom module**: Implement a custom Adobe Commerce module to add CORS headers
 
+<Aside type="note" title="Support scope">
+Third-party modules and custom module implementations are outside the scope of Adobe Commerce support. For production environments, Adobe recommends server-level configuration or same-origin delivery to avoid CORS requirements entirely.
+</Aside>
+
 Refer to your chosen implementation's documentation for specific configuration steps.
 
 </Task>


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds a note to clarify that third-party modules and custom module implementations for CORS are outside the scope of Adobe Commerce support, while reinforcing Adobe's recommendation for production environments.

Changes:

- Added Aside note in the "Add CORS support" section
- Clarifies support boundaries for CORS implementation options
- Reinforces best practices for production environments

## Affected pages

src/content/docs/setup/configuration/cors-setup.mdx

