### PR TITLE
Add best practice slot usage

### DIFF
--- a/src/content/docs/dropins/all/slots.mdx
+++ b/src/content/docs/dropins/all/slots.mdx
@@ -6,7 +6,6 @@ description: Learn how to use drop-in slots to customize drop-in components.
 import { Tabs, TabItem } from '@astrojs/starlight/components';
 import Diagram from '@components/Diagram.astro';
 import Vocabulary from '@components/Vocabulary.astro';
-import Aside from '@components/Aside.astro';
 import Callouts from '@components/Callouts.astro';
 import { Steps } from '@astrojs/starlight/components';
 import Tasks from '@components/Tasks.astro';
@@ -14,6 +13,24 @@ import Task from '@components/Task.astro';
 import TableWrapper from '@components/TableWrapper.astro';
 
 Using slots provides the deepest level of customization for drop-in components. Slots are built-in extension points in the drop-in. A slot provides a place in the drop-in component to add your own UI components and functions. This architecture makes it easy to change the default look, layout, and behavior. Let's learn how slots work.
+
+## Vocabulary
+
+<Vocabulary>
+
+### Container
+
+A component that manages or encapsulates other components. Containers handle logic, fetch data, manage state, and pass data to the UI components that are rendered on the screen.
+
+### Slot
+
+A component that provides placeholders to add other components. You can use the built-in slots for a drop-in component to add or remove UI components and functions. Or you can add your own additional slots.
+
+### Component
+
+In web development, this term is overused. That is why we need to be specific about the kind of component we are talking about. Here are a few examples of components from top to bottom: a **drop-in component** can contain multiple **container components** that can contain multiple **slot components**.
+
+</Vocabulary>
 
 ## Big Picture
 
@@ -23,37 +40,51 @@ The following functions are available to all slots:
 
 <Callouts>
 
-1. `prependSibling`: A function to prepend a new HTML element before the slot's content.
-1. `prependChild`: A function to prepend a new HTML element to the slot's content.
-1. `replaceWith`: A function to replace the slot's content with a new HTML element.
-1. `appendChild`: A function to append a new HTML element to the slot's content.
-1. `appendSibling`: A function to append a new HTML element after the slot's content.
-1. `remove`: A function to remove the slot from the DOM.
-1. `getSlotElement`: A function to get a slot element.
-1. `onChange`: A function to listen to changes in the slot's context.
-1. `dictionary`: JSON Object for the current locale. If the locale changes, the `dictionary` values change to reflect the values for the selected language.
+1. `prependSibling`: Prepends a new HTML element before the content of the slot.
+1. `prependChild`: Prepends a new HTML element to the content of the slot.
+1. `replaceWith`: Replaces the content of the slot with a new HTML element.
+1. `appendChild`: Appends a new HTML element to the content of the slot.
+1. `appendSibling`: Appends a new HTML element after the content of the slot.
+1. `remove`: Removes the slot from the DOM.
+1. `getSlotElement`: Gets a slot element.
+1. `onChange`: Listens to changes in the context of the slot.
+1. `dictionary`: Provides a JSON Object for the current locale. If the locale changes, the `dictionary` values change to reflect the values for the selected language.
 
 </Callouts>
 
-## Vocabulary
+## Best practice for dynamic slot content
 
-<Vocabulary>
+**Do not use context methods inside other context methods.** Context methods include `appendChild()`, `prependChild()`, `replaceWith()`, `appendSibling()`, `prependSibling()`, `remove()`, `getSlotElement()`, and `onChange()`.
 
-### Container
+Instead, create and append wrapper elements on mount, then update their content inside callbacks using standard DOM methods like `innerHTML`:
 
-Component that manages or encapsulates other components. Containers handle logic, fetch data, manage state, and pass data to the UI components that are rendered on the screen.
+```js
+slots: {
+  MySlot: (ctx) => {
+    const wrapper = document.createElement('div');
+    
+    // Use context method on mount (outside other context methods)
+    ctx.appendChild(wrapper);
+    
+    // Update content inside onChange using standard DOM methods
+    ctx.onChange((next) => {
+      if (next.data.condition) {
+        wrapper.innerHTML = 'Content A';
+      } else {
+        wrapper.innerHTML = 'Content B';
+      }
+    });
+  }
+}
+```
 
-### Slot
-
-Component that provides placeholders to add other components. You can use a drop-in component's built-in slots to add or remove UI components and functions. Or you can add your own additional slots.
-
-### Component
-
-In web development, this term is overused. That's why we need to be specific about the kind of component we are talking about. Here's a few examples of components from top-to-bottom: a **drop-in component** can contain multiple **container components** that can contain multiple **slot components** that can contain multiple **UI components**.
-
-</Vocabulary>
-
----
+```js
+// ❌ Incorrect: Calling context method inside context method
+ctx.onChange((next) => {
+  const element = document.createElement('div');
+  ctx.appendChild(element);  // Incorrect - context method inside context method
+});
+```
 
 ## Related resources
 

--- a/src/content/docs/dropins/cart/slots.mdx
+++ b/src/content/docs/dropins/cart/slots.mdx
@@ -18,40 +18,22 @@ The Cart drop-in exposes **49 slots** in **6 containers** for customizing specif
 <strong>Version: 1.5.1</strong>
 </div>
 
-<table>
-<thead>
-<tr>
-<th style="white-space: nowrap;">Container</th>
-<th>Slots</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td style="white-space: nowrap;"><a href="#cartsummarygrid-slots"><code>CartSummaryGrid</code></a></td>
-<td><code>Thumbnail</code></td>
-</tr>
-<tr>
-<td style="white-space: nowrap;"><a href="#cartsummarylist-slots"><code>CartSummaryList</code></a></td>
-<td><code>Heading</code>, <code>EmptyCart</code>, <code>Footer</code>, <code>Thumbnail</code>, <code>ProductAttributes</code>, <code>CartSummaryFooter</code>, <code>CartItem</code>, <code>UndoBanner</code>, <code>ItemTitle</code>, <code>ItemPrice</code>, <code>ItemQuantity</code>, <code>ItemTotal</code>, <code>ItemSku</code>, <code>ItemRemoveAction</code></td>
-</tr>
-<tr>
-<td style="white-space: nowrap;"><a href="#cartsummarytable-slots"><code>CartSummaryTable</code></a></td>
-<td><code>Item</code>, <code>Price</code>, <code>Quantity</code>, <code>Subtotal</code>, <code>Thumbnail</code>, <code>ProductTitle</code>, <code>Sku</code>, <code>Configurations</code>, <code>ItemAlert</code>, <code>ItemWarning</code>, <code>Actions</code>, <code>UndoBanner</code>, <code>EmptyCart</code></td>
-</tr>
-<tr>
-<td style="white-space: nowrap;"><a href="#giftoptions-slots"><code>GiftOptions</code></a></td>
-<td><code>SwatchImage</code></td>
-</tr>
-<tr>
-<td style="white-space: nowrap;"><a href="#minicart-slots"><code>MiniCart</code></a></td>
-<td><code>ProductList</code>, <code>ProductListFooter</code>, <code>PreCheckoutSection</code>, <code>Thumbnail</code>, <code>Heading</code>, <code>EmptyCart</code>, <code>Footer</code>, <code>ProductAttributes</code>, <code>CartSummaryFooter</code>, <code>CartItem</code>, <code>UndoBanner</code>, <code>ItemTitle</code>, <code>ItemPrice</code>, <code>ItemQuantity</code>, <code>ItemTotal</code>, <code>ItemSku</code>, <code>ItemRemoveAction</code></td>
-</tr>
-<tr>
-<td style="white-space: nowrap;"><a href="#ordersummary-slots"><code>OrderSummary</code></a></td>
-<td><code>EstimateShipping</code>, <code>Coupons</code>, <code>GiftCards</code></td>
-</tr>
-</tbody>
-</table>
+<Aside type="tip" title="Slot usage best practice">
+Do not use context methods inside other context methods (for example, `appendChild()` inside `onChange()`). See [Slots best practices](/dropins/all/slots/#best-practice-for-dynamic-slot-content) for details and examples.
+</Aside>
+
+<TableWrapper nowrap={[0]}>
+
+| Container | Slots |
+|-----------|-------|
+| [`CartSummaryGrid`](#cartsummarygrid-slots) | `Thumbnail` |
+| [`CartSummaryList`](#cartsummarylist-slots) | `Heading`, `EmptyCart`, `Footer`, `Thumbnail`, `ProductAttributes`, `CartSummaryFooter`, `CartItem`, `UndoBanner`, `ItemTitle`, `ItemPrice`, `ItemQuantity`, `ItemTotal`, `ItemSku`, `ItemRemoveAction` |
+| [`CartSummaryTable`](#cartsummarytable-slots) | `Item`, `Price`, `Quantity`, `Subtotal`, `Thumbnail`, `ProductTitle`, `Sku`, `Configurations`, `ItemAlert`, `ItemWarning`, `Actions`, `UndoBanner`, `EmptyCart` |
+| [`GiftOptions`](#giftoptions-slots) | `SwatchImage` |
+| [`MiniCart`](#minicart-slots) | `ProductList`, `ProductListFooter`, `PreCheckoutSection`, `Thumbnail`, `Heading`, `EmptyCart`, `Footer`, `ProductAttributes`, `CartSummaryFooter`, `CartItem`, `UndoBanner`, `ItemTitle`, `ItemPrice`, `ItemQuantity`, `ItemTotal`, `ItemSku`, `ItemRemoveAction` |
+| [`OrderSummary`](#ordersummary-slots) | `EstimateShipping`, `Coupons`, `GiftCards` |
+
+</TableWrapper>
 
 
 ## CartSummaryGrid slots

--- a/src/content/docs/dropins/order/slots.mdx
+++ b/src/content/docs/dropins/order/slots.mdx
@@ -18,6 +18,10 @@ The Order drop-in exposes **11 slots** in **6 containers** for customizing speci
 <strong>Version: 1.4.0</strong>
 </div>
 
+<Aside type="tip" title="Slot usage best practice">
+Do not use context methods inside other context methods (for example, `appendChild()` inside `onChange()`). See [Slots best practices](/dropins/all/slots/#best-practice-for-dynamic-slot-content) for details and examples.
+</Aside>
+
 <table>
 <thead>
 <tr>

--- a/src/content/docs/dropins/personalization/slots.mdx
+++ b/src/content/docs/dropins/personalization/slots.mdx
@@ -18,6 +18,10 @@ The Personalization drop-in exposes **1 slot** in **1 container** for customizin
 <strong>Version: 1.0.1</strong>
 </div>
 
+<Aside type="tip" title="Slot usage best practice">
+Do not use context methods inside other context methods (for example, `appendChild()` inside `onChange()`). See [Slots best practices](/dropins/all/slots/#best-practice-for-dynamic-slot-content) for details and examples.
+</Aside>
+
 <table>
 <thead>
 <tr>

--- a/src/content/docs/dropins/product-discovery/slots.mdx
+++ b/src/content/docs/dropins/product-discovery/slots.mdx
@@ -18,6 +18,10 @@ The Product Discovery drop-in exposes **12 slots** in **2 containers** for custo
 <strong>Version: 2.1.0</strong>
 </div>
 
+<Aside type="tip" title="Slot usage best practice">
+Do not use context methods inside other context methods (for example, `appendChild()` inside `onChange()`). See [Slots best practices](/dropins/all/slots/#best-practice-for-dynamic-slot-content) for details and examples.
+</Aside>
+
 <table>
 <thead>
 <tr>

--- a/src/content/docs/dropins/recommendations/slots.mdx
+++ b/src/content/docs/dropins/recommendations/slots.mdx
@@ -18,6 +18,10 @@ The Recommendations drop-in exposes **6 slots** in **1 container** for customizi
 <strong>Version: 1.1.1</strong>
 </div>
 
+<Aside type="tip" title="Slot usage best practice">
+Do not use context methods inside other context methods (for example, `appendChild()` inside `onChange()`). See [Slots best practices](/dropins/all/slots/#best-practice-for-dynamic-slot-content) for details and examples.
+</Aside>
+
 <table>
 <thead>
 <tr>

--- a/src/content/docs/dropins/user-auth/slots.mdx
+++ b/src/content/docs/dropins/user-auth/slots.mdx
@@ -18,6 +18,10 @@ The User Auth drop-in exposes **5 slots** in **7 containers** for customizing sp
 <strong>Version: 2.1.5</strong>
 </div>
 
+<Aside type="tip" title="Slot usage best practice">
+Do not use context methods inside other context methods (for example, `appendChild()` inside `onChange()`). See [Slots best practices](/dropins/all/slots/#best-practice-for-dynamic-slot-content) for details and examples.
+</Aside>
+
 <table>
 <thead>
 <tr>


### PR DESCRIPTION
## Improve slot documentation structure and consistency

This PR adds a best-practices section to the slot documentation in the main Slots topic and adds Asides with links to that section.

## Preview
General Slots topic:

<img width="745" height="788" alt="image" src="https://github.com/user-attachments/assets/f4b23f79-11a5-4a9f-94dc-30963d78248b" />

Each drop-in's Slot topic:

<img width="756" height="163" alt="image" src="https://github.com/user-attachments/assets/ea1cfd0e-b60d-4bff-8166-85585b218248" />


### Associated JIRA ticket

NA — Slack conversation.

## Affected pages

- [src/content/docs/dropins/all/slots.mdx](https://github.com/commerce-docs/microsite-commerce-storefront/blob/slot-bestpractice/src/content/docs/dropins/all/slots.mdx)
- [src/content/docs/dropins/cart/slots.mdx](https://github.com/commerce-docs/microsite-commerce-storefront/blob/slot-bestpractice/src/content/docs/dropins/cart/slots.mdx)
- [src/content/docs/dropins/order/slots.mdx](https://github.com/commerce-docs/microsite-commerce-storefront/blob/slot-bestpractice/src/content/docs/dropins/order/slots.mdx)
- [src/content/docs/dropins/personalization/slots.mdx](https://github.com/commerce-docs/microsite-commerce-storefront/blob/slot-bestpractice/src/content/docs/dropins/personalization/slots.mdx)
- [src/content/docs/dropins/product-discovery/slots.mdx](https://github.com/commerce-docs/microsite-commerce-storefront/blob/slot-bestpractice/src/content/docs/dropins/product-discovery/slots.mdx)
- [src/content/docs/dropins/recommendations/slots.mdx](https://github.com/commerce-docs/microsite-commerce-storefront/blob/slot-bestpractice/src/content/docs/dropins/recommendations/slots.mdx)
- [src/content/docs/dropins/user-auth/slots.mdx](https://github.com/commerce-docs/microsite-commerce-storefront/blob/slot-bestpractice/src/content/docs/dropins/user-auth/slots.mdx)

