### PR TITLE
Fix import path for Prettier configuration file

### DIFF
--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -1,4 +1,4 @@
-const baseConfig = require('./configuration/prettier.cjs');
+const baseConfig = require('./config/prettier.cjs');
 
 /**
  * @type {import('prettier').Config}


### PR DESCRIPTION
## Purpose of this pull request

This pull request fixes a broken import path in the Prettier configuration file. The base config import was pointing to a non-existent `./configuration/prettier.cjs` directory and has been corrected to `./config/prettier.cjs` to match the actual project structure.

### Associated JIRA ticket

COMDOX-1420

## Affected pages

This change affects only the development tooling configuration and does not impact any published documentation pages.
