### PR TITLE
Requisition List Documentation

### DIFF
--- a/src/content/docs/dropins-b2b/requisition-list/containers/index.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/containers/index.mdx
@@ -1,0 +1,39 @@
+---
+title: Requisition List Containers
+description: Overview of containers available in the Requisition List drop-in.
+sidebar:
+  label: Overview
+  order: 1
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import TableWrapper from '@components/TableWrapper.astro';
+
+The **Requisition List** drop-in provides pre-built container components for integrating into your storefront.
+
+<div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
+<strong>Version: 1.0.0-beta4</strong>
+</div>
+
+## What are Containers?
+
+Containers are pre-built UI components that combine functionality, state management, and presentation. They provide a complete solution for specific features and can be customized through props, slots, and CSS.
+
+## Available Containers
+
+<TableWrapper nowrap={[0]}>
+
+| Container | Description |
+| --------- | ----------- |
+| [RequisitionListForm](/dropins-b2b/requisition-list/containers/requisition-list-form/) | Provides a form for creating or editing requisition list details including name and description. |
+| [RequisitionListGrid](/dropins-b2b/requisition-list/containers/requisition-list-grid/) | Displays requisition lists in a grid layout with filtering, sorting, and selection capabilities. |
+| [RequisitionListHeader](/dropins-b2b/requisition-list/containers/requisition-list-header/) | Displays header information for a requisition list including name, description, and action buttons. |
+| [RequisitionListSelector](/dropins-b2b/requisition-list/containers/requisition-list-selector/) | Provides a selector interface for choosing a requisition list when adding products from the catalog. |
+| [RequisitionListView](/dropins-b2b/requisition-list/containers/requisition-list-view/) | Displays the contents of a specific requisition list including items, quantities, and management actions. |
+
+
+</TableWrapper>
+
+<Aside type="tip">
+Each container is designed to work independently but can be composed together to create comprehensive user experiences.
+</Aside>

--- a/src/content/docs/dropins-b2b/requisition-list/containers/requisition-list-form.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/containers/requisition-list-form.mdx
@@ -1,0 +1,55 @@
+---
+title: RequisitionListForm Container
+description: Learn about the RequisitionListForm container in the Requisition List drop-in.
+sidebar:
+  label: RequisitionListForm
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import TableWrapper from '@components/TableWrapper.astro';
+
+Provides a form for creating or editing requisition list details including name and description.
+
+<div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
+<strong>Version: 1.0.0-beta4</strong>
+</div>
+
+## Configuration
+
+The `RequisitionListForm` container provides the following configuration options:
+
+<TableWrapper nowrap={[0]}>
+
+| Parameter | Type | Req? | Description |
+|---|---|---|---|
+| `mode` | `RequisitionListFormMode` | Yes | The form mode determining whether to create a new requisition list or update an existing one. Use 'create' for new lists and 'update' when modifying existing lists. |
+| `requisitionListUid` | `string` | No | The unique identifier for the requisition list being updated. Required when mode is 'update' to load and modify the existing list data. |
+| `defaultValues` | `RequisitionListFormValues` | No | Pre-populated form values for the requisition list. Use to prepopulate the form when creating from a template or duplicating an existing list. |
+| `onSuccess` | `function` | No | Callback function triggered on successful completion. Use to implement custom success handling, navigation, or notifications. |
+| `onError` | `function` | No | Callback function triggered when an error occurs. Use to implement custom error handling, logging, or user notifications. |
+| `onCancel` | `function` | Yes | Callback function triggered when user cancels the form. Use to implement navigation back to the list view or close modal dialogs. |
+
+</TableWrapper>
+
+## Slots
+
+This container does not expose any customizable slots.
+
+## Usage
+
+The following example demonstrates how to use the `RequisitionListForm` container:
+
+```js
+import { render as provider } from '@dropins/storefront-requisition-list/render.js';
+import { RequisitionListForm } from '@dropins/storefront-requisition-list/containers/RequisitionListForm.js';
+
+await provider.render(RequisitionListForm, {
+  mode: mode,
+  onCancel: onCancel,
+  requisitionListUid: "abc-123",
+})(block);
+```
+
+
+
+{/* This documentation is auto-generated from: https://github.com/adobe-commerce/storefront-requisition-list */}

--- a/src/content/docs/dropins-b2b/requisition-list/containers/requisition-list-grid.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/containers/requisition-list-grid.mdx
@@ -1,0 +1,61 @@
+---
+title: RequisitionListGrid Container
+description: Learn about the RequisitionListGrid container in the Requisition List drop-in.
+sidebar:
+  label: RequisitionListGrid
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import TableWrapper from '@components/TableWrapper.astro';
+
+Displays requisition lists in a grid layout with filtering, sorting, and selection capabilities.
+
+<div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
+<strong>Version: 1.0.0-beta4</strong>
+</div>
+
+## Configuration
+
+The `RequisitionListGrid` container provides the following configuration options:
+
+<TableWrapper nowrap={[0,1]}>
+
+| Parameter | Type | Req? | Description |
+|---|---|---|---|
+| `routeRequisitionListDetails` | `function` | No | Function to generate the URL for navigating to the requisition list details page. Use to implement custom routing logic or add query parameters when users click on a list. |
+| `fallbackRoute` | `string` | No | Fallback URL to redirect when requisition lists are not enabled. Defaults to '/customer/account' |
+
+</TableWrapper>
+
+## Slots
+
+This container exposes the following slots for customization:
+
+<TableWrapper nowrap={[0,1]}>
+
+| Slot | Type | Required | Description |
+|------|------|----------|-------------|
+| `Header` | `SlotProps` | No | Customize grid header section. |
+
+</TableWrapper>
+
+## Usage
+
+The following example demonstrates how to use the `RequisitionListGrid` container:
+
+```js
+import { render as provider } from '@dropins/storefront-requisition-list/render.js';
+import { RequisitionListGrid } from '@dropins/storefront-requisition-list/containers/RequisitionListGrid.js';
+
+await provider.render(RequisitionListGrid, {
+  routeRequisitionListDetails: routeRequisitionListDetails,
+  fallbackRoute: "example",
+  slots: {
+    // Add custom slot implementations here
+  }
+})(block);
+```
+
+
+
+{/* This documentation is auto-generated from: https://github.com/adobe-commerce/storefront-requisition-list */}

--- a/src/content/docs/dropins-b2b/requisition-list/containers/requisition-list-header.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/containers/requisition-list-header.mdx
@@ -1,0 +1,53 @@
+---
+title: RequisitionListHeader Container
+description: Learn about the RequisitionListHeader container in the Requisition List drop-in.
+sidebar:
+  label: RequisitionListHeader
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import TableWrapper from '@components/TableWrapper.astro';
+
+Displays header information for a requisition list including name, description, and action buttons.
+
+<div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
+<strong>Version: 1.0.0-beta4</strong>
+</div>
+
+## Configuration
+
+The `RequisitionListHeader` container provides the following configuration options:
+
+<TableWrapper nowrap={[0,1]}>
+
+| Parameter | Type | Req? | Description |
+|---|---|---|---|
+| `requisitionList` | `RequisitionList` | Yes | The requisition list data object containing name, description, and metadata. Required to display the list information in the header. |
+| `routeRequisitionListGrid` | `function` | No | Function to generate the URL for navigating back to the requisition list grid view. Use to implement breadcrumb navigation or back buttons. |
+| `onUpdate` | `function` | No | Callback function triggered when the requisition list is updated (name or description changed). Use to refresh the parent component or show success notifications. |
+| `onAlert` | `function` | No | Callback function triggered when alert |
+
+</TableWrapper>
+
+## Slots
+
+This container does not expose any customizable slots.
+
+## Usage
+
+The following example demonstrates how to use the `RequisitionListHeader` container:
+
+```js
+import { render as provider } from '@dropins/storefront-requisition-list/render.js';
+import { RequisitionListHeader } from '@dropins/storefront-requisition-list/containers/RequisitionListHeader.js';
+
+await provider.render(RequisitionListHeader, {
+  requisitionList: requisitionList,
+  routeRequisitionListGrid: routeRequisitionListGrid,
+  onUpdate: onUpdate,
+})(block);
+```
+
+
+
+{/* This documentation is auto-generated from: https://github.com/adobe-commerce/storefront-requisition-list */}

--- a/src/content/docs/dropins-b2b/requisition-list/containers/requisition-list-selector.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/containers/requisition-list-selector.mdx
@@ -1,0 +1,54 @@
+---
+title: RequisitionListSelector Container
+description: Learn about the RequisitionListSelector container in the Requisition List drop-in.
+sidebar:
+  label: RequisitionListSelector
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import TableWrapper from '@components/TableWrapper.astro';
+
+Provides a selector interface for choosing a requisition list when adding products from the catalog.
+
+<div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
+<strong>Version: 1.0.0-beta4</strong>
+</div>
+
+## Configuration
+
+The `RequisitionListSelector` container provides the following configuration options:
+
+<TableWrapper nowrap={[0,1]}>
+
+| Parameter | Type | Req? | Description |
+|---|---|---|---|
+| `canCreate` | `boolean` | No | When true, allows users to create new requisition lists from the selector. Set to false to restrict users to only adding to existing lists based on permissions. |
+| `sku` | `string` | Yes | The product SKU to add to the selected requisition list. Required to identify which product the user is adding. |
+| `selectedOptions` | `string[]` | No | Array of selected product option IDs for configurable products. Use to capture size, color, or other variant selections before adding to the list. |
+| `quantity` | `number` | No | The quantity of the product to add to the requisition list. Defaults to 1 if not specified. |
+| `beforeAddProdToReqList` | `function` | No | Callback function triggered when the Add to Requisition List button is clicked, before the dropdown opens. Use to validate if the product can be added directly (e.g., check if a configurable product needs options selected) and redirect to the product detail page if needed. If the callback throws an error or rejects, the dropdown will not open, enabling patterns like redirecting complex products to their detail pages. |
+
+</TableWrapper>
+
+## Slots
+
+This container does not expose any customizable slots.
+
+## Usage
+
+The following example demonstrates how to use the `RequisitionListSelector` container:
+
+```js
+import { render as provider } from '@dropins/storefront-requisition-list/render.js';
+import { RequisitionListSelector } from '@dropins/storefront-requisition-list/containers/RequisitionListSelector.js';
+
+await provider.render(RequisitionListSelector, {
+  sku: "PRODUCT-SKU-123",
+  canCreate: true,
+  selectedOptions: [],
+})(block);
+```
+
+
+
+{/* This documentation is auto-generated from: https://github.com/adobe-commerce/storefront-requisition-list */}

--- a/src/content/docs/dropins-b2b/requisition-list/containers/requisition-list-view.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/containers/requisition-list-view.mdx
@@ -1,0 +1,55 @@
+---
+title: RequisitionListView Container
+description: Learn about the RequisitionListView container in the Requisition List drop-in.
+sidebar:
+  label: RequisitionListView
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import TableWrapper from '@components/TableWrapper.astro';
+
+Displays the contents of a specific requisition list including items, quantities, and management actions.
+
+<div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
+<strong>Version: 1.0.0-beta4</strong>
+</div>
+
+## Configuration
+
+The `RequisitionListView` container provides the following configuration options:
+
+<TableWrapper nowrap={[0,1]}>
+
+| Parameter | Type | Req? | Description |
+|---|---|---|---|
+| `requisitionListUid` | `string` | Yes | The UID of the requisition list to display. The UID must be a base64-encoded string. If an invalid UID is provided, the component will render the NotFound state. The component will fetch the requisition list data internally. |
+| `skipProductLoading` | `boolean` | No | When true, skips automatic product data fetching on component mount. Used in tests to prevent API calls. |
+| `pageSize` | `number` | No | Number of items per page for pagination. Defaults to DEFAULT_PAGE_SIZE. |
+| `selectedItems` | `Set<string>` | Yes | Number of items per page for pagination. Defaults to DEFAULT_PAGE_SIZE. |
+| `routeRequisitionListGrid` | `function` | No | Function that returns the URL to the requisition list grid view or performs navigation |
+| `fallbackRoute` | `string` | No | Fallback URL to redirect when requisition lists are not enabled. Defaults to '/customer/account' |
+
+</TableWrapper>
+
+## Slots
+
+This container does not expose any customizable slots.
+
+## Usage
+
+The following example demonstrates how to use the `RequisitionListView` container:
+
+```js
+import { render as provider } from '@dropins/storefront-requisition-list/render.js';
+import { RequisitionListView } from '@dropins/storefront-requisition-list/containers/RequisitionListView.js';
+
+await provider.render(RequisitionListView, {
+  requisitionListUid: "abc-123",
+  selectedItems: "example",
+  skipProductLoading: true,
+})(block);
+```
+
+
+
+{/* This documentation is auto-generated from: https://github.com/adobe-commerce/storefront-requisition-list */}

--- a/src/content/docs/dropins-b2b/requisition-list/dictionary.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/dictionary.mdx
@@ -1,0 +1,169 @@
+---
+title: Requisition List Dictionary
+description: Customize user-facing text and labels in the Requisition List drop-in for localization and branding.
+sidebar:
+  label: Dictionary
+  order: 8
+---
+
+import { Aside } from '@astrojs/starlight/components';
+
+The **Requisition List dictionary** contains all user-facing text, labels, and messages displayed by this drop-in. Customize the dictionary to:
+
+- **Localize** the drop-in for different languages and regions
+- **Customize** labels and messages to match your brand voice
+- **Override** default text without modifying source code for the drop-in
+
+Dictionaries use the **i18n (internationalization)** pattern, where each text string is identified by a unique key path.
+
+<div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
+<strong>Version: 1.0.0-beta4</strong>
+</div>
+
+## How to customize
+
+Override dictionary values during drop-in initialization. The drop-in deep-merges your custom values with the defaults.
+
+```javascript
+import { initialize } from '@dropins/storefront-requisition-list';
+
+await initialize({
+  langDefinitions: {
+    en_US: {
+      "RequisitionList": {
+        "containerTitle": {
+          "0": "Custom value",
+          "1": "Custom value"
+        }
+      }
+    }
+  }
+});
+```
+
+You only need to include the keys you want to change. For multi-language support and advanced patterns, see the [Dictionary customization guide](/dropins/all/dictionaries/).
+
+## Default keys and values
+
+Below are the default English (`en_US`) strings provided by the **Requisition List** drop-in:
+
+```json title="en_US.json"
+{
+  "RequisitionList": {
+    "containerTitle": "Requisition Lists",
+    "RequisitionListWrapper": {
+      "name": "Name & Description",
+      "itemsCount": "Items",
+      "lastUpdated": "Latest activity",
+      "actions": "Actions",
+      "loginMsg": "Please login",
+      "deleteRequisitionListTitle": "Are you sure you want to delete this Requisition List?",
+      "deleteRequisitionListMessage": "Requisition List will be permanently deleted. This action can not be undone.",
+      "confirmAction": "Confirm",
+      "cancelAction": "Cancel",
+      "emptyList": "No Requisition Lists found"
+    },
+    "AddNewReqList": {
+      "addNewReqListBtn": "Add new Requisition List"
+    },
+    "RequisitionListItem": {
+      "actionUpdate": "Update",
+      "actionDelete": "Delete"
+    },
+    "RequisitionListForm": {
+      "actionCancel": "Cancel",
+      "actionSave": "Save",
+      "requiredField": "This is a required field.",
+      "nameMinLength": "Name must be at least {min} characters long.",
+      "nameInvalidCharacters": "Name contains invalid characters. Only letters, numbers, spaces, and basic punctuation are allowed.",
+      "floatingLabel": "Requisition List Name *",
+      "placeholder": "Requisition List Name",
+      "label": "Description",
+      "updateTitle": "Update Requisition List",
+      "createTitle": "Create Requisition List",
+      "addToRequisitionList": "Add to Requisition List"
+    },
+    "RequisitionListSelector": {
+      "addToNewRequisitionList": "Add to New Requisition List",
+      "addToSelected": "Add to Selected List"
+    },
+    "RequisitionListAlert": {
+      "errorCreate": "Error creating requisition list.",
+      "successCreate": "Requisition list created successfully.",
+      "errorAddToCart": "Error adding item to cart.",
+      "successAddToCart": "Item(s) added to cart successfully.",
+      "errorUpdateQuantity": "Error updating quantity.",
+      "successUpdateQuantity": "Item quantity updated successfully.",
+      "errorUpdate": "Error updating requisition list.",
+      "successUpdate": "Requisition list updated successfully.",
+      "errorDeleteItem": "Error deleting item.",
+      "successDeleteItem": "Item(s) deleted successfully.",
+      "errorDeleteReqList": "Error deleting requisition list.",
+      "successDeleteReqList": "Requisition list deleted successfully.",
+      "errorMove": "Error moving item(s) to cart.",
+      "successMove": "Item(s) successfully moved to cart.",
+      "errorAddToRequisitionList": "Error adding item(s) to requisition list.",
+      "successAddToRequisitionList": "Item(s) successfully added to requisition list."
+    },
+    "RequisitionListView": {
+      "actionDelete": "Delete",
+      "statusDeleting": "Deleting...",
+      "actionDeleteSelected": "Delete Selected",
+      "actionDeleteSelectedItems": "Delete selected items",
+      "actionSelectAll": "Select All",
+      "actionSelectNone": "Select None",
+      "actionAddToCart": "Add to Cart",
+      "statusAddingToCart": "Adding...",
+      "actionAddSelectedToCart": "Add Selected to Cart",
+      "statusBulkAddingToCart": "Adding to Cart...",
+      "actionUpdateQuantity": "Update",
+      "statusUpdatingQuantity": "Updating...",
+      "errorUpdateQuantity": "Error updating quantity",
+      "successUpdateQuantity": "Item quantity updated successfully.",
+      "actionBackToRequisitionListsOverview": "Back to requisition lists overview",
+      "actionBackToRequisitionLists": "Back to Requisition Lists",
+      "actionRename": "Rename",
+      "actionDeleteList": "Delete List",
+      "deleteListTitle": "Delete Requisition List?",
+      "deleteListMessage": "Are you sure you want to delete this requisition list? This action cannot be undone.",
+      "deleteItemsTitle": "Delete Item(s)?",
+      "deleteItemsMessage": "Are you sure you want to delete the selected item(s) from this requisition list? This action cannot be undone.",
+      "confirmAction": "Delete",
+      "cancelAction": "Cancel",
+      "emptyRequisitionList": " Requisition List is empty",
+      "productListTable": {
+        "headers": {
+          "productName": "Product name",
+          "sku": "SKU",
+          "price": "Price",
+          "quantity": "Quantity",
+          "subtotal": "Subtotal",
+          "actions": "Actions"
+        },
+        "itemQuantity": "Item quantity",
+        "outOfStock": "Out of stock",
+        "onlyXLeftInStock": "Only {count} left in stock"
+      },
+      "errorLoadPage": "Failed to load page",
+      "errorLoadingProducts": "Failed to load product data",
+      "notFoundTitle": "Requisition List Not Found",
+      "notFoundMessage": "The requisition list you are looking for does not exist or you do not have access to it.",
+      "notFoundActionLabel": "Back to Requisition Lists"
+    },
+    "RequisitionListsNotEnabled": {
+      "title": "Requisition Lists Not Available",
+      "message": "Requisition Lists are not available. Please contact your administrator for more information.",
+      "actionLabel": "Go to My Account"
+    },
+    "PageSizePicker": {
+      "show": "Show",
+      "itemsPerPage": "Items per page"
+    },
+    "PaginationItemsCounter": {
+      "itemsCounter": "Items {from}-{to} of {total}"
+    }
+  }
+}
+```
+
+{/* This documentation is auto-generated from: https://github.com/adobe-commerce/storefront-requisition-list */}

--- a/src/content/docs/dropins-b2b/requisition-list/events.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/events.mdx
@@ -1,0 +1,523 @@
+---
+title: Requisition List Data & Events
+description: Learn about the events used by the Requisition List and the data available within the events.
+sidebar:
+  label: Events
+  order: 5
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import TableWrapper from '@components/TableWrapper.astro';
+
+The **Requisition List** drop-in uses the [event bus](/sdk/reference/events) to emit and listen to events for communication between drop-ins and external integrations.
+
+<div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
+<strong>Version: 1.0.0-beta4</strong>
+</div>
+
+## Events reference
+
+{/* EVENTS_TABLE_START */}
+<TableWrapper nowrap={[0, 1]}>
+
+| Event | Direction | Description |
+|-------|-----------|-------------|
+| [requisitionList/alert](#requisitionlistalert-emits-and-listens) | Emits and listens | Triggered when an alert or notification is triggered. |
+| [requisitionList/data](#requisitionlistdata-emits-and-listens) | Emits and listens | Triggered when data is available or changes. |
+| [requisitionList/initialized](#requisitionlistinitialized-emits-and-listens) | Emits and listens | Triggered when the component completes initialization. |
+| [requisitionLists/data](#requisitionlistsdata-emits-and-listens) | Emits and listens | Triggered when data is available or changes. |
+
+</TableWrapper>
+{/* EVENTS_TABLE_END */}
+
+## Event details
+
+The following sections provide detailed information about each event, including its direction, event payload, and usage examples.
+
+
+### `requisitionList/alert` (emits and listens)
+
+Triggered when an alert or notification is triggered.
+
+#### Event payload
+
+```typescript
+RequisitionListActionPayload
+```
+
+See [`RequisitionListActionPayload`](#requisitionlistactionpayload) for full type definition.
+
+
+
+#### When triggered
+
+- After successful list operations (create, update, delete)
+- After adding items to cart from a list
+- After item operations (add, update, remove)
+- On operation errors or validation failures
+
+
+
+#### Example: Example
+
+```js
+import { events } from '@dropins/tools/event-bus.js';
+
+events.on('requisitionList/alert', (payload) => {
+  const { type, message } = payload.data;
+  
+  // Display alert using your notification system
+  showNotification({
+    type,
+    message,
+    duration: type === 'error' ? 5000 : 3000
+  });
+  
+  console.log(`${type.toUpperCase()}: ${message}`);
+});
+```
+
+
+
+#### Usage scenarios
+
+- Display toast notifications.
+- Show inline error messages.
+- Log user actions for analytics.
+- Trigger accessibility announcements.
+- Update status indicators.
+
+---
+
+
+
+
+### `requisitionList/data` (emits and listens)
+
+Triggered when data is available or changes.
+
+#### Event payload
+
+```typescript
+RequisitionList | null
+```
+
+See [`RequisitionList`](#requisitionlist) for full type definition.
+
+
+
+#### When triggered
+
+- After loading a requisition list
+- After adding items to the list
+- After removing items from the list
+- After updating item quantities
+- After updating list details (name, description)
+
+
+
+#### Example 1: Basic list data handler
+
+```js
+import { events } from '@dropins/tools/event-bus.js';
+
+events.on('requisitionList/data', (payload) => {
+  const list = payload.data;
+  
+  console.log(`List "${list.name}" updated`);
+  console.log(`Total items: ${list.items.length}`);
+  
+  // Update the UI
+  updateListDisplay(list);
+  
+  // Update item count badge
+  updateItemCount(list.items.length);
+  
+  // Refresh totals
+  calculateListTotals(list.items);
+});
+```
+
+#### Example 2: Add entire requisition list to cart
+
+```js
+import { events } from '@dropins/tools/event-bus.js';
+import { addRequisitionListItemsToCart } from '@dropins/storefront-requisition-list/api.js';
+
+class QuickCartIntegration {
+  constructor() {
+    events.on('requisitionList/data', this.handleListData.bind(this));
+    events.on('cart/updated', this.handleCartUpdated.bind(this));
+  }
+  
+  handleListData(payload) {
+    const list = payload.data;
+    
+    // Add quick-add button to UI
+    this.renderQuickAddButton(list);
+  }
+  
+  renderQuickAddButton(list) {
+    const button = document.createElement('button');
+    button.className = 'quick-add-to-cart';
+    button.textContent = `Add all ${list.items.length} items to cart`;
+    button.onclick = () => this.addAllToCart(list);
+    
+    document.querySelector('#list-actions').appendChild(button);
+  }
+  
+  async addAllToCart(list) {
+    try {
+      showLoadingOverlay('Adding items to cart...');
+      
+      // Add all items from requisition list to cart
+      await addRequisitionListItemsToCart({
+        requisitionListUid: list.uid,
+        requisitionListItems: list.items.map(item => ({
+          uid: item.uid,
+          quantity: item.quantity
+        }))
+      });
+      
+      hideLoadingOverlay();
+      showSuccessNotification(`Added ${list.items.length} items to cart`);
+      
+      // Redirect to cart
+      setTimeout(() => window.location.href = '/cart', 1500);
+      
+    } catch (error) {
+      hideLoadingOverlay();
+      showErrorNotification('Failed to add items: ' + error.message);
+    }
+  }
+  
+  handleCartUpdated(payload) {
+    // Update cart badge
+    document.querySelector('.cart-count').textContent = payload.data.itemCount;
+  }
+}
+
+const quickCart = new QuickCartIntegration();
+```
+
+#### Example 3: Selective cart integration with inventory check
+
+```js
+import { events } from '@dropins/tools/event-bus.js';
+import { addToCart } from '@dropins/storefront-cart/api.js';
+
+class SelectiveCartManager {
+  constructor() {
+    this.selectedItems = new Set();
+    
+    events.on('requisitionList/data', this.handleListData.bind(this));
+  }
+  
+  handleListData(payload) {
+    const list = payload.data;
+    
+    // Render list with selection checkboxes
+    this.renderSelectableList(list);
+  }
+  
+  renderSelectableList(list) {
+    const container = document.querySelector('#list-items');
+    
+    container.innerHTML = list.items.map(item => `
+      <div class="list-item ${item.available ? '' : 'out-of-stock'}">
+        <input 
+          type="checkbox" 
+          data-sku="${item.sku}"
+          ${item.available ? '' : 'disabled'}
+          onchange="window.cartManager.toggleItem('${item.sku}', this.checked)"
+        />
+        <div class="item-info">
+          <h4>${item.name}</h4>
+          <p>SKU: ${item.sku} | Qty: ${item.quantity}</p>
+          ${!item.available ? '<span class="badge">Out of Stock</span>' : ''}
+        </div>
+      </div>
+    `).join('');
+    
+    // Add bulk action button
+    this.addBulkActionButton();
+  }
+  
+  toggleItem(sku, checked) {
+    if (checked) {
+      this.selectedItems.add(sku);
+    } else {
+      this.selectedItems.delete(sku);
+    }
+    this.updateBulkButton();
+  }
+  
+  addBulkActionButton() {
+    const button = document.createElement('button');
+    button.id = 'add-selected';
+    button.textContent = 'Add selected to cart';
+    button.disabled = true;
+    button.onclick = () => this.addSelectedToCart();
+    
+    document.querySelector('#bulk-actions').appendChild(button);
+  }
+  
+  updateBulkButton() {
+    const button = document.querySelector('#add-selected');
+    const count = this.selectedItems.size;
+    
+    button.disabled = count === 0;
+    button.textContent = count > 0 
+      ? `Add ${count} selected items to cart`
+      : 'Select items to add';
+  }
+  
+  async addSelectedToCart() {
+    const items = Array.from(this.selectedItems);
+    
+    try {
+      showLoadingOverlay(`Adding ${items.length} items...`);
+      
+      for (const sku of items) {
+        const item = this.findItemBySku(sku);
+        await addToCart({
+          sku: item.sku,
+          quantity: item.quantity,
+          selectedOptions: item.selectedOptions
+        });
+      }
+      
+      hideLoadingOverlay();
+      showSuccessNotification(`Added ${items.length} items to cart`);
+      
+      // Clear selection
+      this.selectedItems.clear();
+      this.updateBulkButton();
+      
+      // Redirect
+      window.location.href = '/cart';
+      
+    } catch (error) {
+      hideLoadingOverlay();
+      showErrorNotification('Failed to add items: ' + error.message);
+    }
+  }
+  
+  findItemBySku(sku) {
+    // Helper to find item data
+    return this.currentList.items.find(item => item.sku === sku);
+  }
+}
+
+// Make globally accessible
+window.cartManager = new SelectiveCartManager();
+```
+
+
+
+#### Usage scenarios
+
+- Refresh the list details view after changes.
+- Update item count displays and badges.
+- Recalculate list totals and pricing.
+- Update caching or local storage.
+- Enable/disable action buttons based on list state.
+- Add entire requisition lists to the cart with one click.
+- Implement selective item-to-cart workflows.
+- Handle inventory availability in real-time.
+- Track cart conversions from requisition lists.
+- Show progress during bulk add operations.
+
+---
+
+
+
+
+### `requisitionList/initialized` (emits and listens)
+
+Triggered when the component completes initialization.
+
+#### Event payload
+
+
+
+#### When triggered
+
+- After `initialize()` function completes
+- On drop-in first load
+- After configuration is applied
+
+
+
+#### Example: Example
+
+```js
+import { events } from '@dropins/tools/event-bus.js';
+
+events.on('requisitionList/initialized', () => {
+  console.log('Requisition List drop-in ready');
+  
+  // Load initial data
+  loadRequisitionLists();
+  
+  // Enable UI interactions
+  enableRequisitionListFeatures();
+  
+  // Track analytics
+  trackRequisitionListEnabled();
+});
+```
+
+
+
+#### Usage scenarios
+
+- Load initial requisition lists.
+- Enable feature-specific UI elements.
+- Initialize dependent components.
+- Track feature availability.
+- Set up additional event listeners.
+
+---
+
+
+
+
+### `requisitionLists/data` (emits and listens)
+
+Triggered when data is available or changes.
+
+#### Event payload
+
+```typescript
+RequisitionList[] | null
+```
+
+See [`RequisitionList`](#requisitionlist) for full type definition.
+
+
+
+#### When triggered
+
+- After loading requisition lists
+- After creating a new list
+- After deleting a list
+- After list collection changes
+- On pagination or filtering
+
+
+
+#### Example: Example
+
+```js
+import { events } from '@dropins/tools/event-bus.js';
+
+events.on('requisitionLists/data', (payload) => {
+  const { items, totalCount } = payload.data;
+  
+  console.log(`${totalCount} requisition lists loaded`);
+  
+  // Update lists display
+  renderRequisitionLists(items);
+  
+  // Update pagination
+  updatePagination({
+    total: totalCount,
+    current: payload.data.currentPage,
+    pageSize: payload.data.pageSize
+  });
+  
+  // Update empty state
+  if (items.length === 0) {
+    showEmptyState();
+  } else {
+    hideEmptyState();
+  }
+});
+```
+
+
+
+#### Usage scenarios
+
+- Render lists grid or table.
+- Update list count displays.
+- Handle pagination.
+- Show/hide empty states.
+- Update filters and sorting.
+- Cache lists data.
+
+---
+
+## Listening to events
+
+All Requisition List events are emitted through the centralized event bus:
+
+```js
+import { events } from '@dropins/tools/event-bus.js';
+
+// Listen to list data events
+events.on('requisitionList/data', handleListUpdate);
+events.on('requisitionLists/data', handleListsUpdate);
+
+// Listen to UI events
+events.on('requisitionList/alert', handleAlert);
+events.on('requisitionList/redirect', handleRedirect);
+
+// Listen to initialization
+events.on('requisitionList/initialized', handleInit);
+
+// Clean up listeners when done
+events.off('requisitionList/data', handleListUpdate);
+events.off('requisitionList/alert', handleAlert);
+```
+
+<Aside type="tip">
+The `requisitionList/alert` event provides a standardized way to display feedback to users. Consider implementing a global alert handler rather than handling alerts in individual components.
+</Aside>
+
+<Aside type="note">
+The `requisitionList/redirect` event is advisory - your application controls whether to honor the redirect request. This allows you to implement custom routing logic or prevent navigation in certain scenarios.
+</Aside>
+
+## Event flow examples
+
+
+
+
+
+
+## Data Models
+
+The following data models are used in event payloads for this drop-in.
+
+### RequisitionList
+
+Used in: [`requisitionList/data`](#requisitionlistdata-emits-and-listens), [`requisitionLists/data`](#requisitionlistsdata-emits-and-listens).
+
+```ts
+interface RequisitionList {
+  uid: string;
+  name: string;
+  description: string;
+  updated_at: string;
+  items_count: number;
+  items: Item[];
+  page_info?: PageInfo;
+}
+```
+
+### RequisitionListActionPayload
+
+Used in: [`requisitionList/alert`](#requisitionlistalert-emits-and-listens).
+
+```ts
+interface RequisitionListActionPayload {
+    action: 'add' | 'delete' | 'update' | 'move';
+    type: 'success' | 'error';
+    context: 'product' | 'requisitionList';
+    skus?: string[]; // for product-related actions
+    message?: string[]; // for uncontrolled/custom messages
+  }
+```
+

--- a/src/content/docs/dropins-b2b/requisition-list/functions.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/functions.mdx
@@ -1,0 +1,374 @@
+---
+title: Requisition List Functions
+description: API functions provided by the Requisition List drop-in for programmatic control and customization.
+sidebar:
+  label: Functions
+  order: 6
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 3
+---
+
+import TableWrapper from '@components/TableWrapper.astro';
+import Link from '@components/Link.astro';
+import { Aside } from '@astrojs/starlight/components';
+
+The Requisition List drop-in provides **11 API functions** for managing requisition lists and their items, including creating lists, adding/removing products, and managing list metadata.
+
+<div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
+<strong>Version: 1.0.0-beta4</strong>
+</div>
+
+<TableWrapper nowrap={[0]}>
+
+| Function | Description |
+| --- | --- |
+| [`addProductsToRequisitionList`](#addproductstorequisitionlist) | Adds products to a requisition list.. |
+| [`addRequisitionListItemsToCart`](#addrequisitionlistitemstocart) | This function adds the chosen items from a requisition list to the logged-in user cart.. |
+| [`createRequisitionList`](#createrequisitionlist) | This function creates a new requisition list with the name and description provided for a logged-in user.. |
+| [`deleteRequisitionList`](#deleterequisitionlist) | This function deletes a requisition list identified by uid.. |
+| [`deleteRequisitionListItems`](#deleterequisitionlistitems) | Deletes items from a requisition list.. |
+| [`getProductData`](#getproductdata) | API function for the drop-in.. |
+| [`getRequisitionList`](#getrequisitionlist) | This function returns information about the desired requisition list from a logged-in user,.. |
+| [`getRequisitionLists`](#getrequisitionlists) | This function returns the requisition lists from a logged-in user.. |
+| [`getStoreConfig`](#getstoreconfig) | API function for the drop-in.. |
+| [`updateRequisitionList`](#updaterequisitionlist) | This function updates an existing requisition list with the name and description provided for a logged-in user.. |
+| [`updateRequisitionListItems`](#updaterequisitionlistitems) | This function updates the items of an existing requisition list with the quantity and options provided for a logged-in user.. |
+
+</TableWrapper>
+
+## addProductsToRequisitionList
+
+Adds products to a requisition list.
+
+```ts
+const addProductsToRequisitionList = async (
+  requisitionListUid: string,
+  requisitionListItems: Array<RequisitionListItemsInput>
+): Promise<RequisitionList | null>
+```
+
+<TableWrapper nowrap={[0]}>
+
+| Parameter | Type | Req? | Description |
+|---|---|---|---|
+| `requisitionListUid` | `string` | Yes | The unique identifier for the requisition list to which products will be added. This UID is returned when creating or retrieving requisition lists. |
+| `requisitionListItems` | `Array<RequisitionListItemsInput>` | Yes | An array of product objects to add to the requisition list. Each object includes the product SKU, quantity, and optional configuration like parent SKU for configurable products, selected options (color, size), and entered options (custom text fields). |
+
+</TableWrapper>
+
+### Events
+
+Emits the `requisitionList/data` event.
+
+### Returns
+
+Returns [`RequisitionList`](#requisitionlist) or `null`.
+
+## addRequisitionListItemsToCart
+
+This function adds the chosen items from a requisition list to the logged-in user cart.
+
+```ts
+const addRequisitionListItemsToCart = async (
+  requisitionListUid: string,
+  requisitionListItemUids: Array<string>
+): Promise<Array<string> | null>
+```
+
+<TableWrapper nowrap={[0,1]}>
+
+| Parameter | Type | Req? | Description |
+|---|---|---|---|
+| `requisitionListUid` | `string` | Yes | The unique identifier for the requisition list containing the items to add to the cart. |
+| `requisitionListItemUids` | `Array<string>` | Yes | An array of requisition list item UIDs to add to the cart. These are the unique identifiers for specific items within the list, not product SKUs. |
+
+</TableWrapper>
+
+### Events
+
+Does not emit any drop-in events.
+
+### Returns
+
+Returns `Array<string> | null`.
+
+## createRequisitionList
+
+This function creates a new requisition list with the name and description provided for a logged-in user.
+
+```ts
+const createRequisitionList = async (
+  name: string,
+  description?: string
+): Promise<RequisitionList | null>
+```
+
+<TableWrapper nowrap={[0,1]}>
+
+| Parameter | Type | Req? | Description |
+|---|---|---|---|
+| `name` | `string` | Yes | The display name for the new requisition list. This helps users identify and organize their lists (e.g., \*\*Office Supplies Q1\*\*, \*\*Weekly Inventory Restock\*\*). |
+| `description` | `string` | No | An optional text description providing additional context about the requisition list's purpose or contents (e.g., \*\*Monthly recurring orders for maintenance supplies\*\*). |
+
+</TableWrapper>
+
+### Events
+
+Emits the `requisitionList/data` event.
+
+### Returns
+
+Returns [`RequisitionList`](#requisitionlist) or `null`.
+
+## deleteRequisitionList
+
+This function deletes a requisition list identified by uid.
+
+```ts
+const deleteRequisitionList = async (
+  requisitionListUid: string
+): Promise<{
+  items: RequisitionList[];
+  page_info: any;
+  status: any;
+} | null>
+```
+
+<TableWrapper nowrap={[0,1]}>
+
+| Parameter | Type | Req? | Description |
+|---|---|---|---|
+| `requisitionListUid` | `string` | Yes | The unique identifier for the requisition list to delete. This operation is permanent and removes the list and all its items. |
+
+</TableWrapper>
+
+### Events
+
+Emits the `requisitionLists/data` event.
+
+### Returns
+
+```ts
+Promise<{
+  items: RequisitionList[];
+  page_info: any;
+  status: any;
+} | null>
+```
+
+See [`RequisitionList`](#requisitionlist).
+
+## deleteRequisitionListItems
+
+Deletes items from a requisition list.
+
+```ts
+const deleteRequisitionListItems = async (
+  requisitionListUid: string,
+  items: Array<string>,
+  pageSize: number,
+  currentPage: number
+): Promise<RequisitionList | null>
+```
+
+<TableWrapper nowrap={[0,1]}>
+
+| Parameter | Type | Req? | Description |
+|---|---|---|---|
+| `requisitionListUid` | `string` | Yes | The unique identifier for the requisition list from which items will be removed. |
+| `items` | `Array<string>` | Yes | An array of requisition list item UIDs to remove. These are the unique identifiers returned in the list's items array, not product SKUs. |
+| `pageSize` | `number` | Yes | The number of items to return per page in the updated requisition list response. |
+| `currentPage` | `number` | Yes | The page number for pagination (1-indexed). Used to retrieve a specific page of items after deletion. |
+
+</TableWrapper>
+
+### Events
+
+Emits the `requisitionList/data` event.
+
+### Returns
+
+Returns [`RequisitionList`](#requisitionlist) or `null`.
+
+## getProductData
+
+### Signature
+
+```typescript
+function getProductData(skus: string[]): Promise<Product[] | null>
+```
+
+### Parameters
+
+<TableWrapper nowrap={[0,1]}>
+
+| Parameter | Type | Required | Description |
+|---|---|---|---|
+| `skus` | `string[]` | Yes | An array of product SKUs (stock keeping units) to retrieve product details for. Used to fetch product information including prices, stock status, and configuration options. |
+
+</TableWrapper>
+
+---
+
+## getRequisitionList
+
+This function returns information about the desired requisition list from a logged-in user,
+
+```ts
+const getRequisitionList = async (
+  requisitionListID: string,
+  currentPage?: number,
+  pageSize?: number
+): Promise<RequisitionList | null>
+```
+
+<TableWrapper nowrap={[0,1]}>
+
+| Parameter | Type | Req? | Description |
+|---|---|---|---|
+| `requisitionListID` | `string` | Yes | The unique identifier for the requisition list to retrieve. Returns the list metadata and all items. |
+| `currentPage` | `number` | No | The page number for pagination (1-indexed). Defaults to page 1 if not specified. |
+| `pageSize` | `number` | No | The number of items to return per page. Controls pagination of the requisition list items. |
+
+</TableWrapper>
+
+### Events
+
+Emits the `requisitionList/data` event.
+
+### Returns
+
+Returns [`RequisitionList`](#requisitionlist) or `null`.
+
+## getRequisitionLists
+
+This function returns the requisition lists from a logged-in user.
+
+```ts
+const getRequisitionLists = async (
+  currentPage?: number,
+  pageSize?: number
+): Promise<RequisitionList[] | null>
+```
+
+<TableWrapper nowrap={[0,1]}>
+
+| Parameter | Type | Req? | Description |
+|---|---|---|---|
+| `currentPage` | `number` | No | The page number for pagination (1-indexed). Used to navigate through multiple pages of requisition lists. |
+| `pageSize` | `number` | No | The number of requisition lists to return per page. Controls how many lists appear on each page. |
+
+</TableWrapper>
+
+### Events
+
+Emits the `requisitionLists/data` event.
+
+### Returns
+
+Returns an array of [`RequisitionList`](#requisitionlist) objects or `null`.
+
+## getStoreConfig
+
+```ts
+const getStoreConfig = async (): Promise<any>
+```
+
+### Events
+
+Does not emit any drop-in events.
+
+### Returns
+
+Returns `void`.
+
+## updateRequisitionList
+
+This function updates an existing requisition list with the name and description provided for a logged-in user.
+
+```ts
+const updateRequisitionList = async (
+  requisitionListUid: string,
+  name: string,
+  description?: string,
+  pageSize?: number,
+  currentPage?: number
+): Promise<RequisitionList | null>
+```
+
+<TableWrapper nowrap={[0,1]}>
+
+| Parameter | Type | Req? | Description |
+|---|---|---|---|
+| `requisitionListUid` | `string` | Yes | The unique identifier for the requisition list to update. |
+| `name` | `string` | Yes | The new display name for the requisition list. Updates the list's title. |
+| `description` | `string` | No | The new text description for the requisition list. Updates the list's purpose or context information. |
+| `pageSize` | `number` | No | The number of items to return per page in the updated requisition list response. |
+| `currentPage` | `number` | No | The page number for pagination (1-indexed) in the updated requisition list response. |
+
+</TableWrapper>
+
+### Events
+
+Emits the `requisitionList/data` event.
+
+### Returns
+
+Returns [`RequisitionList`](#requisitionlist) or `null`.
+
+## updateRequisitionListItems
+
+This function updates the items of an existing requisition list with the quantity and options provided for a logged-in user.
+
+```ts
+const updateRequisitionListItems = async (
+  requisitionListUid: string,
+  requisitionListItems: Array<UpdateRequisitionListItemsInput>,
+  pageSize: number,
+  currentPage: number
+): Promise<RequisitionList | null>
+```
+
+<TableWrapper nowrap={[0]}>
+
+| Parameter | Type | Req? | Description |
+|---|---|---|---|
+| `requisitionListUid` | `string` | Yes | The unique identifier for the requisition list containing the items to update. |
+| `requisitionListItems` | `Array<UpdateRequisitionListItemsInput>` | Yes | An array of requisition list items to update. Each object includes the item UID and the fields to modify (such as quantity, selected options, or entered options). |
+| `pageSize` | `number` | Yes | The number of items to return per page in the updated requisition list response. |
+| `currentPage` | `number` | Yes | The page number for pagination (1-indexed) in the updated requisition list response. |
+
+</TableWrapper>
+
+### Events
+
+Emits the `requisitionList/data` event.
+
+### Returns
+
+Returns [`RequisitionList`](#requisitionlist) or `null`.
+
+## Data Models
+
+The following data models are used by functions in this drop-in.
+
+### RequisitionList
+
+The `RequisitionList` object is returned by the following functions: [`addProductsToRequisitionList`](#addproductstorequisitionlist), [`createRequisitionList`](#createrequisitionlist), [`deleteRequisitionList`](#deleterequisitionlist), [`deleteRequisitionListItems`](#deleterequisitionlistitems), [`getRequisitionList`](#getrequisitionlist), [`getRequisitionLists`](#getrequisitionlists), [`updateRequisitionList`](#updaterequisitionlist), [`updateRequisitionListItems`](#updaterequisitionlistitems).
+
+```ts
+interface RequisitionList {
+  uid: string;
+  name: string;
+  description: string;
+  updated_at: string;
+  items_count: number;
+  items: Item[];
+  page_info?: PageInfo;
+}
+```
+
+
+
+{/* This documentation is auto-generated from the drop-in source repository: REPO_URL */}

--- a/src/content/docs/dropins-b2b/requisition-list/index.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/index.mdx
@@ -1,0 +1,67 @@
+---
+title: Requisition List overview
+description: Learn about the features and functions of the Requisition List drop-in component.
+sidebar:
+  order: 1
+---
+
+import { Badge } from '@astrojs/starlight/components';
+import { Aside } from '@astrojs/starlight/components';
+
+The Requisition List drop-in enables creating and manage requisition lists and multiple requisition lists per account for Adobe Commerce storefronts. It also supports adding products from product pages and adding products from list pages.
+
+## Supported Commerce features
+
+The following table provides an overview of the Adobe Commerce features that the Requisition List drop-in supports:
+
+| Feature | Status |
+| ------- | ------ |
+| Create and manage requisition lists | <Badge text="Supported" variant="tip" /> |
+| Multiple requisition lists per account | <Badge text="Supported" variant="tip" /> |
+| Add products from product pages | <Badge text="Supported" variant="tip" /> |
+| Add products from list pages | <Badge text="Supported" variant="tip" /> |
+| Requisition list item management | <Badge text="Supported" variant="tip" /> |
+| Update item quantities | <Badge text="Supported" variant="tip" /> |
+| Delete items and lists | <Badge text="Supported" variant="tip" /> |
+| Add list items to cart | <Badge text="Supported" variant="tip" /> |
+| Batch item operations | <Badge text="Supported" variant="tip" /> |
+| Requisition list grid view | <Badge text="Supported" variant="tip" /> |
+| Customer authentication required | <Badge text="Supported" variant="tip" /> |
+| GraphQL API integration | <Badge text="Supported" variant="tip" /> |
+
+## Section topics
+
+The topics in this section will help you understand how to customize and use the Requisition List effectively within your storefront.
+
+### Quick Start
+
+Provides quick reference information and getting started guide for the Requisition List drop-in. This topic covers package details, import paths, and basic usage examples to help you integrate Requisition List functionality into your site.
+
+### Initialization
+
+**[Drop-in developer]:** Add 1-2 sentences describing what configuration options are available and what needs to be set up before using this drop-in.
+
+### Containers
+
+**[Drop-in developer]:** Add 1-2 sentences listing the main UI containers and what they're used for.
+
+### Functions
+
+**[Drop-in developer]:** Add 1-2 sentences describing the main API functions and what operations they enable.
+
+### Events
+
+**[Drop-in developer]:** Add 1-2 sentences describing what events are emitted and when they trigger.
+
+### Slots
+
+**[Drop-in developer]:** Add 1-2 sentences describing what parts of the UI can be customized with slots.
+
+### Dictionary
+
+**[Drop-in developer]:** Add 1-2 sentences describing the i18n keys and what they're used for.
+
+### Styles
+
+**[Drop-in developer]:** Add 1-2 sentences describing what visual elements can be styled.
+

--- a/src/content/docs/dropins-b2b/requisition-list/initialization.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/initialization.mdx
@@ -1,0 +1,241 @@
+---
+title: Requisition List initialization
+description: Configure the Requisition List drop-in with language definitions, custom data models, and drop-in-specific options.
+sidebar:
+  label: Initialization
+  order: 3
+---
+
+import TableWrapper from '@components/TableWrapper.astro';
+import { Aside } from '@astrojs/starlight/components';
+
+The **Requisition List initializer** configures the drop-in for managing saved product lists and recurring orders. Use initialization to customize how requisition list data is displayed and enable internationalization for multi-language B2B storefronts.
+
+<div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
+<strong>Version: 1.0.0-beta4</strong>
+</div>
+
+
+
+## Configuration options
+
+The following table describes the configuration options available for the **Requisition List** initializer:
+
+<TableWrapper nowrap={[0,1]}>
+
+| Parameter | Type | Req? | Description |
+|---|---|---|---|
+| `langDefinitions` | [`LangDefinitions`](#langdefinitions) | No | Language definitions for internationalization (i18n). Override dictionary keys for localization or branding. |
+
+</TableWrapper>
+
+## Default configuration
+
+The initializer runs with these defaults when no configuration is provided:
+
+```javascript title="scripts/initializers/requisition-list.js"
+import { initializers } from '@dropins/tools/initializer.js';
+import { initialize } from '@dropins/storefront-requisition-list';
+
+// All configuration options are optional
+await initializers.mountImmediately(initialize, {
+  langDefinitions: {}, // Uses built-in English strings
+  models: {}, // Uses default data models
+  
+});
+```
+
+## Language definitions
+
+Override dictionary keys for localization or branding. The `langDefinitions` object maps locale keys to custom strings that override default text for the drop-in.
+
+```javascript title="scripts/initializers/requisition-list.js"
+import { initializers } from '@dropins/tools/initializer.js';
+import { initialize } from '@dropins/storefront-requisition-list';
+
+const customStrings = {
+  'AddToCart': 'Add to Bag',
+  'Checkout': 'Complete Purchase',
+  'Price': 'Cost',
+};
+
+const langDefinitions = {
+  default: customStrings,
+};
+
+await initializers.mountImmediately(initialize, { langDefinitions });
+```
+
+<Aside type="tip">
+For complete dictionary customization including all available keys and multi-language support, see the [Requisition List Dictionary](/dropins-b2b/requisition-list/dictionary/) page.
+</Aside>
+
+## Customizing data models
+
+Extend or transform data models by providing custom transformer functions. Use the `models` option to add custom fields or modify existing data structures returned from the backend.
+
+### Available models
+
+The following models can be customized through the `models` configuration option:
+
+
+<TableWrapper nowrap={[0]}>
+
+| Model | Description |
+|---|---|
+| [`RequisitionListModel`](#requisitionlistmodel) | Transforms requisition list data from `GraphQL` including list details, items, quantities, and metadata. Use this to add custom fields or modify existing requisition list data structures. |
+| [`RequisitionListItemModel`](#requisitionlistitemmodel) | Transforms requisition list item data including product details, quantities, and custom options. Use this to add custom fields or modify item data structures. |
+
+</TableWrapper>
+
+The following example shows how to customize the `RequisitionListModel` model for the **Requisition List** drop-in:
+
+```javascript title="scripts/initializers/requisition-list.js"
+import { initializers } from '@dropins/tools/initializer.js';
+import { initialize } from '@dropins/storefront-requisition-list';
+
+const models = {
+  RequisitionListModel: {
+    transformer: (data) => ({
+      // Add formatted last updated date
+      lastUpdatedDisplay: data?.updated_at ? 
+        new Date(data.updated_at).toLocaleDateString() : null,
+      // Add total items summary
+      itemsSummary: `${data?.items_count || 0} items`,
+      // Add list description preview (first 50 chars)
+      descriptionPreview: data?.description ? 
+        data.description.substring(0, 50) + '...' : null,
+    }),
+  },
+};
+
+await initializers.mountImmediately(initialize, { models });
+```
+
+
+
+## Configuration types
+
+The following TypeScript definitions show the structure of each configuration object:
+
+### langDefinitions
+
+Maps locale identifiers to dictionaries of key-value pairs. The `default` locale is used as the fallback when no specific locale matches. Each dictionary key corresponds to a text string used in the drop-in UI.
+
+```typescript
+langDefinitions?: {
+  [locale: string]: {
+    [key: string]: string;
+  };
+};
+```
+
+
+## Model definitions
+
+The following TypeScript definitions show the structure of each customizable model:
+
+### RequisitionListModel
+
+```typescript
+export interface RequisitionList {
+  uid: string;
+  name: string;
+  description: string;
+  updated_at: string;
+  items_count: number;
+  items: Item[];
+  page_info?: PageInfo;
+}
+
+export interface PageInfo {
+  page_size: number;
+  current_page: number;
+  total_pages: number;
+}
+```
+
+### RequisitionListItemModel
+
+```typescript
+export interface Item {
+  uid: string;
+  sku: string;
+  product: Product;
+  quantity: number;
+  customizable_options?: {
+    uid: string;
+    is_required: boolean;
+    label: string;
+    sort_order: number;
+    type: string;
+    values: {
+      uid: string;
+      label: string;
+      price: { type: string; units: string; value: number };
+      value: string;
+    }[];
+  }[];
+  bundle_options?: {
+    uid: string;
+    label: string;
+    type: string;
+    values: {
+      uid: string;
+      label: string;
+      original_price: { value: number; currency: string };
+      priceV2: { value: number; currency: string };
+      quantity: number;
+    }[];
+  }[];
+  configurable_options?: {
+    option_uid: string;
+    option_label: string;
+    value_uid: string;
+    value_label: string;
+  }[];
+  links?: {
+    uid: string;
+    price?: number;
+    sample_url?: string;
+    sort_order?: number;
+    title?: string;
+  }[];
+  samples?: {
+    url?: string;
+    sort_order?: number;
+    title?: string;
+  }[];
+  gift_card_options?: {
+    amount?: { value?: number; currency?: string; };
+    custom_giftcard_amount?: { value?: number; currency?: string; };
+    message?: string;
+    recipient_email?: string;
+    recipient_name?: string;
+    sender_name?: string;
+    sender_email?: string;
+  };
+}
+
+export interface Product {
+  sku: string;
+  parent_sku: string;
+  name: string;
+  shortDescription: string;
+  metaDescription: string;
+  metaKeyword: string;
+  metaTitle: string;
+  description: string;
+  addToCartAllowed: boolean;
+  url: string;
+  urlKey: string;
+  externalId: string;
+  images: {
+    url: string;
+    label: string;
+    roles: string[];
+  }[];
+}
+```
+
+{/* This documentation is auto-generated from: https://github.com/adobe-commerce/storefront-requisition-list */}

--- a/src/content/docs/dropins-b2b/requisition-list/quick-start.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/quick-start.mdx
@@ -1,0 +1,69 @@
+---
+title: Requisition List Quick Start
+description: Quick reference and getting started guide for the Requisition List drop-in.
+sidebar:
+  label: Quick Start
+  order: 2
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import Link from '@components/Link.astro';
+
+Get started with the Requisition List drop-in to enable reusable product lists for repeat B2B ordering.
+
+
+<div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
+<strong>Version: 1.0.0-beta4</strong>
+</div>
+
+
+
+## Quick example
+
+The Requisition List drop-in is included in the <Link href="https://github.com/hlxsites/aem-boilerplate-commerce" text="Commerce boilerplate" />. This example shows the basic pattern:
+
+```js
+// 1. Import initializer (handles all setup)
+import '../../scripts/initializers/requisition-list.js';
+
+// 2. Import the container you need
+import RequisitionListForm from '@dropins/storefront-requisition-list/containers/RequisitionListForm.js';
+
+// 3. Import the provider
+import { render as provider } from '@dropins/storefront-requisition-list/render.js';
+
+// 4. Render in your block
+export default async function decorate(block) {
+  await provider.render(RequisitionListForm, {
+    // Configuration options - see Containers page
+  })(block);
+}
+```
+
+**New to drop-ins?** See the [Using drop-ins](/dropins/all/quick-start/) guide for complete step-by-step instructions.
+
+
+
+## Quick reference
+
+**Import paths:**
+- Initializer: `import '../../scripts/initializers/requisition-list.js'`
+- Containers: `import ContainerName from '@dropins/storefront-requisition-list/containers/ContainerName.js'`
+- Provider: `import { render } from '@dropins/storefront-requisition-list/render.js'`
+
+**Package:** `@dropins/storefront-requisition-list`
+
+**Version:** 1.0.0-beta4 (verify compatibility with your Commerce instance)
+
+**Example container:** `RequisitionListForm`
+
+## Learn more
+
+- [Containers](/dropins-b2b/requisition-list/containers/) - Available UI components and configuration options
+- [Initialization](/dropins-b2b/requisition-list/initialization/) - Customize initializer settings and data models
+- [Functions](/dropins-b2b/requisition-list/functions/) - Control drop-in behavior programmatically
+- [Events](/dropins-b2b/requisition-list/events/) - Listen to and respond to drop-in state changes
+- [Slots](/dropins-b2b/requisition-list/slots/) - Extend containers with custom content
+
+{/* This documentation is auto-generated from: https://github.com/adobe-commerce/storefront-requisition-list */}
+

--- a/src/content/docs/dropins-b2b/requisition-list/slots.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/slots.mdx
@@ -1,0 +1,67 @@
+---
+title: Requisition List Slots
+description: Customize UI sections in the Requisition List drop-in using slots.
+sidebar:
+  label: Slots
+  order: 5
+tableOfContents:
+  minHeadingLevel: 2
+  maxHeadingLevel: 2
+---
+
+import TableWrapper from '@components/TableWrapper.astro';
+import { Aside } from '@astrojs/starlight/components';
+
+The Requisition List drop-in exposes slots for customizing specific UI sections. Use slots to replace or extend container components. For default properties available to all slots, see [Extending drop-in components](/dropins/all/extending/).
+
+<div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
+<strong>Version: 1.0.0-beta4</strong>
+</div>
+
+<TableWrapper nowrap={[0]}>
+
+| Container | Slots |
+|-----------|-------|
+| [`RequisitionListGrid`](#requisitionlistgrid-slots) | `Header` |
+
+</TableWrapper>
+
+
+
+## RequisitionListGrid slots
+
+The slots for the `RequisitionListGrid` container allow you to customize its appearance and behavior.
+
+```typescript
+interface RequisitionListGridProps {
+  slots?: {
+    Header?: SlotProps;
+  };
+}
+```
+
+### Header slot
+
+The Header slot allows you to customize the header section of the `RequisitionListGrid` container.
+
+#### Example
+
+```js
+import { render as provider } from '@dropins/storefront-requisition-list/render.js';
+import { RequisitionListGrid } from '@dropins/storefront-requisition-list/containers/RequisitionListGrid.js';
+
+await provider.render(RequisitionListGrid, {
+  slots: {
+    Header: (ctx) => {
+      // Your custom implementation
+      const element = document.createElement('div');
+      element.innerText = 'Custom Header';
+      ctx.appendChild(element);
+    }
+  }
+})(block);
+```
+
+
+
+{/* This documentation is auto-generated from: https://github.com/adobe-commerce/storefront-requisition-list */}

--- a/src/content/docs/dropins-b2b/requisition-list/styles.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/styles.mdx
@@ -1,0 +1,141 @@
+---
+title: Requisition List styles
+description: CSS classes and customization examples for the Requisition List drop-in.
+---
+
+import Link from '@components/Link.astro';
+
+Customize the Requisition List drop-in using CSS classes and design tokens. This page covers the Requisition List-specific container classes and customization examples. For comprehensive information about design tokens, responsive breakpoints, and styling best practices, see [Styling Drop-In Components](/dropins/all/styling/).
+
+<div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
+<strong>Version: 1.0.0-beta4</strong>
+</div>
+
+## Customization example
+
+Add this to the CSS file of the specific <Link href="https://github.com/hlxsites/aem-boilerplate-commerce/blob/main/blocks/" text="commerce block" /> where you're using the Requisition List drop-in.
+
+For a complete list of available design tokens (colors, spacing, typography, and more), see the [Design tokens reference](/dropins/all/styling/#design-tokens-reference).
+
+```css title="styles/styles.css" del={2-2} ins={3-3}
+.requisition-list-view__batch-actions {
+  --batch-actions-background: #f0f4f8;
+  --batch-actions-background: var(--color-brand-800);
+}
+```
+
+## Container classes
+
+The Requisition List drop-in uses BEM-style class naming. Use the browser DevTools to inspect elements and find specific class names.
+
+```css
+/* BatchActions */
+.requisition-list-view__batch-actions {}
+.requisition-list-view__batch-actions-buttons {}
+.requisition-list-view__batch-actions-count-badge {}
+.requisition-list-view__batch-actions-delete-icon {}
+.requisition-list-view__batch-actions-left {}
+.requisition-list-view__batch-actions-select-label {}
+.requisition-list-view__batch-actions-select-toggle {}
+.requisition-list-view__batch-actions-select-toggle--active {}
+.requisition-list-view__bulk-actions {}
+
+/* EmptyList */
+.empty-list {}
+
+/* NotFound */
+.not-found {}
+
+/* PageSizePicker */
+.page-size-picker {}
+.page-size-picker__label {}
+.page-size-picker__select {}
+
+/* PaginationItemsCounter */
+.pagination-items-counter {}
+
+/* ProductListTable */
+.requisition-list-view-product-list-table-container {}
+.requisition-list-view-product-list-table-container__submit-container {}
+.requisition-list-view-product-list-table__checkbox {}
+.requisition-list-view-product-list-table__discount-container {}
+.requisition-list-view-product-list-table__index-container {}
+.requisition-list-view-product-list-table__item-container {}
+.requisition-list-view-product-list-table__item-details {}
+.requisition-list-view-product-list-table__low-stock {}
+.requisition-list-view-product-list-table__out-of-stock {}
+.requisition-list-view-product-list-table__product-configurable-name {}
+.requisition-list-view-product-list-table__product-name {}
+.requisition-list-view-product-list-table__quantity {}
+.requisition-list-view-product-list-table__sku {}
+.requisition-list-view-product-list-table__thumbnail {}
+
+/* RequisitionListActions */
+.requisition-list-actions {}
+.requisition-list-actions--selectable {}
+.requisition-list-actions__title {}
+
+/* RequisitionListForm */
+.requisition-list-form {}
+.requisition-list-form__actions {}
+.requisition-list-form__form {}
+.requisition-list-form__notification {}
+.requisition-list-form__title {}
+.requisition-list-form_progress-spinner {}
+
+/* RequisitionListGridWrapper */
+.dropin-button--tertiary {}
+.requisition-list-empty-list {}
+.requisition-list-grid-wrapper__actions {}
+.requisition-list-grid-wrapper__add-new {}
+.requisition-list-grid-wrapper__content {}
+.requisition-list-grid-wrapper__list-header {}
+.requisition-list-grid-wrapper__name__description {}
+.requisition-list-grid-wrapper__name__title {}
+.requisition-list-grid-wrapper__pagination {}
+.requisition-list-grid-wrapper__pagination-picker {}
+.requisition-list__alert-wrapper {}
+
+/* RequisitionListHeader */
+.requisition-list-header {}
+.requisition-list-header__action-link {}
+.requisition-list-header__actions {}
+.requisition-list-header__back {}
+.requisition-list-header__back-arrow {}
+.requisition-list-header__back-link {}
+.requisition-list-header__description {}
+.requisition-list-header__main {}
+.requisition-list-header__title {}
+.requisition-list-header__title-section {}
+
+/* RequisitionListModal */
+.dropin-modal {}
+.dropin-modal__body--full {}
+.dropin-modal__body--medium {}
+.dropin-modal__content {}
+.dropin-modal__header-title {}
+.dropin-modal__header-title-content {}
+.requisition-list-modal {}
+.requisition-list-modal--overlay {}
+.requisition-list-modal__buttons {}
+.requisition-list-modal__spinner {}
+
+/* RequisitionListSelector */
+.dropin-card--secondary {}
+.dropin-card__content {}
+.requisition-list-actions {}
+.requisition-list-form__actions {}
+.requisition-list-modal {}
+.requisition-list-selector__available-lists {}
+.requisition-list-selector__form {}
+
+/* RequisitionListView */
+.requisition-list-view__container {}
+.requisition-list-view__loading {}
+.requisition-list-view__pagination {}
+.requisition-list-view__pagination-picker {}
+```
+
+For the source CSS files, see the <Link href="https://github.com/adobe-commerce/storefront-requisition-list/tree/main/src" text="storefront-requisition-list repository" />.
+
+


### PR DESCRIPTION
**Note:** This PR supersedes #622 with a cleaner file structure for easier review.

## Requisition List Documentation

Complete documentation for the Requisition List B2B drop-in.

### 📖 Preview
Full preview with all dropins: https://commerce-docs.github.io/microsite-commerce-storefront/dropins-b2b/requisition-list/

### 📁 Files Added
- Overview and Quick Start
- Functions API reference
- Events reference
- Containers and slots
- Styles and i18n

### ✅ Review Checklist
- [ ] Technical accuracy
- [ ] Examples tested  
- [ ] No sensitive info
- [ ] Developer-friendly

Part of #600 - B2B Documentation Initiative