### PR TITLE
fixed forward slash on sidebar link

### DIFF
--- a/astro.sidebar.mjs
+++ b/astro.sidebar.mjs
@@ -24,7 +24,7 @@ export function generateSidebar() {
           collapsed: false,
           items: [
             { label: 'Overview', link: '/get-started/' },
-            { label: 'Create a storefront', link: '/get-started/create-storefront' },
+            { label: 'Create a storefront', link: '/get-started/create-storefront/' },
             { label: 'Learn the architecture', link: '/get-started/architecture/' },
             { label: 'Browser compatibility', link: '/get-started/browser-compatibility/' },
             { label: 'Run Lighthouse audits', link: '/get-started/run-lighthouse/' },


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) fixes a forward slash issue on the create a storefront link in the sidebar. Some people encounter this error. 

### Associated JIRA ticket

Emergency fix.


### Staging preview
https://commerce-docs.github.io/microsite-commerce-storefront/get-started/
