### PR TITLE
USF-3617 Document custom placeholders for multiline form fields

### DIFF
--- a/src/content/docs/dropins/user-account/dictionary.mdx
+++ b/src/content/docs/dropins/user-account/dictionary.mdx
@@ -45,6 +45,50 @@ await initialize({
 
 You only need to include the keys you want to change. For multi-language support and advanced patterns, see the [Dictionary customization guide](/dropins/all/dictionaries/).
 
+## Customizing form field labels and placeholders
+
+Address form fields support custom labels and placeholders through the dictionary. This is particularly useful for multiline fields like street addresses, where you want to provide clear guidance for each line.
+
+The pattern for customizing form fields is:
+
+```
+Account.AddressForm.fields.{field_code}.label
+Account.AddressForm.fields.{field_code}.placeholder
+```
+
+Where `{field_code}` is the field's code (e.g., `street`, `street_multiline_2`, `city`, `postcode`).
+
+### Example: Customizing street address fields
+
+```javascript
+import { initialize } from '@dropins/storefront-account';
+
+await initialize({
+  langDefinitions: {
+    en_US: {
+      "Account": {
+        "AddressForm": {
+          "fields": {
+            "street": {
+              "label": "Street Address",
+              "placeholder": "Enter your street name"
+            },
+            "street_multiline_2": {
+              "label": "House/Flat Number",
+              "placeholder": "Enter your house or flat number"
+            }
+          }
+        }
+      }
+    }
+  }
+});
+```
+
+<Aside type="tip">
+For multiline fields like street address, each line is treated as a separate field with its own code. The first line uses the base field code (e.g., `street`), and subsequent lines append `_multiline_N` where N is the line number (e.g., `street_multiline_2` for the second line).
+</Aside>
+
 ## Default keys and values
 
 Below are the default English (`en_US`) strings provided by the **User Account** drop-in:
@@ -232,6 +276,16 @@ Below are the default English (`en_US`) strings provided by the **User Account**
         "defaultShippingLabel": "Set as default shipping address",
         "defaultBillingLabel": "Set as default billing address",
         "saveAddressBook": "Save in address book"
+      },
+      "fields": {
+        "street": {
+          "label": "Street Address",
+          "placeholder": "Enter your street address"
+        },
+        "street_multiline_2": {
+          "label": "House/Flat Number",
+          "placeholder": "Enter your house/flat number"
+        }
       }
     },
     "FormText": {

--- a/src/content/docs/dropins/user-account/dictionary.mdx
+++ b/src/content/docs/dropins/user-account/dictionary.mdx
@@ -86,7 +86,7 @@ await initialize({
 ```
 
 <Aside type="tip">
-For multiline fields like street address, each line is treated as a separate field with its own code. The first line uses the base field code (e.g., `street`), and subsequent lines append `_multiline_N` where N is the line number (e.g., `street_multiline_2` for the second line).
+For multiline fields like street address, each line has its own field code. The first line uses the base field code (for example, street), and subsequent lines append _multiline_N where N is the line number (for example, street_multiline_2 for the second line).
 </Aside>
 
 ## Default keys and values

--- a/src/content/docs/dropins/user-account/dictionary.mdx
+++ b/src/content/docs/dropins/user-account/dictionary.mdx
@@ -49,7 +49,7 @@ You only need to include the keys you want to change. For multi-language support
 
 Address form fields support custom labels and placeholders through the dictionary. This is particularly useful for multiline fields like street addresses, where you want to provide clear guidance for each line.
 
-The pattern for customizing form fields is:
+The pattern for customizing form fields:
 
 ```
 Account.AddressForm.fields.{field_code}.label

--- a/src/content/docs/dropins/user-account/dictionary.mdx
+++ b/src/content/docs/dropins/user-account/dictionary.mdx
@@ -47,7 +47,7 @@ You only need to include the keys you want to change. For multi-language support
 
 ## Customizing form field labels and placeholders
 
-Address form fields support custom labels and placeholders through the dictionary. This is particularly useful for multiline fields like street addresses, where you want to provide clear guidance for each line.
+Address form fields support custom labels and placeholders through the dictionary. Multiline fields like street addresses benefit from clear guidance for each line.
 
 The pattern for customizing form fields:
 


### PR DESCRIPTION
## Purpose of this pull request

Add documentation for customizing labels and placeholders in address form fields, particularly for multiline street address fields.

### Associated JIRA ticket

[USF-3617](https://jira.corp.adobe.com/browse/USF-3617)