### PR TITLE
'Adobe Cloud as Cloud Service' -> 'Adobe Commerce as Cloud Service'

### DIFF
--- a/src/content/docs/get-started/architecture.mdx
+++ b/src/content/docs/get-started/architecture.mdx
@@ -119,9 +119,9 @@ The flow demonstrates how a simple table in a document becomes a fully functiona
 
 ## Adobe Commerce or Adobe Commerce as a Cloud Service
 
-Adobe Commerce or [Adobe Cloud as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) is the backend system that powers your Commerce storefront. On Adobe Commerce, you must use version 2.4.7 or later with the storefront compatibility package installed.
+Adobe Commerce or [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) is the backend system that powers your Commerce storefront. On Adobe Commerce, you must use version 2.4.7 or later with the storefront compatibility package installed.
 
-Adobe Cloud as a Cloud Service is the recommended deployment option for Adobe Commerce. It provides a fully managed, scalable, and secure environment for running your Commerce storefront. All product requirements and services are automatically managed and updated by Adobe.
+Adobe Commerce as a Cloud Service is the recommended deployment option for Adobe Commerce. It provides a fully managed, scalable, and secure environment for running your Commerce storefront. All product requirements and services are automatically managed and updated by Adobe.
 
 Before starting the project, ensure that your Commerce backend meets the following requirements:
 


### PR DESCRIPTION
Fix typo
'Adobe Cloud as Cloud Service' -> 'Adobe Commerce as Cloud Service'