### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lighthouseci.yml
+++ b/.github/workflows/lighthouseci.yml
@@ -1,4 +1,6 @@
 name: Audit Web Vitals
+permissions:
+  contents: read
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/commerce-docs/microsite-commerce-storefront/security/code-scanning/15](https://github.com/commerce-docs/microsite-commerce-storefront/security/code-scanning/15)

To fix this issue, we should add a `permissions` block at the root of the workflow YAML file, setting it to the minimal required permissions. For this snippet, a good starting point would be `contents: read`; if posting to pull requests, you might also need `pull-requests: write`. This block should be placed right after the workflow `name:` and before `on:` to apply to all jobs (unless job-level overrides are needed). Only the beginning of `.github/workflows/lighthouseci.yml` needs to be changed: insert the appropriate `permissions` block after the `name:` line. No other modifications are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
