### PR TITLE
Update checkout validate shipping address tutorial

### DIFF
--- a/src/content/docs/dropins/checkout/tutorials/validate-shipping-address.mdx
+++ b/src/content/docs/dropins/checkout/tutorials/validate-shipping-address.mdx
@@ -30,6 +30,7 @@ import * as checkoutApi from '@dropins/storefront-checkout/api.js';
 import * as orderApi from '@dropins/storefront-order/api.js';
 import { PaymentMethodCode } from '@dropins/storefront-payment-services/api.js';
 import { events } from '@adobe-commerce/event-bus';
+import { SHIPPING_ADDRESS_DATA_KEY } from './constants.js';
 import { showModal, validateAddress } from './utils.js';
 
 // Handler passed to the PlaceOrder container
@@ -59,9 +60,8 @@ const handlePlaceOrder = async ({ cartId, code }) => {
         suggestedAddress: suggestion,
         handleSelectedAddress: async ({ selection, address }) => {
           if (selection === 'suggested') {
-            await checkoutApi.setShippingAddress({ address });
-
             // Update the shipping form using the suggested address
+            sessionStorage.removeItem(SHIPPING_ADDRESS_DATA_KEY);
             shippingForm.setProps((prevProps) => ({
               ...prevProps,
               inputsDefaultValueSet: address,


### PR DESCRIPTION
## Purpose of this pull request

Update the checkout tutorial to validate the shipping address:
- There’s no need to call `setShippingAddress` api, it’s already set by the shipping form container when updating the `inputsDefaultValueSet` prop.
- Remove the session storage item used for the shipping address to reset the data and ensure it’s updated correctly based on the suggestion.

### Associated JIRA ticket

No ticket.

### Staging preview

N/A

## Affected pages

<!-- REQUIRED List the affected pages on experienceleague.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://experienceleague.adobe.com/developer/commerce/storefront/dropins/checkout/tutorials/validate-shipping-address/

## Links to source code

<!--OPTIONAL Link to any associated source code PRs related to update-->
N/A

