### PR TITLE
Remove caution on launch scheduling

### DIFF
--- a/src/content/docs/setup/launch/index.mdx
+++ b/src/content/docs/setup/launch/index.mdx
@@ -18,10 +18,6 @@ Completing all pre-work and tasks required to launch a new storefront can be ove
 
 As you develop, carefully track all changes made in development or staging environments to ensure that they can be applied and deployed when you migrate to production.
 
-:::caution
-Avoid scheduling a launch shortly before a weekend. The Adobe engineering team might have limited availability to fix critical issues if they occur.
-:::
-
 <Checklist checklistKey="seo">
 ### SEO and indexing
 


### PR DESCRIPTION
## Purpose of this pull request

Integrate review feedback:  Removed caution about scheduling launches before weekends.

### Associated JIRA ticket

[USF-3578](https://jira.corp.adobe.com/browse/USF-3578)


## Affected pages

-https://experienceleague.adobe.com/developer/commerce/storefront/setup/launch/

