### PR TITLE
Add Price Book ID setup documentation

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -334,6 +334,7 @@ async function config() {
                         items: [
                           { label: 'Overview', link: '/setup/configuration/' },
                           { label: 'Storefront configuration', link: '/setup/configuration/commerce-configuration/' },
+                          { label: 'Price Book ID setup', link: '/setup/configuration/price-book-setup/' },
                           { label: 'AEM Assets integration', link: '/setup/configuration/aem-assets-configuration/' },
                           { label: 'AEM Commerce prerender', link: '/setup/configuration/aem-prerender/' },
                           { label: 'Content delivery network', link: '/setup/configuration/content-delivery-network/' },

--- a/src/content/docs/setup/configuration/price-book-setup.mdx
+++ b/src/content/docs/setup/configuration/price-book-setup.mdx
@@ -64,19 +64,6 @@ Before you begin, ensure you have:
 
 </Steps>
 
-## How it works
-
-When Adobe Commerce Optimizer is enabled:
-
-1. The Auth drop-in emits the `auth/adobe-commerce-optimizer` event when a customer logs in.
-1. The event includes the Price Book ID for the customer from Adobe Commerce Optimizer.
-1. The `setAdobeCommerceOptimizerHeader` function adds the `AC-Price-Book-ID` header to all GraphQL requests.
-1. Adobe Commerce uses this header to return pricing specific to the Price Book for the customer.
-
-<Aside type="tip">
-The `eager: true` option ensures the event handler is registered before any authentication occurs, preventing race conditions.
-</Aside>
-
 ## Troubleshooting
 
 ### Price Book ID header is not being sent
@@ -93,7 +80,20 @@ If the header is being sent but pricing remains unchanged:
 
 - Verify that the Price Book ID is correctly configured in Adobe Commerce Optimizer.
 - Confirm that your Adobe Commerce backend is configured to recognize and process the `AC-Price-Book-ID` header.
-- Check that the customer's Price Book has active pricing rules.
+- Check that the customer has a Price Book with active pricing rules.
+
+## How it works
+
+When Adobe Commerce Optimizer is enabled:
+
+1. The Auth drop-in emits the `auth/adobe-commerce-optimizer` event when a customer logs in.
+1. The event includes the Price Book ID for the customer from Adobe Commerce Optimizer.
+1. The `setAdobeCommerceOptimizerHeader` function adds the `AC-Price-Book-ID` header to all GraphQL requests.
+1. Adobe Commerce uses this header to return pricing specific to the Price Book for the customer.
+
+<Aside type="tip">
+The `eager: true` option ensures the event handler is registered before any authentication occurs, preventing race conditions.
+</Aside>
 
 ## Additional resources
 

--- a/src/content/docs/setup/configuration/price-book-setup.mdx
+++ b/src/content/docs/setup/configuration/price-book-setup.mdx
@@ -101,7 +101,7 @@ The `eager: true` option ensures the event handler is registered before any auth
 
 ## Additional resources
 
-- <Link href="https://experienceleague.adobe.com/docs/commerce-merchant-services/price-indexer/price-indexing.html" text="Adobe Commerce Optimizer documentation" />
+- <Link href="https://experienceleague.adobe.com/en/docs/commerce/optimizer/setup/pricebooks" text="Adobe Commerce Optimizer Price Books documentation" />
 - [Storefront configuration](/setup/configuration/commerce-configuration/)
 - [Auth drop-in documentation](/dropins/user-auth/quick-start/)
 

--- a/src/content/docs/setup/configuration/price-book-setup.mdx
+++ b/src/content/docs/setup/configuration/price-book-setup.mdx
@@ -86,10 +86,14 @@ If the header is being sent but pricing remains unchanged:
 
 When Adobe Commerce Optimizer is enabled:
 
+<Steps>
+
 1. The Auth drop-in emits the `auth/adobe-commerce-optimizer` event when a customer logs in.
 1. The event includes the Price Book ID for the customer from Adobe Commerce Optimizer.
 1. The `setAdobeCommerceOptimizerHeader` function adds the `AC-Price-Book-ID` header to all GraphQL requests.
 1. Adobe Commerce uses this header to return pricing specific to the Price Book for the customer.
+
+</Steps>
 
 <Aside type="tip">
 The `eager: true` option ensures the event handler is registered before any authentication occurs, preventing race conditions.

--- a/src/content/docs/setup/configuration/price-book-setup.mdx
+++ b/src/content/docs/setup/configuration/price-book-setup.mdx
@@ -58,7 +58,7 @@ Before you begin, ensure you have:
 
    After making these changes, verify that the Price Book ID header is being sent with GraphQL requests:
 
-   - Log in as a customer in your storefront.
+   - Log in to your storefront as a customer.
    - Open your browser's developer tools and navigate to the Network tab.
    - Look for GraphQL requests and verify the `AC-Price-Book-ID` header is present in the request headers.
 

--- a/src/content/docs/setup/configuration/price-book-setup.mdx
+++ b/src/content/docs/setup/configuration/price-book-setup.mdx
@@ -69,9 +69,9 @@ Before you begin, ensure you have:
 When Adobe Commerce Optimizer is enabled:
 
 1. The Auth drop-in emits the `auth/adobe-commerce-optimizer` event when a customer logs in.
-1. The event includes the customer's Price Book ID from Adobe Commerce Optimizer.
+1. The event includes the Price Book ID for the customer from Adobe Commerce Optimizer.
 1. The `setAdobeCommerceOptimizerHeader` function adds the `AC-Price-Book-ID` header to all GraphQL requests.
-1. Adobe Commerce uses this header to return pricing specific to the customer's price book.
+1. Adobe Commerce uses this header to return pricing specific to the Price Book for the customer.
 
 <Aside type="tip">
 The `eager: true` option ensures the event handler is registered before any authentication occurs, preventing race conditions.

--- a/src/content/docs/setup/configuration/price-book-setup.mdx
+++ b/src/content/docs/setup/configuration/price-book-setup.mdx
@@ -1,0 +1,103 @@
+---
+title: Price Book ID setup
+description: Enable Adobe Commerce Optimizer Price Book ID functionality in your storefront.
+---
+
+import { Steps, Aside } from '@astrojs/starlight/components';
+import Link from '@components/Link.astro';
+
+This guide shows you how to enable Adobe Commerce Optimizer (ACO) Price Book ID functionality in the Adobe Commerce boilerplate. Price Book IDs allow you to deliver personalized pricing based on customer segments, contracts, or other business rules managed through Adobe Commerce Optimizer.
+
+## Prerequisites
+
+Before you begin, ensure you have:
+
+- An active Adobe Commerce Optimizer subscription.
+- Access to your boilerplate repository code.
+- The Auth drop-in installed and configured in your storefront.
+
+## Enable Price Book ID
+
+<Steps>
+
+1. **Enable Adobe Commerce Optimizer in the Auth drop-in initializer**
+
+   Open the Auth drop-in initializer file at `scripts/initializers/auth.js` and add the `adobeCommerceOptimizer: true` option:
+
+   ```javascript
+   // Initialize auth
+   return initializers.mountImmediately(initialize, {
+     langDefinitions,
+     adobeCommerceOptimizer: true // Enable ACO
+   });
+   ```
+
+1. **Replace the customer group header function**
+
+   Open the main initializers file at `scripts/initializers/index.js` and replace the `setCustomerGroupHeader` function with the `setAdobeCommerceOptimizerHeader` function:
+
+   ```javascript
+   const setAdobeCommerceOptimizerHeader = (adobeCommerceOptimizer) => {
+     if (adobeCommerceOptimizer?.priceBookId) {
+       CS_FETCH_GRAPHQL.setFetchGraphQlHeader('AC-Price-Book-ID', adobeCommerceOptimizer.priceBookId);
+     } else {
+       CS_FETCH_GRAPHQL.removeFetchGraphQlHeader('AC-Price-Book-ID');
+     }
+   };
+   ```
+
+1. **Update the event listener**
+
+   In the same `scripts/initializers/index.js` file, replace the `auth/group-uid` event listener with the `auth/adobe-commerce-optimizer` event:
+
+   ```javascript
+   events.on('auth/adobe-commerce-optimizer', setAdobeCommerceOptimizerHeader, { eager: true });
+   ```
+
+1. **Test the implementation**
+
+   After making these changes, verify that the Price Book ID header is being sent with GraphQL requests:
+
+   - Log in as a customer in your storefront.
+   - Open your browser's developer tools and navigate to the Network tab.
+   - Look for GraphQL requests and verify the `AC-Price-Book-ID` header is present in the request headers.
+
+</Steps>
+
+## How it works
+
+When Adobe Commerce Optimizer is enabled:
+
+1. The Auth drop-in emits the `auth/adobe-commerce-optimizer` event when a customer logs in.
+1. The event includes the customer's Price Book ID from Adobe Commerce Optimizer.
+1. The `setAdobeCommerceOptimizerHeader` function adds the `AC-Price-Book-ID` header to all GraphQL requests.
+1. Adobe Commerce uses this header to return pricing specific to the customer's price book.
+
+<Aside type="tip">
+The `eager: true` option ensures the event handler is registered before any authentication occurs, preventing race conditions.
+</Aside>
+
+## Troubleshooting
+
+### Price Book ID header is not being sent
+
+If the `AC-Price-Book-ID` header is not appearing in your GraphQL requests:
+
+- Verify that `adobeCommerceOptimizer: true` is set in the Auth drop-in initializer.
+- Confirm that the customer has a valid Price Book ID assigned in Adobe Commerce Optimizer.
+- Check the browser console for any JavaScript errors that might prevent the event from firing.
+
+### Pricing is not changing
+
+If the header is being sent but pricing remains unchanged:
+
+- Verify that the Price Book ID is correctly configured in Adobe Commerce Optimizer.
+- Confirm that your Adobe Commerce backend is configured to recognize and process the `AC-Price-Book-ID` header.
+- Check that the customer's Price Book has active pricing rules.
+
+## Additional resources
+
+- <Link href="https://experienceleague.adobe.com/docs/commerce-merchant-services/price-indexer/price-indexing.html" text="Adobe Commerce Optimizer documentation" />
+- [Storefront configuration](/setup/configuration/commerce-configuration/)
+- [Auth drop-in documentation](/dropins/user-auth/quick-start/)
+

--- a/src/content/docs/setup/configuration/price-book-setup.mdx
+++ b/src/content/docs/setup/configuration/price-book-setup.mdx
@@ -8,13 +8,17 @@ import Link from '@components/Link.astro';
 
 This guide shows you how to enable Adobe Commerce Optimizer (ACO) Price Book ID functionality in the Adobe Commerce boilerplate. Price Book IDs are assigned to <Link href="https://experienceleague.adobe.com/en/docs/commerce/optimizer/setup/pricebooks#view-price-books-in-commerce-optimizer" text="catalog views in Commerce Optimizer" /> and allow you to deliver personalized pricing based on customer segments, contracts, or other business rules.
 
+<Aside type="caution" title="Adobe Commerce Optimizer only">
+This guide is specifically for **Adobe Commerce Optimizer (ACO)** implementations. If you are using Adobe Commerce as a Cloud Service (ACCS) or Adobe Commerce PaaS without Optimizer, this feature does not apply to your setup. See the <Link href="/setup/configuration/commerce-configuration/" text="Storefront configuration" /> documentation for configuration options for your Commerce environment.
+</Aside>
+
 ## Prerequisites
 
 Before you begin, ensure you have:
 
 - An active Adobe Commerce Optimizer subscription.
-- Access to your boilerplate repository code.
-- The Auth drop-in installed and configured in your storefront.
+- Access to your <Link href="https://github.com/hlxsites/aem-boilerplate-commerce" text="boilerplate repository" /> code.
+- The <Link href="/dropins/user-auth/quick-start/" text="Auth drop-in" /> installed and configured in your storefront.
 
 ## Enable Price Book ID
 
@@ -22,7 +26,7 @@ Before you begin, ensure you have:
 
 1. **Enable Adobe Commerce Optimizer in the Auth drop-in initializer**
 
-   Open the Auth drop-in initializer file at `scripts/initializers/auth.js` and add the `adobeCommerceOptimizer: true` option:
+   Open the <Link href="/dropins/user-auth/initialization/" text="Auth drop-in initializer" /> file at `scripts/initializers/auth.js` and add the `adobeCommerceOptimizer: true` option:
 
    ```javascript
    // Initialize auth
@@ -48,11 +52,13 @@ Before you begin, ensure you have:
 
 1. **Update the event listener**
 
-   In the same `scripts/initializers/index.js` file, replace the `auth/group-uid` event listener with the `auth/adobe-commerce-optimizer` event:
+   In the same `scripts/initializers/index.js` file, replace the `auth/group-uid` event listener with the `auth/adobe-commerce-optimizer` <Link href="/dropins/all/events/" text="event" />:
 
    ```javascript
    events.on('auth/adobe-commerce-optimizer', setAdobeCommerceOptimizerHeader, { eager: true });
    ```
+   
+   The `{ eager: true }` option ensures the event handler executes immediately if the event has already been emitted. See <Link href="/dropins/all/events/#subscription-options" text="Event subscription options" /> for more details.
 
 1. **Test the implementation**
 
@@ -88,15 +94,19 @@ When Adobe Commerce Optimizer is enabled:
 
 <Steps>
 
-1. The Auth drop-in emits the `auth/adobe-commerce-optimizer` event when a customer logs in.
-1. The event includes the Price Book ID from Adobe Commerce Optimizer.
+1. The <Link href="/dropins/user-auth/" text="Auth drop-in" /> emits the `auth/adobe-commerce-optimizer` event when a customer logs in.
+1. The event includes the Price Book ID from Adobe Commerce Optimizer for the authenticated customer.
 1. The `setAdobeCommerceOptimizerHeader` function adds the `AC-Price-Book-ID` header to all GraphQL requests.
 1. Adobe Commerce uses this header to return pricing specific to the Price Book associated with the catalog view.
 
 </Steps>
 
 <Aside type="tip">
-The `eager: true` option ensures the event handler is registered before any authentication occurs, preventing race conditions.
+The `eager: true` option ensures the event handler is registered before any authentication occurs, preventing race conditions. Learn more about <Link href="/dropins/all/events/#subscription-options" text="event subscription options" />.
+</Aside>
+
+<Aside type="note">
+Price Books are <Link href="https://experienceleague.adobe.com/en/docs/commerce/optimizer/setup/pricebooks#view-price-books-in-commerce-optimizer" text="assigned to catalog views in Commerce Optimizer" />. The `commerceOptimizer` GraphQL query returns the appropriate Price Book ID for the authenticated customer based on your Commerce Optimizer configuration. For more information about Commerce Optimizer setup, see the <Link href="https://experienceleague.adobe.com/en/docs/commerce/optimizer/setup/catalog-view" text="Catalog view configuration" /> documentation.
 </Aside>
 
 ## Additional resources

--- a/src/content/docs/setup/configuration/price-book-setup.mdx
+++ b/src/content/docs/setup/configuration/price-book-setup.mdx
@@ -6,7 +6,7 @@ description: Enable Adobe Commerce Optimizer Price Book ID functionality in your
 import { Steps, Aside } from '@astrojs/starlight/components';
 import Link from '@components/Link.astro';
 
-This guide shows you how to enable Adobe Commerce Optimizer (ACO) Price Book ID functionality in the Adobe Commerce boilerplate. Price Book IDs allow you to deliver personalized pricing based on customer segments, contracts, or other business rules managed through Adobe Commerce Optimizer.
+This guide shows you how to enable Adobe Commerce Optimizer (ACO) Price Book ID functionality in the Adobe Commerce boilerplate. Price Book IDs are assigned to <Link href="https://experienceleague.adobe.com/en/docs/commerce/optimizer/setup/pricebooks#view-price-books-in-commerce-optimizer" text="catalog views in Commerce Optimizer" /> and allow you to deliver personalized pricing based on customer segments, contracts, or other business rules.
 
 ## Prerequisites
 
@@ -71,16 +71,16 @@ Before you begin, ensure you have:
 If the `AC-Price-Book-ID` header is not appearing in your GraphQL requests:
 
 - Verify that `adobeCommerceOptimizer: true` is set in the Auth drop-in initializer.
-- Confirm that the customer has a valid Price Book ID assigned in Adobe Commerce Optimizer.
+- Confirm that a Price Book ID is assigned to the catalog view in Adobe Commerce Optimizer.
 - Check the browser console for any JavaScript errors that might prevent the event from firing.
 
 ### Pricing is not changing
 
 If the header is being sent but pricing remains unchanged:
 
-- Verify that the Price Book ID is correctly configured in Adobe Commerce Optimizer.
-- Confirm that your Adobe Commerce backend is configured to recognize and process the `AC-Price-Book-ID` header.
-- Check that the customer has a Price Book with active pricing rules.
+- Verify that the Price Book ID is correctly configured for the catalog view in Adobe Commerce Optimizer.
+- Confirm that your Adobe Commerce backend is configured to recognize and process the `AC-Price-Book-ID` <Link href="/setup/configuration/commerce-configuration/#headers" text="header" />.
+- Check that the Price Book has active pricing rules.
 
 ## How it works
 
@@ -89,9 +89,9 @@ When Adobe Commerce Optimizer is enabled:
 <Steps>
 
 1. The Auth drop-in emits the `auth/adobe-commerce-optimizer` event when a customer logs in.
-1. The event includes the Price Book ID for the customer from Adobe Commerce Optimizer.
+1. The event includes the Price Book ID from Adobe Commerce Optimizer.
 1. The `setAdobeCommerceOptimizerHeader` function adds the `AC-Price-Book-ID` header to all GraphQL requests.
-1. Adobe Commerce uses this header to return pricing specific to the Price Book for the customer.
+1. Adobe Commerce uses this header to return pricing specific to the Price Book associated with the catalog view.
 
 </Steps>
 

--- a/src/content/docs/setup/configuration/price-book-setup.mdx
+++ b/src/content/docs/setup/configuration/price-book-setup.mdx
@@ -12,7 +12,8 @@ This guide shows you how to enable Adobe Commerce Optimizer (ACO) Price Book ID 
 
 Before you begin, ensure you have:
 
-- An active Adobe Commerce Optimizer subscription.
+- An active Adobe Commerce Optimizer subscription. 
+- The storefront is configured to connect to Adobe Commerce Optimizer
 - Access to your boilerplate repository code.
 - The Auth drop-in installed and configured in your storefront.
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds documentation for enabling Adobe Commerce Optimizer Price Book ID functionality in the Adobe Commerce boilerplate, allowing developers to deliver personalized pricing based on customer segments and contracts.

### Associated JIRA ticket

https://jira.corp.adobe.com/browse/USF-3571

### Staging preview

NA

## Affected pages

New pages added:
- /setup/configuration/price-book-setup/

Modified pages:
- Sidebar configuration (astro.config.mjs)

## Links to source code

Not applicable - documentation only

## Preview

![PriceBook](https://github.com/user-attachments/assets/701aaaf1-844f-4d99-950c-4e8395113058)
