### PR TITLE
Potential fix for code scanning alert no. 48: Incomplete URL substring sanitization

### DIFF
--- a/scripts/audit-enrichment-accuracy.js
+++ b/scripts/audit-enrichment-accuracy.js
@@ -286,9 +286,22 @@ for (const [repoName, repoConfig] of Object.entries(dropinsToCheck)) {
             }
 
             // Warn if description claims to call a mutation but doesn't link to it
-            if (enrichment.description.includes('mutation') && !enrichment.description.includes('developer.adobe.com')) {
-                console.log(`      ⚠️  [Description] Mentions 'mutation' but no link to GraphQL docs`);
-                totalIssues++;
+            if (enrichment.description.includes('mutation')) {
+                // Check if any URL in description links to developer.adobe.com
+                const urlRegex = /\bhttps?:\/\/[^\s)]+/g;
+                const urls = enrichment.description.match(urlRegex) || [];
+                const hasDevAdobeLink = urls.some(urlStr => {
+                    try {
+                        const urlObj = new URL(urlStr);
+                        return urlObj.hostname === 'developer.adobe.com';
+                    } catch {
+                        return false;
+                    }
+                });
+                if (!hasDevAdobeLink) {
+                    console.log(`      ⚠️  [Description] Mentions 'mutation' but no link to GraphQL docs`);
+                    totalIssues++;
+                }
             }
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/commerce-docs/microsite-commerce-storefront/security/code-scanning/48](https://github.com/commerce-docs/microsite-commerce-storefront/security/code-scanning/48)

The best way to fix the problem is to parse all URLs in the `enrichment.description` field and inspect their hosts properly. Instead of checking whether `developer.adobe.com` exists as a substring, we should extract all URLs from the description and check whether any of their normalized hostnames is exactly `developer.adobe.com` (or matches the explicit list of allowed hosts if relevant). Specifically:

- On line 289, replace `enrichment.description.includes('developer.adobe.com')` with proper logic:
    - Use a regular expression to extract all URLs from `enrichment.description`.
    - Parse each extracted URL using the `URL` constructor (native in Node).
    - Check whether any of their `hostname` properties exactly matches `developer.adobe.com` (or a whitelist).
    - If none match, issue the warning.
- Introduce the required import (none, as `URL` is global in recent Node versions).
- Add a helper function if needed for extracting/validating URLs.
- Keep contextual lines to preserve code structure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
