### PR TITLE
Adds clarification about required endpoints for various situations.

### DIFF
--- a/src/content/docs/boilerplate/configuration.mdx
+++ b/src/content/docs/boilerplate/configuration.mdx
@@ -28,7 +28,7 @@ The boilerplate uses multiple configuration files depending on your deployment s
 Which endpoints you set depends on your Commerce backend:
 
 - **Adobe Commerce as a Cloud Service (ACCS)** — Set only **`commerce-endpoint`** to your ACCS GraphQL endpoint URL.
-- **Adobe Commerce Optimizer (ACO)** — Set **`commerce-endpoint`** to your ACO GraphQL URL (catalog) and **`commerce-core-endpoint`** to your core endpoint URL (PaaS or your own Adobe Commerce hosted environment).
+- **Adobe Commerce Optimizer (ACO)** — Set **`commerce-endpoint`** to your ACO GraphQL URL (catalog) and **`commerce-core-endpoint`** to your Commerce core endpoint URL (PaaS or your own Adobe Commerce hosted environment).
 
 For full details and examples, see [Storefront configuration](/setup/configuration/commerce-configuration/).
 

--- a/src/content/docs/boilerplate/configuration.mdx
+++ b/src/content/docs/boilerplate/configuration.mdx
@@ -23,6 +23,15 @@ The boilerplate uses multiple configuration files depending on your deployment s
 - **Production deployment** - Configuration Service with template files for site setup
 - **Drop-in initialization** - Initializer files in `scripts/initializers/`
 
+## Endpoints by backend
+
+Which endpoints you set depends on your Commerce backend:
+
+- **Adobe Commerce as a Cloud Service (ACCS)** — Set only **`commerce-endpoint`** to your ACCS GraphQL endpoint URL.
+- **Adobe Commerce Optimizer (ACO)** — Set **`commerce-endpoint`** to your ACO GraphQL URL (catalog) and **`commerce-core-endpoint`** to your core endpoint URL (PaaS or your own Adobe Commerce hosted environment).
+
+For full details and examples, see [Storefront configuration](/setup/configuration/commerce-configuration/).
+
 ## Demo Configuration (Local Development)
 
 For local development, you can use the demo configuration for the boilerplate as a starting point. The live demo configuration is available at <Link href="https://main--aem-boilerplate-commerce--hlxsites.aem.live/config.json" text="https://main--aem-boilerplate-commerce--hlxsites.aem.live/config.json" /> and connects to the sample Commerce backend for the boilerplate:
@@ -125,7 +134,7 @@ Comprehensive site configuration template for production deployment:
   "public": {
     "default": {
       "commerce-core-endpoint": "{ENDPOINT}",
-      "commerce-endpoint": "{CS_ENDPOINT}",
+      "commerce-endpoint": "{CATALOG_ENDPOINT}",
       "headers": {
         "all": {
           "Store": "default"

--- a/src/content/docs/setup/configuration/commerce-configuration.mdx
+++ b/src/content/docs/setup/configuration/commerce-configuration.mdx
@@ -139,7 +139,7 @@ Adobe Commerce PaaS environments use standard Adobe Commerce header naming conve
 
 </TabItem>
 
-<TabItem label="Adobe Commerce as a Cloud Service (SaaS)">
+<TabItem label="Adobe Commerce as a Cloud Service (ACCS)">
 
 Adobe Commerce as a Cloud Service uses standard Adobe Commerce header naming conventions but does not require API keys or environment IDs in the default configuration.
 
@@ -520,7 +520,7 @@ This example shows the configuration for Adobe Commerce as a Cloud Service (ACCS
 
 <TabItem label="Adobe Commerce Optimizer (ACO)">
 
-This example shows the configuration for Adobe Commerce Optimizer (ACO), which uses different header naming conventions and includes Adobe Commerce Optimizer-specific settings. For ACO you must set **`commerce-endpoint`** (ACO GraphQL URL for catalog) at a minimum, and **`commerce-core-endpoint`** (your core endpoint—PaaS or your own Adobe Commerce hosted environment) if you want to use transactional or other core related functionality. You must also include `"adobe-commerce-optimizer": true`. This example is from https://main--boilerplate-aco--adobe-commerce.aem.live/ (no core endpoint).
+This example shows the configuration for Adobe Commerce Optimizer (ACO), which uses different header naming conventions and includes ACO-specific settings. For ACO, set commerce-endpoint (ACO GraphQL URL for catalog) at a minimum. Set commerce-core-endpoint (your core endpoint—PaaS or your own Adobe Commerce hosted environment) to enable transactional or other core-related functionality. Include "adobe-commerce-optimizer": true. This example is from https://main--boilerplate-aco--adobe-commerce.aem.live/ and does not include a core endpoint.
 
 ```json title="ACO config.json" showLineNumbers
 {

--- a/src/content/docs/setup/configuration/commerce-configuration.mdx
+++ b/src/content/docs/setup/configuration/commerce-configuration.mdx
@@ -472,15 +472,14 @@ This example shows the configuration for an Adobe Commerce PaaS environment, whi
 ```
 </TabItem>
 
-<TabItem label="Adobe Commerce as a Cloud Service (SaaS)">
+<TabItem label="Adobe Commerce as a Cloud Service (ACCS)">
 
-This example shows the configuration for Adobe Commerce as a Cloud Service, which uses standard Adobe Commerce header naming conventions. This configuration is used on this site: https://main--boilerplate-accs--adobe-commerce.aem.live/
+This example shows the configuration for Adobe Commerce as a Cloud Service (ACCS). For ACCS you only need to set **`commerce-endpoint`** to your ACCS GraphQL URL; the same endpoint is used for catalog and core. This configuration is used on this site: https://main--boilerplate-accs--adobe-commerce.aem.live/
 
 ```json title="ACCS config.json" showLineNumbers
 {
   "public": {
     "default": {
-      "commerce-core-endpoint": "https://na1-sandbox.api.commerce.adobe.com/LwndYQs37CvkUQk9WEmNkz/graphql",
       "commerce-endpoint": "https://na1-sandbox.api.commerce.adobe.com/LwndYQs37CvkUQk9WEmNkz/graphql",
       "headers": {
         "all": {
@@ -519,15 +518,15 @@ This example shows the configuration for Adobe Commerce as a Cloud Service, whic
 
 </TabItem>
 
-<TabItem label="Adobe Commerce Optimizer">
+<TabItem label="Adobe Commerce Optimizer (ACO)">
 
-This example shows the configuration for Adobe Commerce Optimizer, which uses different header naming conventions and includes Optimizer-specific settings. This configuration is used on this site: https://main--boilerplate-aco--adobe-commerce.aem.live/
+This example shows the configuration for Adobe Commerce Optimizer (ACO), which uses different header naming conventions and includes Adobe Commerce Optimizer-specific settings. For ACO you must set **`commerce-endpoint`** (ACO GraphQL URL for catalog) at a minimum, and **`commerce-core-endpoint`** (your core endpoint—PaaS or your own Adobe Commerce hosted environment) if you want to use transactional or other core related functionality. You must also include `"adobe-commerce-optimizer": true`. This example is from https://main--boilerplate-aco--adobe-commerce.aem.live/ (no core endpoint).
 
-```json title="Optimizer config.json" showLineNumbers
+```json title="ACO config.json" showLineNumbers
 {
   "public": {
     "default": {
-      "commerce-core-endpoint": "https://na1-sandbox.api.commerce.adobe.com/8idEEDDiVwjCEJAyB5kjfi/graphql",
+      "adobe-commerce-optimizer": true,
       "commerce-endpoint": "https://na1-sandbox.api.commerce.adobe.com/8idEEDDiVwjCEJAyB5kjfi/graphql",
       "headers": {
         "cs": {
@@ -596,9 +595,10 @@ To work with your own Commerce backend locally:
    - Copy the configuration to your clipboard and paste it into your `config.json` file in your code repo.
 
 2. **Edit config.json** with your Commerce backend values:
-   - Update `commerce-endpoint` and `commerce-core-endpoint` (if needed)
-   - Update `headers` for authentication
-   - Update `analytics` values for your store
+   - Update `commerce-endpoint` (required).
+   - Add/update `commerce-core-endpoint` if necessary.
+   - Update `headers`.
+   - Update `analytics` values for your store.
    - Update any other values as needed, such as `commerce-assets-enabled`, etc.
 
 3. **Add config.json to .gitignore** (optional):


### PR DESCRIPTION
Trying to clarify endpoint requirements. Technically, the boilerplate does the following:

At runtime, read `config.json` and use `commerce-endpoint` for **all** commerce api requests, or if defined, uses `commerce-core-endpoint` for JUST core requests, like for cart/auth/store_config/etc and `commerce-endpoint` for catalog requests.

Like so (pseudocode):

```
const catalogEndpoint = getConfigValue('commerce-endpoint);
const coreEndpoint = getConfigValue('commerce-core-endpoint || catalogEndpoint;

makeCoreQueries(coreEndpoint) // <-- either the commerce-core-endpoint or the catalogEndpoint (commerce-endpoint) fallback
makeCatalogQueries(catalogEndpoint) // <-- always the commerce-endpoint
```

I cleaned up the config section to be more explicit, but please double check copy changes as usual.