### PR TITLE
Update link to storefront events documentation

### DIFF
--- a/src/content/docs/setup/analytics/adobe-experience-platform.mdx
+++ b/src/content/docs/setup/analytics/adobe-experience-platform.mdx
@@ -104,7 +104,7 @@ Once configured, your storefront will automatically send the following types of 
 If `LiveSearch` is not installed and configured, these search events are not sent.
 </Aside>
 
-For a complete list of storefront events, see the <Link href="https://github.com/adobe/elsie/blob/main/src/content/docs/sdk/reference/events.md" text="Storefront events documentation" />.
+For a complete list of storefront events, see the <Link href="https://developer.adobe.com/commerce/services/shared-services/storefront-events/" text="Storefront events documentation" />.
 
 <Aside type="note" title="Debugging events">
 To debug events in your storefront, you can use the AEP Debugger Events view. For instructions on how to use the <Link href="https://experienceleague.adobe.com/docs/experience-platform/debugger/home.html" text="AEP Debugger video tutorial" />.


### PR DESCRIPTION
## Purpose of this pull request

This pull request updates the documentation in the Adobe Experience Platform analytics setup guide to reference the correct and most up-to-date source for storefront events.

## Affected topic

- https://experienceleague.adobe.com/developer/commerce/storefront/setup/analytics/adobe-experience-platform/
