### PR TITLE
Added Adobe-managed CDN information

### DIFF
--- a/src/content/docs/setup/configuration/content-delivery-network.mdx
+++ b/src/content/docs/setup/configuration/content-delivery-network.mdx
@@ -5,27 +5,33 @@ description: Learn how to configure a CDN for your Commerce Storefront powered b
 
 import Aside from '@components/Aside.astro';
 import Badge from '@components/overrides/Badge.astro';
+import Link from '@components/Link.astro';
+import TableWrapper from '@components/TableWrapper.astro';
 import { Tabs, TabItem, Steps } from '@astrojs/starlight/components';
 import Task from '@components/Task.astro';
 import Tasks from '@components/Tasks.astro';
 
-A CDN is a critical component of your Commerce Storefront. It is responsible for delivering content to your customers in the most efficient and secure way possible.
+A CDN is a critical component of your Commerce Storefront. It delivers content to your customers efficiently and securely. There are three CDN options for Commerce Storefronts: Fastly, Adobe-managed CDN, and BYO CDN.
 
-CDN features, usage, and provider details vary depending on your backend commerce implementation. By default, Adobe Commerce on Cloud projects use Fastly, while Adobe Commerce as a Cloud Service projects use an Adobe-managed CDN service.
+<TableWrapper nowrap={[0, 2]}>
 
-<Aside type="tip" title="Using Adobe-managed CDN?">
-If your project uses Adobe-managed CDN (not Fastly), see [Adobe Managed CDN](https://www.aem.live/docs/byo-cdn-adobe-managed) for setup instructions, including push invalidation configuration. The remaining sections on this page apply only to Fastly CDN.
-</Aside>
+| CDN option | Description | Setup guide |
+|------------|-------------|-------------|
+| **Fastly** | Default for Adobe Commerce on Cloud (PaaS) projects. Included with your Adobe Commerce license. | This page (see sections below) |
+| **Adobe-managed CDN** | Default for Adobe Commerce as a Cloud Service projects. | <Link href="https://www.aem.live/docs/byo-cdn-adobe-managed" text="Adobe Managed CDN setup" /> |
+| **BYO CDN** | Bring your own CDN from any supported vendor. | <Link href="https://www.aem.live/docs/byo-cdn-setup" text="BYO CDN setup" /> |
 
-If necessary, you can configure your own CDN, also known as "Bring Your Own CDN" (BYO CDN). See [BYO CDN Setup](https://www.aem.live/docs/byo-cdn-setup) for required settings and vendor-specific setup instructions.
+</TableWrapper>
 
 <Aside type="note" title="Image optimization">
 Drop-in components automatically add image optimization parameters (such as width, height, and quality) to image URLs. CDN-based image optimization services rely on these parameters to optimize images. If you need to use different parameters or URL patterns for your CDN provider, you can override the defaults by using the [`setImageParamKeys`](/sdk/reference/initializer/#setimageparamkeysparams) method in the initializer configuration.
 </Aside>
 
-<Badge tooltip="Applies to Adobe Commerce on Cloud projects (Adobe-managed PaaS infrastructure) and on-premises projects only." text="PaaS only" variant="note" href="https://experienceleague.adobe.com/en/docs/commerce/user-guides/product-solutions" /> For Adobe Commerce on Cloud projects, Fastly is included with your Adobe Commerce license and is the default CDN provider. The [`fastly-magento2`](https://github.com/fastly/fastly-magento2) module exposes Fastly service configurations in the Commerce Admin.
+## Fastly CDN for Adobe Commerce on Cloud
 
-The remaining sections on this page provide instructions and guidance for configuring Adobe Commerce on Cloud projects with the Fastly module. It focuses on routing use cases, configuration, validation, and debugging.
+<Badge tooltip="Applies to Adobe Commerce on Cloud projects (Adobe-managed PaaS infrastructure) and on-premises projects only." text="PaaS only" variant="note" href="https://experienceleague.adobe.com/en/docs/commerce/user-guides/product-solutions" />
+
+The remaining sections on this page provide instructions for configuring Adobe Commerce on Cloud projects with the Fastly module (<Link href="https://github.com/fastly/fastly-magento2" text="fastly-magento2" />). Topics include routing use cases, configuration, validation, and debugging.
 
 ## Routing
 

--- a/src/content/docs/setup/configuration/content-delivery-network.mdx
+++ b/src/content/docs/setup/configuration/content-delivery-network.mdx
@@ -13,6 +13,10 @@ A CDN is a critical component of your Commerce Storefront. It is responsible for
 
 CDN features, usage, and provider details vary depending on your backend commerce implementation. By default, Adobe Commerce on Cloud projects use Fastly, while Adobe Commerce as a Cloud Service projects use an Adobe-managed CDN service.
 
+<Aside type="tip" title="Using Adobe-managed CDN?">
+If your project uses Adobe-managed CDN (not Fastly), see [Adobe Managed CDN](https://www.aem.live/docs/byo-cdn-adobe-managed) for setup instructions, including push invalidation configuration. The remaining sections on this page apply only to Fastly CDN.
+</Aside>
+
 If necessary, you can configure your own CDN, also known as "Bring Your Own CDN" (BYO CDN). See [BYO CDN Setup](https://www.aem.live/docs/byo-cdn-setup) for required settings and vendor-specific setup instructions.
 
 <Aside type="note" title="Image optimization">

--- a/src/content/docs/setup/launch/index.mdx
+++ b/src/content/docs/setup/launch/index.mdx
@@ -76,7 +76,7 @@ As you develop, carefully track all changes made in development or staging envir
       environment. Update in Sharepoint in the `.helix/config.xlsx` file (`authToken` and
       `serviceId`).
 * [ ] Validate your [CDN configuration](/setup/configuration/content-delivery-network/) and ensure that caching
-      and cache invalidation work as expected.
+      and push invalidation work as expected.
 * [ ] For [multi-store setups](/setup/seo/indexing/#multi-store-setups), add a store-specific cache buster (for example, a query parameter or proxy through CDN configuration) to Catalog Service and Live Search requests.
 </Checklist>
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) adds and highlights the CDN configuration page, directing users to the correct documentation for Adobe-managed CDN. Previously, users on the Adobe-managed CDN (not Fastly) landed on this page and attempted to follow Fastly-specific instructions, which caused confusion about the push invalidation setup.

## Associated JIRA ticket

COMDOX-1473

## Affected pages

- https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/content-delivery-network/

## Links to source

- https://www.aem.live/docs/byo-cdn-adobe-managed (linked documentation for Adobe-managed CDN setup)