### PR TITLE
Fix 404 link to pre-render documentation

### DIFF
--- a/src/content/docs/setup/launch/index.mdx
+++ b/src/content/docs/setup/launch/index.mdx
@@ -38,7 +38,7 @@ As you develop, carefully track all changes made in development or staging envir
 <Checklist checklistKey="prerendering">
 ### Enable pre-rendering
 
-* [ ] Add pre-rendering for key pages. See the [pre-rendering documentation](https://www.aem.live/docs/prerendering) for details.
+* [ ] Add pre-rendering for key pages. See the [pre-rendering documentation](/setup/configuration/aem-prerender/) for details.
 * [ ] Verify that all URLs are in lower case to support pre-rendering without breaking any links.
 * [ ] Validate HTML source for metadata and enriched body content (to ensure pre-rendering is working).
 * [ ] Check availability of page translations for locales with different languages.


### PR DESCRIPTION
## Purpose of this pull request

Fix broken link the the Launch checklist.


## Affected pages

- https://experienceleague.adobe.com/developer/commerce/storefront/setup/launch/

