### PR TITLE
Potential fix for code scanning alert no. 64: Useless regular-expression character escape

### DIFF
--- a/scripts/@generate-merchant-block-docs.js
+++ b/scripts/@generate-merchant-block-docs.js
@@ -124,7 +124,7 @@ function extractConfigFromSource(blockPath, blockName) {
         const configVarName = configVarMatch[1];
 
         // Find nested destructuring FIRST (most reliable): const { key, key2 } = config
-        const nestedDestructurePattern = new RegExp(`const\\s*\\{([^}]+)\\}\s*=\\s*${configVarName}\\s*;`, 'g');
+        const nestedDestructurePattern = new RegExp(`const\\s*\\{([^}]+)\\}\\s*=\\s*${configVarName}\\s*;`, 'g');
         let nestedMatch;
 
         while ((nestedMatch = nestedDestructurePattern.exec(source)) !== null) {


### PR DESCRIPTION
Potential fix for [https://github.com/commerce-docs/microsite-commerce-storefront/security/code-scanning/64](https://github.com/commerce-docs/microsite-commerce-storefront/security/code-scanning/64)

To fix the bug, change all occurrences of regular expression escape sequences (`\s`) in strings passed to the `RegExp` constructor to double backslashes (`\\s`).  
Specifically, in this case, update the string in the RegExp constructor on line 127:  
```js
const nestedDestructurePattern = new RegExp(`const\\s*\\{([^}]+)\\}\s*=\\s*${configVarName}\\s*;`, 'g');
```
to  
```js
const nestedDestructurePattern = new RegExp(`const\\s*\\{([^}]+)\\}\\s*=\\s*${configVarName}\\s*;`, 'g');
```
This preserves the intended behavior and matches whitespace properly.

No other imports, method definitions, or changes are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
