### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-pull-request.yml
+++ b/.github/workflows/test-pull-request.yml
@@ -1,4 +1,6 @@
 name: Validate Pull Request
+permissions:
+  contents: read
 
 on: pull_request
 


### PR DESCRIPTION
Potential fix for [https://github.com/commerce-docs/microsite-commerce-storefront/security/code-scanning/1](https://github.com/commerce-docs/microsite-commerce-storefront/security/code-scanning/1)

**General Fix:**  
Add a `permissions` entry at either the workflow or the job level to explicitly restrict the permissions of the `GITHUB_TOKEN` used by the workflow.

**Detailed Fix Approach:**  
Since all jobs in this workflow appear to only require read access to the repository contents (to check out code), set `permissions: contents: read` at the workflow level, directly below the `name:` field and before the `on:` key. This ensures the workflow and all jobs limit the `GITHUB_TOKEN` privileges to the minimum required.

**Precise Change:**  
Edit `.github/workflows/test-pull-request.yml` to insert:
```yaml
permissions:
  contents: read
```
as line 2, moving everything else down by one line.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
