### PR TITLE
drop-in version updates

### DIFF
--- a/src/content/docs/boilerplate/blocks-reference.mdx
+++ b/src/content/docs/boilerplate/blocks-reference.mdx
@@ -12,7 +12,7 @@ import Link from '@components/Link.astro';
 This reference provides technical details for all 32 commerce blocks included in the boilerplate. Each block integrates one or more drop-in components to provide complete commerce functionality.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Boilerplate version: 4.0.1</strong>
+<strong>Boilerplate version: 6.0.0</strong>
 </div>
 
 ## Quick reference by functionality

--- a/src/content/docs/boilerplate/configuration.mdx
+++ b/src/content/docs/boilerplate/configuration.mdx
@@ -12,7 +12,7 @@ import Link from '@components/Link.astro';
 The AEM Commerce boilerplate requires configuration to connect to your Adobe Commerce instance and customize the storefront behavior.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Boilerplate version: 4.0.1</strong>
+<strong>Boilerplate version: 6.0.0</strong>
 </div>
 
 ## Configuration Overview

--- a/src/content/docs/boilerplate/customizing-blocks.mdx
+++ b/src/content/docs/boilerplate/customizing-blocks.mdx
@@ -13,7 +13,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 All Commerce blocks in the boilerplate work out of the box, but you can customize them to match your business requirements. This guide covers the main customization approaches.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Boilerplate version: 4.0.1</strong>
+<strong>Boilerplate version: 6.0.0</strong>
 </div>
 
 ## Three ways to customize

--- a/src/content/docs/boilerplate/getting-started.mdx
+++ b/src/content/docs/boilerplate/getting-started.mdx
@@ -15,7 +15,7 @@ import { Steps } from '@astrojs/starlight/components';
 This guide provides practical steps for creating, running, and customizing your Adobe Commerce storefront using the boilerplate.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Boilerplate version: 4.0.1</strong>
+<strong>Boilerplate version: 6.0.0</strong>
 </div>
 
 <Aside type="tip" title="Boilerplate Overview">

--- a/src/content/docs/boilerplate/index.mdx
+++ b/src/content/docs/boilerplate/index.mdx
@@ -14,7 +14,7 @@ Production-ready storefront starter that combines Edge Delivery Services with Co
 **Repository**: <Link href="https://github.com/hlxsites/aem-boilerplate-commerce" text="hlxsites/aem-boilerplate-commerce" />
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 4.0.1</strong>
+<strong>Version: 6.0.0</strong>
 </div>
 
 ## Technical documentation

--- a/src/content/docs/boilerplate/updates.mdx
+++ b/src/content/docs/boilerplate/updates.mdx
@@ -22,7 +22,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Upgrade your Adobe Commerce storefront to get the latest features, security updates, and performance improvements from the Commerce Boilerplate.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Boilerplate version: 4.0.1</strong>
+<strong>Boilerplate version: 6.0.0</strong>
 </div>
 
 ## Overview

--- a/src/content/docs/dropins-b2b/company-management/containers/accept-invitation.mdx
+++ b/src/content/docs/dropins-b2b/company-management/containers/accept-invitation.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Processes company invitation acceptance from email links and displays the result to the user.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/company-management/containers/company-credit.mdx
+++ b/src/content/docs/dropins-b2b/company-management/containers/company-credit.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Displays company credit information including credit limit, outstanding balance, and available credit for B2B customers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/company-management/containers/company-profile.mdx
+++ b/src/content/docs/dropins-b2b/company-management/containers/company-profile.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Manages company profile information including legal name, VAT/Tax ID, contact details, and `payment/shipping` configurations.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/company-management/containers/company-registration.mdx
+++ b/src/content/docs/dropins-b2b/company-management/containers/company-registration.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Provides a company registration form for new B2B customers to create a company account.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/company-management/containers/company-structure.mdx
+++ b/src/content/docs/dropins-b2b/company-management/containers/company-structure.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Displays and manages the company organizational hierarchy with teams and user assignments.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/company-management/containers/company-users.mdx
+++ b/src/content/docs/dropins-b2b/company-management/containers/company-users.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Manages company users including adding, editing, removing users, and controlling user status (Active/Inactive).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/company-management/containers/customer-company-info.mdx
+++ b/src/content/docs/dropins-b2b/company-management/containers/customer-company-info.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Displays basic company information for the currently authenticated customer.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/company-management/containers/index.mdx
+++ b/src/content/docs/dropins-b2b/company-management/containers/index.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Company Management** drop-in provides pre-built container components for integrating into your storefront.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## What are Containers?

--- a/src/content/docs/dropins-b2b/company-management/containers/roles-and-permissions.mdx
+++ b/src/content/docs/dropins-b2b/company-management/containers/roles-and-permissions.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Manages company roles and permission assignments for role-based access control.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/company-management/dictionary.mdx
+++ b/src/content/docs/dropins-b2b/company-management/dictionary.mdx
@@ -17,7 +17,7 @@ The **Company Management dictionary** contains all user-facing text, labels, and
 Dictionaries use the **i18n (internationalization)** pattern, where each text string is identified by a unique key path.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## How to customize

--- a/src/content/docs/dropins-b2b/company-management/events.mdx
+++ b/src/content/docs/dropins-b2b/company-management/events.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Company Management** drop-in uses the [event bus](/sdk/reference/events) to emit and listen to events for communication between drop-ins and external integrations.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Events reference

--- a/src/content/docs/dropins-b2b/company-management/functions.mdx
+++ b/src/content/docs/dropins-b2b/company-management/functions.mdx
@@ -16,7 +16,7 @@ import { Aside } from '@astrojs/starlight/components';
 The Company Management drop-in provides **26 API functions** for managing company structures, users, roles, permissions, and credit, enabling complete B2B company administration workflows.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins-b2b/company-management/initialization.mdx
+++ b/src/content/docs/dropins-b2b/company-management/initialization.mdx
@@ -12,7 +12,7 @@ import { Aside } from '@astrojs/starlight/components';
 The **Company Management initializer** configures the drop-in for managing company accounts, organizational structures, user roles, and permissions. Use initialization to customize how company data is displayed and enable internationalization for multi-language B2B storefronts.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 

--- a/src/content/docs/dropins-b2b/company-management/quick-start.mdx
+++ b/src/content/docs/dropins-b2b/company-management/quick-start.mdx
@@ -13,7 +13,7 @@ Get started with the Company Management drop-in to enable self-service company a
 
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 
@@ -53,7 +53,7 @@ export default async function decorate(block) {
 
 **Package:** `@dropins/storefront-company-management`
 
-**Version:** 1.0.0 (verify compatibility with your Commerce instance)
+**Version:** 1.1.0 (verify compatibility with your Commerce instance)
 
 **Example container:** `AcceptInvitation`
 

--- a/src/content/docs/dropins-b2b/company-management/slots.mdx
+++ b/src/content/docs/dropins-b2b/company-management/slots.mdx
@@ -15,7 +15,7 @@ import { Aside } from '@astrojs/starlight/components';
 The Company Management drop-in exposes slots for customizing specific UI sections. Use slots to replace or extend container components. For default properties available to all slots, see [Extending drop-in components](/dropins/all/extending/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins-b2b/company-management/styles.mdx
+++ b/src/content/docs/dropins-b2b/company-management/styles.mdx
@@ -8,7 +8,7 @@ import Link from '@components/Link.astro';
 Customize the Company Management drop-in using CSS classes and design tokens. This page covers the Company Management-specific container classes and customization examples. For comprehensive information about design tokens, responsive breakpoints, and styling best practices, see [Styling Drop-In Components](/dropins/all/styling/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Customization example

--- a/src/content/docs/dropins-b2b/company-switcher/containers/company-switcher.mdx
+++ b/src/content/docs/dropins-b2b/company-switcher/containers/company-switcher.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Allows users to switch between multiple companies they have access to using a dropdown selector.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/company-switcher/containers/index.mdx
+++ b/src/content/docs/dropins-b2b/company-switcher/containers/index.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Company Switcher** drop-in provides pre-built container components for integrating into your storefront.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## What are Containers?

--- a/src/content/docs/dropins-b2b/company-switcher/dictionary.mdx
+++ b/src/content/docs/dropins-b2b/company-switcher/dictionary.mdx
@@ -17,7 +17,7 @@ The **Company Switcher dictionary** contains all user-facing text, labels, and m
 Dictionaries use the **i18n (internationalization)** pattern, where each text string is identified by a unique key path.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## How to customize

--- a/src/content/docs/dropins-b2b/company-switcher/events.mdx
+++ b/src/content/docs/dropins-b2b/company-switcher/events.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Company Switcher** drop-in uses the [event bus](/sdk/reference/events) to emit and listen to events for communication between drop-ins and external integrations.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Events reference

--- a/src/content/docs/dropins-b2b/company-switcher/functions.mdx
+++ b/src/content/docs/dropins-b2b/company-switcher/functions.mdx
@@ -16,7 +16,7 @@ import { Aside } from '@astrojs/starlight/components';
 The Company Switcher drop-in provides  API functions for managing company context and headers in multi-company B2B scenarios.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins-b2b/company-switcher/initialization.mdx
+++ b/src/content/docs/dropins-b2b/company-switcher/initialization.mdx
@@ -12,7 +12,7 @@ import { Aside } from '@astrojs/starlight/components';
 The **Company Switcher initializer** configures the drop-in for managing multi-company contexts in B2B storefronts. Use initialization to customize company context management, header injection, session persistence, and GraphQL module integration.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 

--- a/src/content/docs/dropins-b2b/company-switcher/quick-start.mdx
+++ b/src/content/docs/dropins-b2b/company-switcher/quick-start.mdx
@@ -13,7 +13,7 @@ Get started with the Company Switcher drop-in to enable multi-company context sw
 
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 
@@ -53,7 +53,7 @@ export default async function decorate(block) {
 
 **Package:** `@dropins/storefront-company-switcher`
 
-**Version:** 1.0.0 (verify compatibility with your Commerce instance)
+**Version:** 1.1.0 (verify compatibility with your Commerce instance)
 
 **Example container:** `CompanySwitcher`
 

--- a/src/content/docs/dropins-b2b/company-switcher/slots.mdx
+++ b/src/content/docs/dropins-b2b/company-switcher/slots.mdx
@@ -19,7 +19,7 @@ The Company Switcher drop-in does not expose any slots for customization.
 This drop-in provides functionality through API methods and configuration options rather than UI customization points. Slots may be added in future versions as the feature set for the drop-in expands.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 

--- a/src/content/docs/dropins-b2b/company-switcher/styles.mdx
+++ b/src/content/docs/dropins-b2b/company-switcher/styles.mdx
@@ -8,7 +8,7 @@ import Link from '@components/Link.astro';
 Customize the Company Switcher drop-in using CSS classes and design tokens. This page covers the Company Switcher-specific container classes and customization examples. For comprehensive information about design tokens, responsive breakpoints, and styling best practices, see [Styling Drop-In Components](/dropins/all/styling/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Customization example

--- a/src/content/docs/dropins-b2b/purchase-order/containers/approval-rule-details.mdx
+++ b/src/content/docs/dropins-b2b/purchase-order/containers/approval-rule-details.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Displays detailed information for a specific purchase order approval rule including conditions and approvers.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/purchase-order/containers/approval-rule-form.mdx
+++ b/src/content/docs/dropins-b2b/purchase-order/containers/approval-rule-form.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Provides a form for creating or editing purchase order approval rules with validation and submission handling.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/purchase-order/containers/approval-rules-list.mdx
+++ b/src/content/docs/dropins-b2b/purchase-order/containers/approval-rules-list.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Displays a list of purchase order approval rules with options to create, edit, and view rule details.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/purchase-order/containers/company-purchase-orders.mdx
+++ b/src/content/docs/dropins-b2b/purchase-order/containers/company-purchase-orders.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Displays all purchase orders for the entire company with filtering, sorting, and pagination capabilities.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/purchase-order/containers/customer-purchase-orders.mdx
+++ b/src/content/docs/dropins-b2b/purchase-order/containers/customer-purchase-orders.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Displays purchase orders created by the currently authenticated customer with management controls.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/purchase-order/containers/index.mdx
+++ b/src/content/docs/dropins-b2b/purchase-order/containers/index.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Purchase Order** drop-in provides pre-built container components for integrating into your storefront.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## What are Containers?

--- a/src/content/docs/dropins-b2b/purchase-order/containers/purchase-order-approval-flow.mdx
+++ b/src/content/docs/dropins-b2b/purchase-order/containers/purchase-order-approval-flow.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Manages the approval workflow for a purchase order including approval actions and status updates.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/purchase-order/containers/purchase-order-comment-form.mdx
+++ b/src/content/docs/dropins-b2b/purchase-order/containers/purchase-order-comment-form.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Provides a form for adding comments to a purchase order with validation and submission handling.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/purchase-order/containers/purchase-order-comments-list.mdx
+++ b/src/content/docs/dropins-b2b/purchase-order/containers/purchase-order-comments-list.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Displays the list of comments associated with a purchase order in chronological order.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/purchase-order/containers/purchase-order-confirmation.mdx
+++ b/src/content/docs/dropins-b2b/purchase-order/containers/purchase-order-confirmation.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Displays confirmation details after a purchase order is successfully created or approved.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/purchase-order/containers/purchase-order-history-log.mdx
+++ b/src/content/docs/dropins-b2b/purchase-order/containers/purchase-order-history-log.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Displays the chronological history of actions and status changes for a purchase order.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/purchase-order/containers/purchase-order-status.mdx
+++ b/src/content/docs/dropins-b2b/purchase-order/containers/purchase-order-status.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Displays the current status and detailed information for a specific purchase order.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/purchase-order/containers/require-approval-purchase-orders.mdx
+++ b/src/content/docs/dropins-b2b/purchase-order/containers/require-approval-purchase-orders.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Displays purchase orders that require approval from the currently authenticated user.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/purchase-order/dictionary.mdx
+++ b/src/content/docs/dropins-b2b/purchase-order/dictionary.mdx
@@ -17,7 +17,7 @@ The **Purchase Order dictionary** contains all user-facing text, labels, and mes
 Dictionaries use the **i18n (internationalization)** pattern, where each text string is identified by a unique key path.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## How to customize

--- a/src/content/docs/dropins-b2b/purchase-order/events.mdx
+++ b/src/content/docs/dropins-b2b/purchase-order/events.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Purchase Order** drop-in uses the [event bus](/sdk/reference/events) to emit and listen to events for communication between drop-ins and external integrations.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Events reference

--- a/src/content/docs/dropins-b2b/purchase-order/functions.mdx
+++ b/src/content/docs/dropins-b2b/purchase-order/functions.mdx
@@ -16,7 +16,7 @@ import { Aside } from '@astrojs/starlight/components';
 The Purchase Order drop-in provides **12 API functions** for managing the complete purchase order workflow, including adding items to cart, approving, rejecting, canceling, and tracking purchase order status.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins-b2b/purchase-order/initialization.mdx
+++ b/src/content/docs/dropins-b2b/purchase-order/initialization.mdx
@@ -12,7 +12,7 @@ import { Aside } from '@astrojs/starlight/components';
 The **Purchase Order initializer** configures the drop-in for managing purchase order workflows, approval rules, and order tracking. Use initialization to set the purchase order reference, customize data models, and enable internationalization for multi-language B2B storefronts.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 

--- a/src/content/docs/dropins-b2b/purchase-order/quick-start.mdx
+++ b/src/content/docs/dropins-b2b/purchase-order/quick-start.mdx
@@ -13,7 +13,7 @@ Get started with the Purchase Order drop-in to enable purchase order approval wo
 
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 
@@ -53,7 +53,7 @@ export default async function decorate(block) {
 
 **Package:** `@dropins/storefront-purchase-order`
 
-**Version:** 1.0.0 (verify compatibility with your Commerce instance)
+**Version:** 1.1.0 (verify compatibility with your Commerce instance)
 
 **Example container:** `ApprovalRuleDetails`
 

--- a/src/content/docs/dropins-b2b/purchase-order/slots.mdx
+++ b/src/content/docs/dropins-b2b/purchase-order/slots.mdx
@@ -15,7 +15,7 @@ import { Aside } from '@astrojs/starlight/components';
 The Purchase Order drop-in exposes slots for customizing specific UI sections. Use slots to replace or extend container components. For default properties available to all slots, see [Extending drop-in components](/dropins/all/extending/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins-b2b/purchase-order/styles.mdx
+++ b/src/content/docs/dropins-b2b/purchase-order/styles.mdx
@@ -8,7 +8,7 @@ import Link from '@components/Link.astro';
 Customize the Purchase Order drop-in using CSS classes and design tokens. This page covers the Purchase Order-specific container classes and customization examples. For comprehensive information about design tokens, responsive breakpoints, and styling best practices, see [Styling Drop-In Components](/dropins/all/styling/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Customization example

--- a/src/content/docs/dropins-b2b/quote-management/containers/index.mdx
+++ b/src/content/docs/dropins-b2b/quote-management/containers/index.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Quote Management** drop-in provides pre-built container components for integrating into your storefront.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## What are Containers?

--- a/src/content/docs/dropins-b2b/quote-management/containers/items-quoted-template.mdx
+++ b/src/content/docs/dropins-b2b/quote-management/containers/items-quoted-template.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The `ItemsQuotedTemplate` container displays items stored in a quote template for reuse in future quote requests.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/quote-management/containers/items-quoted.mdx
+++ b/src/content/docs/dropins-b2b/quote-management/containers/items-quoted.mdx
@@ -13,7 +13,7 @@ The `ItemsQuoted` container displays a summary of items that have been quoted, p
 The component includes responsive design for mobile and desktop viewing.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/quote-management/containers/manage-negotiable-quote-template.mdx
+++ b/src/content/docs/dropins-b2b/quote-management/containers/manage-negotiable-quote-template.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The `ManageNegotiableQuoteTemplate` container provides the interface for managing quote templates with template-specific actions and details.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/quote-management/containers/manage-negotiable-quote.mdx
+++ b/src/content/docs/dropins-b2b/quote-management/containers/manage-negotiable-quote.mdx
@@ -13,7 +13,7 @@ The `ManageNegotiableQuote` container provides comprehensive quote management ca
 All actions respect permission-based access control.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/quote-management/containers/order-summary-line.mdx
+++ b/src/content/docs/dropins-b2b/quote-management/containers/order-summary-line.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The `OrderSummaryLine` container renders individual line items within the order summary such as subtotal, shipping, or tax rows.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/quote-management/containers/order-summary.mdx
+++ b/src/content/docs/dropins-b2b/quote-management/containers/order-summary.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The `OrderSummary` container displays a comprehensive pricing breakdown for quotes including subtotal calculations, applied discounts, tax information, and grand total. This component provides transparency in quote pricing.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/quote-management/containers/quote-comments-list.mdx
+++ b/src/content/docs/dropins-b2b/quote-management/containers/quote-comments-list.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The `QuoteCommentsList` container displays all comments and communications between buyer and seller for a negotiable quote.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/quote-management/containers/quote-history-log.mdx
+++ b/src/content/docs/dropins-b2b/quote-management/containers/quote-history-log.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The `QuoteHistoryLog` container shows the complete history of actions, status changes, and updates for a quote throughout its lifecycle.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/quote-management/containers/quote-summary-list.mdx
+++ b/src/content/docs/dropins-b2b/quote-management/containers/quote-summary-list.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The `QuoteSummaryList` container displays quote metadata including quote ID, status, dates, buyer information, and shipping details.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/quote-management/containers/quote-template-comments-list.mdx
+++ b/src/content/docs/dropins-b2b/quote-management/containers/quote-template-comments-list.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The `QuoteTemplateCommentsList` container displays all comments associated with a quote template.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/quote-management/containers/quote-template-history-log.mdx
+++ b/src/content/docs/dropins-b2b/quote-management/containers/quote-template-history-log.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The `QuoteTemplateHistoryLog` container shows the complete history of changes and updates for a quote template.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/quote-management/containers/quote-templates-list-table.mdx
+++ b/src/content/docs/dropins-b2b/quote-management/containers/quote-templates-list-table.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The `QuoteTemplatesListTable` container displays all quote templates in a paginated table with search, filter, and action capabilities.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/quote-management/containers/quotes-list-table.mdx
+++ b/src/content/docs/dropins-b2b/quote-management/containers/quotes-list-table.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The `QuotesListTable` container displays a list of quotes with pagination capabilities. It includes quote list display with status indicators, pagination controls, page size selection, item range display, and responsive table design.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/quote-management/containers/request-negotiable-quote-form.mdx
+++ b/src/content/docs/dropins-b2b/quote-management/containers/request-negotiable-quote-form.mdx
@@ -13,7 +13,7 @@ The `RequestNegotiableQuoteForm` container enables customers to request new nego
 It includes support for file attachments and integrates with cart contents.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/quote-management/containers/shipping-address-display.mdx
+++ b/src/content/docs/dropins-b2b/quote-management/containers/shipping-address-display.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The `ShippingAddressDisplay` container shows the selected shipping address for a quote or a warning if there is no shipping address set.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/quote-management/dictionary.mdx
+++ b/src/content/docs/dropins-b2b/quote-management/dictionary.mdx
@@ -17,7 +17,7 @@ The **Quote Management dictionary** contains all user-facing text, labels, and m
 Dictionaries use the **i18n (internationalization)** pattern, where each text string is identified by a unique key path.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## How to customize

--- a/src/content/docs/dropins-b2b/quote-management/events.mdx
+++ b/src/content/docs/dropins-b2b/quote-management/events.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Quote Management** drop-in uses the [event bus](/sdk/reference/events) to emit and listen to events for communication between drop-ins and external integrations.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Events reference

--- a/src/content/docs/dropins-b2b/quote-management/initialization.mdx
+++ b/src/content/docs/dropins-b2b/quote-management/initialization.mdx
@@ -12,7 +12,7 @@ import { Aside } from '@astrojs/starlight/components';
 The **Quote Management initializer** configures the drop-in for managing negotiable quotes, quote templates, and quote workflows. Use initialization to set quote identifiers, customize data models, and enable internationalization for multi-language B2B storefronts.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 

--- a/src/content/docs/dropins-b2b/quote-management/quick-start.mdx
+++ b/src/content/docs/dropins-b2b/quote-management/quick-start.mdx
@@ -13,7 +13,7 @@ Get started with the Quote Management drop-in to enable B2B quote negotiation an
 
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Quick example
@@ -95,7 +95,7 @@ export default async function decorate(block) {
 
 **Package:** `@dropins/storefront-quote-management`
 
-**Version:** 1.0.0 (verify compatibility with your Commerce instance)
+**Version:** 1.1.0 (verify compatibility with your Commerce instance)
 
 **Example container:** `ItemsQuoted`
 

--- a/src/content/docs/dropins-b2b/quote-management/slots.mdx
+++ b/src/content/docs/dropins-b2b/quote-management/slots.mdx
@@ -15,7 +15,7 @@ import { Aside } from '@astrojs/starlight/components';
 The Quote Management drop-in exposes slots for customizing specific UI sections. Use slots to replace or extend container components. For default properties available to all slots, see [Extending drop-in components](/dropins/all/extending/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 <TableWrapper nowrap={[0,1]}>

--- a/src/content/docs/dropins-b2b/quote-management/styles.mdx
+++ b/src/content/docs/dropins-b2b/quote-management/styles.mdx
@@ -8,7 +8,7 @@ import Link from '@components/Link.astro';
 Customize the Quote Management drop-in using CSS classes and design tokens. This page covers the Quote Management-specific container classes and customization examples. For comprehensive information about design tokens, responsive breakpoints, and styling best practices, see [Styling Drop-In Components](/dropins/all/styling/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Customization example

--- a/src/content/docs/dropins-b2b/requisition-list/containers/index.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/containers/index.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Requisition List** drop-in provides pre-built container components for integrating into your storefront.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## What are Containers?

--- a/src/content/docs/dropins-b2b/requisition-list/containers/requisition-list-form.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/containers/requisition-list-form.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Provides a form for creating or editing requisition list details including name and description.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/requisition-list/containers/requisition-list-grid.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/containers/requisition-list-grid.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Displays requisition lists in a grid layout with filtering, sorting, and selection capabilities.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/requisition-list/containers/requisition-list-header.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/containers/requisition-list-header.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Displays header information for a requisition list including name, description, and action buttons.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/requisition-list/containers/requisition-list-selector.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/containers/requisition-list-selector.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Provides a selector interface for choosing a requisition list when adding products from the catalog.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/requisition-list/containers/requisition-list-view.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/containers/requisition-list-view.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 Displays the contents of a specific requisition list including items, quantities, and management actions.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins-b2b/requisition-list/dictionary.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/dictionary.mdx
@@ -17,7 +17,7 @@ The **Requisition List dictionary** contains all user-facing text, labels, and m
 Dictionaries use the **i18n (internationalization)** pattern, where each text string is identified by a unique key path.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## How to customize

--- a/src/content/docs/dropins-b2b/requisition-list/events.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/events.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Requisition List** drop-in uses the [event bus](/sdk/reference/events) to emit and listen to events for communication between drop-ins and external integrations.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Events reference

--- a/src/content/docs/dropins-b2b/requisition-list/functions.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/functions.mdx
@@ -16,7 +16,7 @@ import { Aside } from '@astrojs/starlight/components';
 The Requisition List drop-in provides **11 API functions** for managing requisition lists and their items, including creating lists, adding/removing products, and managing list metadata.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins-b2b/requisition-list/initialization.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/initialization.mdx
@@ -12,7 +12,7 @@ import { Aside } from '@astrojs/starlight/components';
 The **Requisition List initializer** configures the drop-in for managing saved product lists and recurring orders. Use initialization to customize how requisition list data is displayed and enable internationalization for multi-language B2B storefronts.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 

--- a/src/content/docs/dropins-b2b/requisition-list/quick-start.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/quick-start.mdx
@@ -13,7 +13,7 @@ Get started with the Requisition List drop-in to enable reusable product lists f
 
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 
@@ -53,7 +53,7 @@ export default async function decorate(block) {
 
 **Package:** `@dropins/storefront-requisition-list`
 
-**Version:** 1.0.0 (verify compatibility with your Commerce instance)
+**Version:** 1.1.0 (verify compatibility with your Commerce instance)
 
 **Example container:** `RequisitionListForm`
 

--- a/src/content/docs/dropins-b2b/requisition-list/slots.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/slots.mdx
@@ -15,7 +15,7 @@ import { Aside } from '@astrojs/starlight/components';
 The Requisition List drop-in exposes slots for customizing specific UI sections. Use slots to replace or extend container components. For default properties available to all slots, see [Extending drop-in components](/dropins/all/extending/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins-b2b/requisition-list/styles.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/styles.mdx
@@ -11,7 +11,7 @@ import Link from '@components/Link.astro';
 Customize the Requisition List drop-in using CSS classes and design tokens. This page covers the Requisition List-specific container classes and customization examples. For comprehensive information about design tokens, responsive breakpoints, and styling best practices, see [Styling Drop-In Components](/dropins/all/styling/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.0.0</strong>
+<strong>Version: 1.1.0</strong>
 </div>
 
 ## Customization example

--- a/src/content/docs/dropins/cart/containers/index.mdx
+++ b/src/content/docs/dropins/cart/containers/index.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Cart** drop-in provides pre-built container components for integrating into your storefront.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta3</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## What are Containers?

--- a/src/content/docs/dropins/cart/dictionary.mdx
+++ b/src/content/docs/dropins/cart/dictionary.mdx
@@ -17,7 +17,7 @@ The **Cart dictionary** contains all user-facing text, labels, and messages disp
 Dictionaries use the **i18n (internationalization)** pattern, where each text string is identified by a unique key path.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta3</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## How to customize

--- a/src/content/docs/dropins/cart/events.mdx
+++ b/src/content/docs/dropins/cart/events.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Cart** drop-in uses the [event bus](/sdk/reference/events) to emit and listen to events for communication between drop-ins and external integrations.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta3</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## Events reference

--- a/src/content/docs/dropins/cart/functions.mdx
+++ b/src/content/docs/dropins/cart/functions.mdx
@@ -16,7 +16,7 @@ import { Aside } from '@astrojs/starlight/components';
 The Cart drop-in provides API functions that enable you to programmatically control behavior, fetch data, and integrate with Adobe Commerce backend services.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta3</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins/cart/initialization.mdx
+++ b/src/content/docs/dropins/cart/initialization.mdx
@@ -12,7 +12,7 @@ import { Aside } from '@astrojs/starlight/components';
 The **Cart initializer** configures how the cart manages shopping cart data, including items, pricing, discounts, and customer information. Use initialization to customize cart behavior, enable guest cart features, and transform cart data models to match your storefront requirements.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta3</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 

--- a/src/content/docs/dropins/cart/quick-start.mdx
+++ b/src/content/docs/dropins/cart/quick-start.mdx
@@ -13,7 +13,7 @@ The Cart drop-in is one of the most commonly used components in the Commerce boi
 
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta3</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 
@@ -53,7 +53,7 @@ export default async function decorate(block) {
 
 **Package:** `@dropins/storefront-cart`
 
-**Version:** 3.0.0-beta3 (verify compatibility with your Commerce instance)
+**Version:** 3.1.0 (verify compatibility with your Commerce instance)
 
 **Example container:** `CartSummaryGrid`
 

--- a/src/content/docs/dropins/cart/slots.mdx
+++ b/src/content/docs/dropins/cart/slots.mdx
@@ -15,7 +15,7 @@ import { Aside } from '@astrojs/starlight/components';
 The Cart drop-in exposes slots for customizing specific UI sections. Use slots to replace or extend container components. For default properties available to all slots, see [Extending drop-in components](/dropins/all/extending/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta3</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 <Aside type="tip" title="Slot usage best practice">

--- a/src/content/docs/dropins/cart/styles.mdx
+++ b/src/content/docs/dropins/cart/styles.mdx
@@ -8,7 +8,7 @@ import Link from '@components/Link.astro';
 Customize the Cart drop-in using CSS classes and design tokens. This page covers the Cart-specific container classes and customization examples. For comprehensive information about design tokens, responsive breakpoints, and styling best practices, see [Styling Drop-In Components](/dropins/all/styling/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta3</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## Customization example

--- a/src/content/docs/dropins/checkout/containers/index.mdx
+++ b/src/content/docs/dropins/checkout/containers/index.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Checkout** drop-in provides pre-built container components for integrating into your storefront.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta3</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## What are Containers?

--- a/src/content/docs/dropins/checkout/containers/payment-on-account.mdx
+++ b/src/content/docs/dropins/checkout/containers/payment-on-account.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta3</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins/checkout/containers/purchase-order.mdx
+++ b/src/content/docs/dropins/checkout/containers/purchase-order.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta3</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins/checkout/dictionary.mdx
+++ b/src/content/docs/dropins/checkout/dictionary.mdx
@@ -17,7 +17,7 @@ The **Checkout dictionary** contains all user-facing text, labels, and messages 
 Dictionaries use the **i18n (internationalization)** pattern, where each text string is identified by a unique key path.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta3</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## How to customize

--- a/src/content/docs/dropins/checkout/events.mdx
+++ b/src/content/docs/dropins/checkout/events.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Checkout** drop-in uses the [event bus](/sdk/reference/events) to emit and listen to events for communication between drop-ins and external integrations.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta3</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## Events reference

--- a/src/content/docs/dropins/checkout/functions.mdx
+++ b/src/content/docs/dropins/checkout/functions.mdx
@@ -16,7 +16,7 @@ import { Aside } from '@astrojs/starlight/components';
 The Checkout drop-in provides API functions that enable you to programmatically control behavior, fetch data, and integrate with Adobe Commerce backend services.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta3</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins/checkout/initialization.mdx
+++ b/src/content/docs/dropins/checkout/initialization.mdx
@@ -12,7 +12,7 @@ import { Aside } from '@astrojs/starlight/components';
 The **Checkout initializer** configures the checkout flow, payment processing, shipping options, and order placement. Use initialization to customize checkout behavior, integrate payment providers, and transform checkout data models to match your storefront requirements.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta3</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 

--- a/src/content/docs/dropins/checkout/quick-start.mdx
+++ b/src/content/docs/dropins/checkout/quick-start.mdx
@@ -13,7 +13,7 @@ The Checkout drop-in component provides a customizable UI for the checkout proce
 
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta3</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## Prerequisites
@@ -66,7 +66,7 @@ export default async function decorate(block) {
 
 **Package:** `@dropins/storefront-checkout`
 
-**Version:** 3.0.0-beta3 (verify compatibility with your Commerce instance)
+**Version:** 3.1.0 (verify compatibility with your Commerce instance)
 
 **Example container:** `AddressValidation`
 

--- a/src/content/docs/dropins/checkout/slots.mdx
+++ b/src/content/docs/dropins/checkout/slots.mdx
@@ -15,7 +15,7 @@ import { Aside } from '@astrojs/starlight/components';
 The Checkout drop-in exposes slots for customizing specific UI sections. Use slots to replace or extend container components. For default properties available to all slots, see [Extending drop-in components](/dropins/all/extending/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta3</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins/checkout/styles.mdx
+++ b/src/content/docs/dropins/checkout/styles.mdx
@@ -8,7 +8,7 @@ import Link from '@components/Link.astro';
 Customize the Checkout drop-in using CSS classes and design tokens. This page covers the Checkout-specific container classes and customization examples. For comprehensive information about design tokens, responsive breakpoints, and styling best practices, see [Styling Drop-In Components](/dropins/all/styling/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta3</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## Customization example

--- a/src/content/docs/dropins/order/containers/index.mdx
+++ b/src/content/docs/dropins/order/containers/index.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Order** drop-in provides pre-built container components for integrating into your storefront.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta2</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## What are Containers?

--- a/src/content/docs/dropins/order/containers/order-header.mdx
+++ b/src/content/docs/dropins/order/containers/order-header.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta2</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins/order/containers/order-status.mdx
+++ b/src/content/docs/dropins/order/containers/order-status.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta2</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins/order/dictionary.mdx
+++ b/src/content/docs/dropins/order/dictionary.mdx
@@ -17,7 +17,7 @@ The **Order dictionary** contains all user-facing text, labels, and messages dis
 Dictionaries use the **i18n (internationalization)** pattern, where each text string is identified by a unique key path.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta2</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## How to customize

--- a/src/content/docs/dropins/order/events.mdx
+++ b/src/content/docs/dropins/order/events.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Order** drop-in uses the [event bus](/sdk/reference/events) to emit and listen to events for communication between drop-ins and external integrations.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta2</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## Events reference

--- a/src/content/docs/dropins/order/functions.mdx
+++ b/src/content/docs/dropins/order/functions.mdx
@@ -16,7 +16,7 @@ import { Aside } from '@astrojs/starlight/components';
 The Order drop-in provides API functions that enable you to programmatically control behavior, fetch data, and integrate with Adobe Commerce backend services.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta2</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins/order/initialization.mdx
+++ b/src/content/docs/dropins/order/initialization.mdx
@@ -12,7 +12,7 @@ import { Aside } from '@astrojs/starlight/components';
 The **Order initializer** configures how order data is managed and displayed, including order history, status tracking, and order details. Use initialization to customize order data structures and integrate order management features.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta2</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 

--- a/src/content/docs/dropins/order/quick-start.mdx
+++ b/src/content/docs/dropins/order/quick-start.mdx
@@ -13,7 +13,7 @@ The Order drop-in provides a complete order management experience for customers.
 
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta2</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 
@@ -53,7 +53,7 @@ export default async function decorate(block) {
 
 **Package:** `@dropins/storefront-order`
 
-**Version:** 3.0.0-beta2 (verify compatibility with your Commerce instance)
+**Version:** 3.1.0 (verify compatibility with your Commerce instance)
 
 **Example container:** `CreateReturn`
 

--- a/src/content/docs/dropins/order/slots.mdx
+++ b/src/content/docs/dropins/order/slots.mdx
@@ -15,7 +15,7 @@ import { Aside } from '@astrojs/starlight/components';
 The Order drop-in exposes slots for customizing specific UI sections. Use slots to replace or extend container components. For default properties available to all slots, see [Extending drop-in components](/dropins/all/extending/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta2</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins/order/styles.mdx
+++ b/src/content/docs/dropins/order/styles.mdx
@@ -8,7 +8,7 @@ import Link from '@components/Link.astro';
 Customize the Order drop-in using CSS classes and design tokens. This page covers the Order-specific container classes and customization examples. For comprehensive information about design tokens, responsive breakpoints, and styling best practices, see [Styling Drop-In Components](/dropins/all/styling/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta2</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## Customization example

--- a/src/content/docs/dropins/payment-services/containers/apple-pay.mdx
+++ b/src/content/docs/dropins/payment-services/containers/apple-pay.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 2.0.0</strong>
+<strong>Version: 3.0.1</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins/payment-services/containers/credit-card.mdx
+++ b/src/content/docs/dropins/payment-services/containers/credit-card.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 ... See '`CardType`' from @`adobe-commerce/payment-services-sdk/payment`.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 2.0.0</strong>
+<strong>Version: 3.0.1</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins/payment-services/containers/index.mdx
+++ b/src/content/docs/dropins/payment-services/containers/index.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Payment Services** drop-in provides pre-built container components for integrating into your storefront.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 2.0.0</strong>
+<strong>Version: 3.0.1</strong>
 </div>
 
 ## What are Containers?

--- a/src/content/docs/dropins/payment-services/dictionary.mdx
+++ b/src/content/docs/dropins/payment-services/dictionary.mdx
@@ -17,7 +17,7 @@ The **Payment Services dictionary** contains all user-facing text, labels, and m
 Dictionaries use the **i18n (internationalization)** pattern, where each text string is identified by a unique key path.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 2.0.0</strong>
+<strong>Version: 3.0.1</strong>
 </div>
 
 ## How to customize

--- a/src/content/docs/dropins/payment-services/events.mdx
+++ b/src/content/docs/dropins/payment-services/events.mdx
@@ -11,5 +11,5 @@ import { Aside } from '@astrojs/starlight/components';
 This drop-in does not emit or listen to any drop-in-specific events.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 2.0.0</strong>
+<strong>Version: 3.0.1</strong>
 </div>

--- a/src/content/docs/dropins/payment-services/functions.mdx
+++ b/src/content/docs/dropins/payment-services/functions.mdx
@@ -42,7 +42,7 @@ import { Aside } from '@astrojs/starlight/components';
 This drop-in currently has no functions defined.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 2.0.0</strong>
+<strong>Version: 3.0.1</strong>
 </div>
 
 {/* AUTO-GENERATED CONTENT - Do not edit below this line */}

--- a/src/content/docs/dropins/payment-services/initialization.mdx
+++ b/src/content/docs/dropins/payment-services/initialization.mdx
@@ -12,7 +12,7 @@ import { Aside } from '@astrojs/starlight/components';
 The **Payment Services initializer** configures payment processing features including payment methods, payment providers, and transaction handling. Use initialization to integrate payment gateways and customize payment data models.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 2.0.0</strong>
+<strong>Version: 3.0.1</strong>
 </div>
 
 

--- a/src/content/docs/dropins/payment-services/slots.mdx
+++ b/src/content/docs/dropins/payment-services/slots.mdx
@@ -19,7 +19,7 @@ The Payment Services drop-in does not expose any slots for customization.
 This drop-in wraps the Adobe Payment Services SDK (`@adobe-commerce/payment-services-sdk`), which renders secure payment forms directly into specified DOM elements. The SDK controls all UI rendering to maintain PCI (Payment Card Industry) compliance and security standards. You customize the payment forms through SDK configuration options (field placeholders, card type settings, callback handlers) passed to `sdk.Payment.CreditCard.render()`, not through the slot-based pattern other drop-ins use.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 2.0.0</strong>
+<strong>Version: 3.0.1</strong>
 </div>
 
 

--- a/src/content/docs/dropins/payment-services/styles.mdx
+++ b/src/content/docs/dropins/payment-services/styles.mdx
@@ -8,7 +8,7 @@ import Link from '@components/Link.astro';
 Customize the Payment Services drop-in using CSS classes and design tokens. This page covers the Payment Services-specific container classes and customization examples. For comprehensive information about design tokens, responsive breakpoints, and styling best practices, see [Styling Drop-In Components](/dropins/all/styling/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 2.0.0</strong>
+<strong>Version: 3.0.1</strong>
 </div>
 
 ## Customization example

--- a/src/content/docs/dropins/personalization/containers/index.mdx
+++ b/src/content/docs/dropins/personalization/containers/index.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Personalization** drop-in provides pre-built container components for integrating into your storefront.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta1</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## What are Containers?

--- a/src/content/docs/dropins/personalization/dictionary.mdx
+++ b/src/content/docs/dropins/personalization/dictionary.mdx
@@ -17,7 +17,7 @@ The **Personalization dictionary** contains all user-facing text, labels, and me
 Dictionaries use the **i18n (internationalization)** pattern, where each text string is identified by a unique key path.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta1</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## How to customize

--- a/src/content/docs/dropins/personalization/events.mdx
+++ b/src/content/docs/dropins/personalization/events.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Personalization** drop-in uses the [event bus](/sdk/reference/events) to emit and listen to events for communication between drop-ins and external integrations.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta1</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## Events reference

--- a/src/content/docs/dropins/personalization/functions.mdx
+++ b/src/content/docs/dropins/personalization/functions.mdx
@@ -16,7 +16,7 @@ import { Aside } from '@astrojs/starlight/components';
 The Personalization drop-in provides API functions that enable you to programmatically control behavior, fetch data, and integrate with Adobe Commerce backend services.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta1</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins/personalization/initialization.mdx
+++ b/src/content/docs/dropins/personalization/initialization.mdx
@@ -12,7 +12,7 @@ import { Aside } from '@astrojs/starlight/components';
 The **Personalization initializer** configures personalization features including user preferences, behavioral tracking, and content customization. Use initialization to customize personalization data models and enhance user experience.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta1</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 

--- a/src/content/docs/dropins/personalization/quick-start.mdx
+++ b/src/content/docs/dropins/personalization/quick-start.mdx
@@ -13,7 +13,7 @@ The Personalization drop-in enables dynamic, AI-powered content recommendations 
 
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta1</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 
@@ -53,7 +53,7 @@ export default async function decorate(block) {
 
 **Package:** `@dropins/storefront-personalization`
 
-**Version:** 3.0.0-beta1 (verify compatibility with your Commerce instance)
+**Version:** 3.1.0 (verify compatibility with your Commerce instance)
 
 **Example container:** `TargetedBlock`
 

--- a/src/content/docs/dropins/personalization/slots.mdx
+++ b/src/content/docs/dropins/personalization/slots.mdx
@@ -15,7 +15,7 @@ import { Aside } from '@astrojs/starlight/components';
 The Personalization drop-in exposes slots for customizing specific UI sections. Use slots to replace or extend container components. For default properties available to all slots, see [Extending drop-in components](/dropins/all/extending/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta1</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins/personalization/styles.mdx
+++ b/src/content/docs/dropins/personalization/styles.mdx
@@ -8,7 +8,7 @@ import Link from '@components/Link.astro';
 Customize the Personalization drop-in using CSS classes and design tokens. This page covers the Personalization-specific container classes and customization examples. For comprehensive information about design tokens, responsive breakpoints, and styling best practices, see [Styling Drop-In Components](/dropins/all/styling/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta1</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## Customization example

--- a/src/content/docs/dropins/product-details/containers/index.mdx
+++ b/src/content/docs/dropins/product-details/containers/index.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Product Details** drop-in provides pre-built container components for integrating into your storefront.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.3.5</strong>
+<strong>Version: 3.0.1</strong>
 </div>
 
 ## What are Containers?

--- a/src/content/docs/dropins/product-details/containers/product-details.mdx
+++ b/src/content/docs/dropins/product-details/containers/product-details.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 ADOBE CONFIDENTIAL
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.3.5</strong>
+<strong>Version: 3.0.1</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins/product-details/containers/product-gift-card-options.mdx
+++ b/src/content/docs/dropins/product-details/containers/product-gift-card-options.mdx
@@ -11,7 +11,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.3.5</strong>
+<strong>Version: 3.0.1</strong>
 </div>
 
 ## Configuration

--- a/src/content/docs/dropins/product-details/dictionary.mdx
+++ b/src/content/docs/dropins/product-details/dictionary.mdx
@@ -17,7 +17,7 @@ The **Product Details dictionary** contains all user-facing text, labels, and me
 Dictionaries use the **i18n (internationalization)** pattern, where each text string is identified by a unique key path.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.3.5</strong>
+<strong>Version: 3.0.1</strong>
 </div>
 
 ## How to customize

--- a/src/content/docs/dropins/product-details/events.mdx
+++ b/src/content/docs/dropins/product-details/events.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Product Details** drop-in uses the [event bus](/sdk/reference/events) to emit and listen to events for communication between drop-ins and external integrations.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.3.5</strong>
+<strong>Version: 3.0.1</strong>
 </div>
 
 ## Events reference

--- a/src/content/docs/dropins/product-details/functions.mdx
+++ b/src/content/docs/dropins/product-details/functions.mdx
@@ -16,7 +16,7 @@ import { Aside } from '@astrojs/starlight/components';
 The Product Details drop-in provides API functions that enable you to programmatically control behavior, fetch data, and integrate with Adobe Commerce backend services.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.3.5</strong>
+<strong>Version: 3.0.1</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins/product-details/initialization.mdx
+++ b/src/content/docs/dropins/product-details/initialization.mdx
@@ -12,7 +12,7 @@ import { Aside } from '@astrojs/starlight/components';
 The **Product Details initializer** configures how product information is displayed and managed, including images, descriptions, pricing, and options. Use initialization to customize product data models and enhance product presentation.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.3.5</strong>
+<strong>Version: 3.0.1</strong>
 </div>
 
 

--- a/src/content/docs/dropins/product-details/quick-start.mdx
+++ b/src/content/docs/dropins/product-details/quick-start.mdx
@@ -13,7 +13,7 @@ The Product Details drop-in provides a comprehensive product display page with i
 
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.3.5</strong>
+<strong>Version: 3.0.1</strong>
 </div>
 
 
@@ -53,7 +53,7 @@ export default async function decorate(block) {
 
 **Package:** `@dropins/storefront-pdp`
 
-**Version:** 1.3.5 (verify compatibility with your Commerce instance)
+**Version:** 3.0.1 (verify compatibility with your Commerce instance)
 
 **Example container:** `ProductAttributes`
 

--- a/src/content/docs/dropins/product-details/slots.mdx
+++ b/src/content/docs/dropins/product-details/slots.mdx
@@ -15,7 +15,7 @@ import { Aside } from '@astrojs/starlight/components';
 The Product Details drop-in exposes slots for customizing specific UI sections. Use slots to replace or extend container components. For default properties available to all slots, see [Extending drop-in components](/dropins/all/extending/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.3.5</strong>
+<strong>Version: 3.0.1</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins/product-details/styles.mdx
+++ b/src/content/docs/dropins/product-details/styles.mdx
@@ -8,7 +8,7 @@ import Link from '@components/Link.astro';
 Customize the Product Details drop-in using CSS classes and design tokens. This page covers the Product Details-specific container classes and customization examples. For comprehensive information about design tokens, responsive breakpoints, and styling best practices, see [Styling Drop-In Components](/dropins/all/styling/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.3.5</strong>
+<strong>Version: 3.0.1</strong>
 </div>
 
 ## Customization example

--- a/src/content/docs/dropins/product-discovery/containers/facets.mdx
+++ b/src/content/docs/dropins/product-discovery/containers/facets.mdx
@@ -1,6 +1,6 @@
 ---
 title: Facets container
-description: Learn about the Facets container and configurations for the Product Discovery drop-in component v2.0.0.
+description: Learn about the Facets container and configurations for the Product Discovery drop-in component v3.0.0.
 ---
 
 import OptionsTable from '@components/OptionsTable.astro';

--- a/src/content/docs/dropins/product-discovery/containers/index.mdx
+++ b/src/content/docs/dropins/product-discovery/containers/index.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Product Discovery** drop-in provides pre-built container components for integrating into your storefront.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 2.1.0</strong>
+<strong>Version: 3.0.0</strong>
 </div>
 
 ## What are Containers?
@@ -25,10 +25,10 @@ Containers are pre-built UI components that combine functionality, state managem
 
 | Container | Description |
 | --------- | ----------- |
-| [Facets](/dropins/product-discovery/containers/facets/) | Learn about the Facets container and configurations for the Product Discovery drop-in component v2.0.0. |
-| [Pagination](/dropins/product-discovery/containers/pagination/) | Learn about the Pagination container and configurations for the Product Discovery drop-in component v2.0.0. |
-| [SearchResults](/dropins/product-discovery/containers/search-results/) | Learn about the `SearchResults` container and configurations for the Product Discovery drop-in component v2.0.0. |
-| [SortBy](/dropins/product-discovery/containers/sort-by/) | Learn about the `SortBy` container and configurations for the Product Discovery drop-in component v2.0.0. |
+| [Facets](/dropins/product-discovery/containers/facets/) | Learn about the Facets container and configurations for the Product Discovery drop-in component v3.0.0. |
+| [Pagination](/dropins/product-discovery/containers/pagination/) | Learn about the Pagination container and configurations for the Product Discovery drop-in component v3.0.0. |
+| [SearchResults](/dropins/product-discovery/containers/search-results/) | Learn about the `SearchResults` container and configurations for the Product Discovery drop-in component v3.0.0. |
+| [SortBy](/dropins/product-discovery/containers/sort-by/) | Learn about the `SortBy` container and configurations for the Product Discovery drop-in component v3.0.0. |
 
 
 </TableWrapper>

--- a/src/content/docs/dropins/product-discovery/containers/pagination.mdx
+++ b/src/content/docs/dropins/product-discovery/containers/pagination.mdx
@@ -1,6 +1,6 @@
 ---
 title: Pagination container
-description: Learn about the Pagination container and configurations for the Product Discovery drop-in component v2.0.0.
+description: Learn about the Pagination container and configurations for the Product Discovery drop-in component v3.0.0.
 ---
 
 import OptionsTable from '@components/OptionsTable.astro';

--- a/src/content/docs/dropins/product-discovery/containers/search-results.mdx
+++ b/src/content/docs/dropins/product-discovery/containers/search-results.mdx
@@ -1,6 +1,6 @@
 ---
 title: SearchResults container
-description: Learn about the SearchResults container and configurations for the Product Discovery drop-in component v2.0.0.
+description: Learn about the SearchResults container and configurations for the Product Discovery drop-in component v3.0.0.
 ---
 
 import OptionsTable from '@components/OptionsTable.astro';

--- a/src/content/docs/dropins/product-discovery/containers/sort-by.mdx
+++ b/src/content/docs/dropins/product-discovery/containers/sort-by.mdx
@@ -1,6 +1,6 @@
 ---
 title: SortBy container
-description: Learn about the SortBy container and configurations for the Product Discovery drop-in component v2.0.0.
+description: Learn about the SortBy container and configurations for the Product Discovery drop-in component v3.0.0.
 ---
 
 import OptionsTable from '@components/OptionsTable.astro';

--- a/src/content/docs/dropins/product-discovery/dictionary.mdx
+++ b/src/content/docs/dropins/product-discovery/dictionary.mdx
@@ -17,7 +17,7 @@ The **Product Discovery dictionary** contains all user-facing text, labels, and 
 Dictionaries use the **i18n (internationalization)** pattern, where each text string is identified by a unique key path.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 2.1.0</strong>
+<strong>Version: 3.0.0</strong>
 </div>
 
 ## How to customize

--- a/src/content/docs/dropins/product-discovery/events.mdx
+++ b/src/content/docs/dropins/product-discovery/events.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Product Discovery** drop-in uses the [event bus](/sdk/reference/events) to emit and listen to events for communication between drop-ins and external integrations.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 2.1.0</strong>
+<strong>Version: 3.0.0</strong>
 </div>
 
 ## Events reference

--- a/src/content/docs/dropins/product-discovery/functions.mdx
+++ b/src/content/docs/dropins/product-discovery/functions.mdx
@@ -16,7 +16,7 @@ import { Aside } from '@astrojs/starlight/components';
 The Product Discovery drop-in provides API functions that enable you to programmatically control behavior, fetch data, and integrate with Adobe Commerce backend services.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 2.1.0</strong>
+<strong>Version: 3.0.0</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins/product-discovery/initialization.mdx
+++ b/src/content/docs/dropins/product-discovery/initialization.mdx
@@ -12,7 +12,7 @@ import { Aside } from '@astrojs/starlight/components';
 The **Product Discovery initializer** configures search and filtering functionality, including faceted search, sorting, and product listing. Use initialization to customize search behavior and product discovery data models.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 2.1.0</strong>
+<strong>Version: 3.0.0</strong>
 </div>
 
 

--- a/src/content/docs/dropins/product-discovery/quick-start.mdx
+++ b/src/content/docs/dropins/product-discovery/quick-start.mdx
@@ -13,7 +13,7 @@ The Product Discovery drop-in powers search and category browsing with AI-enhanc
 
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 2.1.0</strong>
+<strong>Version: 3.0.0</strong>
 </div>
 
 
@@ -53,7 +53,7 @@ export default async function decorate(block) {
 
 **Package:** `@dropins/storefront-product-discovery`
 
-**Version:** 2.1.0 (verify compatibility with your Commerce instance)
+**Version:** 3.0.0 (verify compatibility with your Commerce instance)
 
 **Example container:** `Facets`
 

--- a/src/content/docs/dropins/product-discovery/slots.mdx
+++ b/src/content/docs/dropins/product-discovery/slots.mdx
@@ -15,7 +15,7 @@ import { Aside } from '@astrojs/starlight/components';
 The Product Discovery drop-in exposes slots for customizing specific UI sections. Use slots to replace or extend container components. For default properties available to all slots, see [Extending drop-in components](/dropins/all/extending/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 2.1.0</strong>
+<strong>Version: 3.0.0</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins/product-discovery/styles.mdx
+++ b/src/content/docs/dropins/product-discovery/styles.mdx
@@ -8,7 +8,7 @@ import Link from '@components/Link.astro';
 Customize the Product Discovery drop-in using CSS classes and design tokens. This page covers the Product Discovery-specific container classes and customization examples. For comprehensive information about design tokens, responsive breakpoints, and styling best practices, see [Styling Drop-In Components](/dropins/all/styling/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 2.1.0</strong>
+<strong>Version: 3.0.0</strong>
 </div>
 
 ## Customization example

--- a/src/content/docs/dropins/recommendations/containers/index.mdx
+++ b/src/content/docs/dropins/recommendations/containers/index.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Recommendations** drop-in provides pre-built container components for integrating into your storefront.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.1.1</strong>
+<strong>Version: 3.0.0</strong>
 </div>
 
 ## What are Containers?

--- a/src/content/docs/dropins/recommendations/dictionary.mdx
+++ b/src/content/docs/dropins/recommendations/dictionary.mdx
@@ -17,7 +17,7 @@ The **Recommendations dictionary** contains all user-facing text, labels, and me
 Dictionaries use the **i18n (internationalization)** pattern, where each text string is identified by a unique key path.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.1.1</strong>
+<strong>Version: 3.0.0</strong>
 </div>
 
 ## How to customize

--- a/src/content/docs/dropins/recommendations/events.mdx
+++ b/src/content/docs/dropins/recommendations/events.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Recommendations** drop-in uses the [event bus](/sdk/reference/events) to emit and listen to events for communication between drop-ins and external integrations.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.1.1</strong>
+<strong>Version: 3.0.0</strong>
 </div>
 
 ## Events reference

--- a/src/content/docs/dropins/recommendations/functions.mdx
+++ b/src/content/docs/dropins/recommendations/functions.mdx
@@ -16,7 +16,7 @@ import { Aside } from '@astrojs/starlight/components';
 The Recommendations drop-in provides API functions that enable you to programmatically control behavior, fetch data, and integrate with Adobe Commerce backend services.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.1.1</strong>
+<strong>Version: 3.0.0</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins/recommendations/initialization.mdx
+++ b/src/content/docs/dropins/recommendations/initialization.mdx
@@ -12,7 +12,7 @@ import { Aside } from '@astrojs/starlight/components';
 The **Recommendations initializer** configures product recommendation features including personalized suggestions, frequently bought together, and related products. Use initialization to customize recommendation algorithms and data models.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.1.1</strong>
+<strong>Version: 3.0.0</strong>
 </div>
 
 

--- a/src/content/docs/dropins/recommendations/quick-start.mdx
+++ b/src/content/docs/dropins/recommendations/quick-start.mdx
@@ -13,7 +13,7 @@ The Recommendations drop-in displays personalized product recommendations powere
 
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.1.1</strong>
+<strong>Version: 3.0.0</strong>
 </div>
 
 
@@ -53,7 +53,7 @@ export default async function decorate(block) {
 
 **Package:** `@dropins/storefront-recommendations`
 
-**Version:** 1.1.1 (verify compatibility with your Commerce instance)
+**Version:** 3.0.0 (verify compatibility with your Commerce instance)
 
 **Example container:** `ProductList`
 

--- a/src/content/docs/dropins/recommendations/slots.mdx
+++ b/src/content/docs/dropins/recommendations/slots.mdx
@@ -15,7 +15,7 @@ import { Aside } from '@astrojs/starlight/components';
 The Recommendations drop-in exposes slots for customizing specific UI sections. Use slots to replace or extend container components. For default properties available to all slots, see [Extending drop-in components](/dropins/all/extending/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.1.1</strong>
+<strong>Version: 3.0.0</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins/recommendations/styles.mdx
+++ b/src/content/docs/dropins/recommendations/styles.mdx
@@ -8,7 +8,7 @@ import Link from '@components/Link.astro';
 Customize the Recommendations drop-in using CSS classes and design tokens. This page covers the Recommendations-specific container classes and customization examples. For comprehensive information about design tokens, responsive breakpoints, and styling best practices, see [Styling Drop-In Components](/dropins/all/styling/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.1.1</strong>
+<strong>Version: 3.0.0</strong>
 </div>
 
 ## Customization example

--- a/src/content/docs/dropins/user-account/containers/index.mdx
+++ b/src/content/docs/dropins/user-account/containers/index.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **User Account** drop-in provides pre-built container components for integrating into your storefront.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta4</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## What are Containers?

--- a/src/content/docs/dropins/user-account/dictionary.mdx
+++ b/src/content/docs/dropins/user-account/dictionary.mdx
@@ -17,7 +17,7 @@ The **User Account dictionary** contains all user-facing text, labels, and messa
 Dictionaries use the **i18n (internationalization)** pattern, where each text string is identified by a unique key path.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta4</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## How to customize

--- a/src/content/docs/dropins/user-account/events.mdx
+++ b/src/content/docs/dropins/user-account/events.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **User Account** drop-in uses the [event bus](/sdk/reference/events) to emit and listen to events for communication between drop-ins and external integrations.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta4</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## Events reference

--- a/src/content/docs/dropins/user-account/functions.mdx
+++ b/src/content/docs/dropins/user-account/functions.mdx
@@ -16,7 +16,7 @@ import { Aside } from '@astrojs/starlight/components';
 The User Account drop-in provides API functions that enable you to programmatically control behavior, fetch data, and integrate with Adobe Commerce backend services.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta4</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins/user-account/initialization.mdx
+++ b/src/content/docs/dropins/user-account/initialization.mdx
@@ -12,7 +12,7 @@ import { Aside } from '@astrojs/starlight/components';
 The **User Account initializer** configures user account management features including profile editing, address management, and account settings. Use initialization to customize account data models and user interface behaviors.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta4</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 

--- a/src/content/docs/dropins/user-account/quick-start.mdx
+++ b/src/content/docs/dropins/user-account/quick-start.mdx
@@ -13,7 +13,7 @@ The User Account drop-in provides a complete customer account management experie
 
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta4</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 
@@ -53,7 +53,7 @@ export default async function decorate(block) {
 
 **Package:** `@dropins/storefront-account`
 
-**Version:** 3.0.0-beta4 (verify compatibility with your Commerce instance)
+**Version:** 3.1.0 (verify compatibility with your Commerce instance)
 
 **Example container:** `AddressForm`
 

--- a/src/content/docs/dropins/user-account/slots.mdx
+++ b/src/content/docs/dropins/user-account/slots.mdx
@@ -15,7 +15,7 @@ import { Aside } from '@astrojs/starlight/components';
 The User Account drop-in exposes slots for customizing specific UI sections. Use slots to replace or extend container components. For default properties available to all slots, see [Extending drop-in components](/dropins/all/extending/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta4</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins/user-account/styles.mdx
+++ b/src/content/docs/dropins/user-account/styles.mdx
@@ -8,7 +8,7 @@ import Link from '@components/Link.astro';
 Customize the User Account drop-in using CSS classes and design tokens. This page covers the User Account-specific container classes and customization examples. For comprehensive information about design tokens, responsive breakpoints, and styling best practices, see [Styling Drop-In Components](/dropins/all/styling/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta4</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## Customization example

--- a/src/content/docs/dropins/user-auth/containers/index.mdx
+++ b/src/content/docs/dropins/user-auth/containers/index.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **User Auth** drop-in provides pre-built container components for integrating into your storefront.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta2</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## What are Containers?

--- a/src/content/docs/dropins/user-auth/dictionary.mdx
+++ b/src/content/docs/dropins/user-auth/dictionary.mdx
@@ -17,7 +17,7 @@ The **User Auth dictionary** contains all user-facing text, labels, and messages
 Dictionaries use the **i18n (internationalization)** pattern, where each text string is identified by a unique key path.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta2</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## How to customize

--- a/src/content/docs/dropins/user-auth/events.mdx
+++ b/src/content/docs/dropins/user-auth/events.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **User Auth** drop-in uses the [event bus](/sdk/reference/events) to emit and listen to events for communication between drop-ins and external integrations.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta2</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## Events reference

--- a/src/content/docs/dropins/user-auth/functions.mdx
+++ b/src/content/docs/dropins/user-auth/functions.mdx
@@ -16,7 +16,7 @@ import { Aside } from '@astrojs/starlight/components';
 The User Auth drop-in provides API functions that enable you to programmatically control behavior, fetch data, and integrate with Adobe Commerce backend services.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta2</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins/user-auth/initialization.mdx
+++ b/src/content/docs/dropins/user-auth/initialization.mdx
@@ -12,7 +12,7 @@ import { Aside } from '@astrojs/starlight/components';
 The **User Auth initializer** configures authentication and authorization features including login, registration, password management, and session handling. Use initialization to customize authentication flows and user data models.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta2</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 

--- a/src/content/docs/dropins/user-auth/quick-start.mdx
+++ b/src/content/docs/dropins/user-auth/quick-start.mdx
@@ -13,7 +13,7 @@ The User Auth drop-in handles customer authentication flows including sign-in, a
 
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta2</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 
@@ -53,7 +53,7 @@ export default async function decorate(block) {
 
 **Package:** `@dropins/storefront-auth`
 
-**Version:** 3.0.0-beta2 (verify compatibility with your Commerce instance)
+**Version:** 3.1.0 (verify compatibility with your Commerce instance)
 
 **Example container:** `AuthCombine`
 

--- a/src/content/docs/dropins/user-auth/slots.mdx
+++ b/src/content/docs/dropins/user-auth/slots.mdx
@@ -15,7 +15,7 @@ import { Aside } from '@astrojs/starlight/components';
 The User Auth drop-in exposes slots for customizing specific UI sections. Use slots to replace or extend container components. For default properties available to all slots, see [Extending drop-in components](/dropins/all/extending/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta2</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 <Aside type="tip" title="Slot usage best practice">

--- a/src/content/docs/dropins/user-auth/styles.mdx
+++ b/src/content/docs/dropins/user-auth/styles.mdx
@@ -8,7 +8,7 @@ import Link from '@components/Link.astro';
 Customize the User Auth drop-in using CSS classes and design tokens. This page covers the User Auth-specific container classes and customization examples. For comprehensive information about design tokens, responsive breakpoints, and styling best practices, see [Styling Drop-In Components](/dropins/all/styling/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta2</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## Customization example

--- a/src/content/docs/dropins/wishlist/containers/index.mdx
+++ b/src/content/docs/dropins/wishlist/containers/index.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Wishlist** drop-in provides pre-built container components for integrating into your storefront.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta1</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## What are Containers?

--- a/src/content/docs/dropins/wishlist/dictionary.mdx
+++ b/src/content/docs/dropins/wishlist/dictionary.mdx
@@ -17,7 +17,7 @@ The **Wishlist dictionary** contains all user-facing text, labels, and messages 
 Dictionaries use the **i18n (internationalization)** pattern, where each text string is identified by a unique key path.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta1</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## How to customize

--- a/src/content/docs/dropins/wishlist/events.mdx
+++ b/src/content/docs/dropins/wishlist/events.mdx
@@ -12,7 +12,7 @@ import TableWrapper from '@components/TableWrapper.astro';
 The **Wishlist** drop-in uses the [event bus](/sdk/reference/events) to emit and listen to events for communication between drop-ins and external integrations.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta1</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## Events reference

--- a/src/content/docs/dropins/wishlist/functions.mdx
+++ b/src/content/docs/dropins/wishlist/functions.mdx
@@ -16,7 +16,7 @@ import { Aside } from '@astrojs/starlight/components';
 The Wishlist drop-in provides API functions that enable you to programmatically control behavior, fetch data, and integrate with Adobe Commerce backend services.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta1</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins/wishlist/initialization.mdx
+++ b/src/content/docs/dropins/wishlist/initialization.mdx
@@ -12,7 +12,7 @@ import { Aside } from '@astrojs/starlight/components';
 The **Wishlist initializer** configures wishlist functionality including saving items, sharing lists, and managing multiple wishlists. Use initialization to customize wishlist behavior and data models.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta1</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 

--- a/src/content/docs/dropins/wishlist/quick-start.mdx
+++ b/src/content/docs/dropins/wishlist/quick-start.mdx
@@ -13,7 +13,7 @@ The Wishlist drop-in enables customers to save products for later purchase, mana
 
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta1</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 
@@ -53,7 +53,7 @@ export default async function decorate(block) {
 
 **Package:** `@dropins/storefront-wishlist`
 
-**Version:** 3.0.0-beta1 (verify compatibility with your Commerce instance)
+**Version:** 3.1.0 (verify compatibility with your Commerce instance)
 
 **Example container:** `Wishlist`
 

--- a/src/content/docs/dropins/wishlist/slots.mdx
+++ b/src/content/docs/dropins/wishlist/slots.mdx
@@ -15,7 +15,7 @@ import { Aside } from '@astrojs/starlight/components';
 The Wishlist drop-in exposes slots for customizing specific UI sections. Use slots to replace or extend container components. For default properties available to all slots, see [Extending drop-in components](/dropins/all/extending/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta1</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>

--- a/src/content/docs/dropins/wishlist/styles.mdx
+++ b/src/content/docs/dropins/wishlist/styles.mdx
@@ -8,7 +8,7 @@ import Link from '@components/Link.astro';
 Customize the Wishlist drop-in using CSS classes and design tokens. This page covers the Wishlist-specific container classes and customization examples. For comprehensive information about design tokens, responsive breakpoints, and styling best practices, see [Styling Drop-In Components](/dropins/all/styling/).
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 3.0.0-beta1</strong>
+<strong>Version: 3.1.0</strong>
 </div>
 
 ## Customization example

--- a/src/content/docs/get-started/architecture.mdx
+++ b/src/content/docs/get-started/architecture.mdx
@@ -1,51 +1,127 @@
 ---
-title: Learn the Storefront architecture
+title: Storefront Architecture
 description: Learn how to plan, develop, and launch a headless Adobe Commerce storefront with Edge Delivery Services.
 ---
 
 import Aside from '@components/Aside.astro';
-import { CardGrid, Card, Tabs, TabItem } from '@astrojs/starlight/components';
-import Callouts from '@components/Callouts.astro';
 import Diagram from '@components/Diagram.astro';
-import Task from '@components/Task.astro';
-import Tasks from '@components/Tasks.astro';
+import Link from '@components/Link.astro';
+import { Steps } from '@astrojs/starlight/components';
 
-This overview guides you to the right resources for building headless Adobe Commerce storefronts with [Edge Delivery Services](https://www.aem.live/).
+This overview guides you to the right resources for building headless Adobe Commerce storefronts with Edge Delivery Services.
 
-## Big picture
+Headless Adobe Commerce storefronts on Edge Delivery Services use a **composable architecture** with domain-driven [drop-in components](/dropins/all/introduction/) that connect through APIs and integrate with the <Link href="https://github.com/hlxsites/aem-boilerplate-commerce" text="Commerce boilerplate" />. Drop-in components are reusable across projects, can be developed and deployed independently for faster cycles, and integrate out-of-the-box with Edge Delivery Services. Doc-based authoring enables business users to manage content without developer help.
 
-Headless Adobe Commerce storefronts on Edge Delivery Services are built using a composable architecture with domain-driven commerce components called [drop-in components](/dropins/all/introduction/). This architecture allows you to build and deploy a storefront that is composed of multiple Adobe services, each with its own responsibility. Drop-in components are connected through APIs and can be developed, tested, and deployed independently for faster development cycles.
+Content is authored in documents (DA.live, Google Docs, SharePoint), in-context (Universal Editor, Storefront Builder), or AEM Sites—and rendered as blocks. See the <Link href="https://www.aem.live/docs/authoring-guide" text="AEM authoring guide" /> for details.
 
-Drop-in components use [Adobe Commerce](https://experienceleague.adobe.com/en/docs/commerce/catalog-service/installation#access-the-service) APIs to provide data and functionality. These components are reusable across projects and integrate out-of-the-box with Edge Delivery Services through the [Commerce boilerplate](https://github.com/hlxsites/aem-boilerplate-commerce). Adobe Commerce storefronts on Edge Delivery Services support doc-based authoring, enabling business users to manage content without developer help.
+This page explains the architecture, then points you to [Backend options](/get-started/backends/) to identify your backend and confirm prerequisites.
 
-The following diagram illustrates the composable architecture of a headless Adobe Commerce storefront on Edge Delivery Services:
+## Architecture overview
 
-<Diagram caption="Composable architecture of a headless Adobe Commerce storefront on Edge Delivery Services.">
-  ![Composable architecture of a headless Adobe Commerce storefront on Edge Delivery
-  Services.](@images/implementation/Architecture.svg)
-</Diagram>
+<Diagram type="mermaid" code={`
+graph TB
+    EDS["<b>Edge Delivery Services</b><br/>Hosting & CDN"]
+    Blocks["<b>Blocks</b><br/>Author in DA.live"]
+    CommerceBlocks["<b>Commerce Blocks</b><br/>Author in DA.live"]
+    EDS --> Blocks
+    EDS --> CommerceBlocks
+    Blocks --> Boilerplate["<b>Commerce Boilerplate</b><br/>config.json + API clients"]
+    CommerceBlocks --> B2CGroup["<b>B2C Drop-ins</b><br/>Cart, Checkout, Account, and more"]
+    CommerceBlocks --> B2BGroup["<b>B2B Drop-ins</b><br/>Company, Quote, PO, and more"]
+    B2CGroup --> Boilerplate
+    B2BGroup --> Boilerplate
+    Boilerplate --> BackendChoice{Backend}
+    BackendChoice -->|"API Keys Required"| PaaS["<b>Commerce PaaS</b>"]
+    BackendChoice -->|"No API Keys"| CloudService["<b>Adobe Commerce as a Cloud Service</b>"]
+    BackendChoice -->|"Optimizer Headers"| Optimizer["<b>Adobe Commerce Optimizer</b>"]
+    subgraph Services["Commerce Services"]
+        CS["Catalog Service"]
+        LS["Live Search"]
+        PR["Product Recommendations"]
+        GraphQL["Core GraphQL"]
+    end
+    PaaS -.-> Services
+    CloudService -.-> Services
+    Optimizer -.-> Services
+    classDef storefront fill:#e8f5e9,stroke:#4caf50
+    classDef paas fill:#e3f2fd,stroke:#2196f3
+    classDef cloudService fill:#f3e5f5,stroke:#9c27b0
+    classDef optimizer fill:#fff3e0,stroke:#ff9800
+    class EDS,Blocks,CommerceBlocks,Boilerplate storefront
+    class PaaS paas
+    class CloudService cloudService
+    class Optimizer optimizer
+`} caption="Storefront architecture: blocks and drop-ins connect to the Commerce boilerplate, which routes to your backend (PaaS, Adobe Commerce as a Cloud Service, or Adobe Commerce Optimizer) and Commerce services." />
 
-:::note
-Although not represented in this diagram, [API Mesh for Adobe Developer App Builder](https://developer.adobe.com/graphql-mesh-gateway/) is an option for integrating multiple APIs into a single API endpoint. It can be used to aggregate data from multiple APIs and provide a single endpoint for the storefront to consume.
-:::
+The storefront is the front-end layer that renders the user interface and provides a seamless shopping experience. It is built from drop-in components and blocks connected to Adobe Commerce and other services through APIs and hosted on **Edge Delivery Services**—a cloud-based CDN that delivers content at the edge for low latency and high performance. The Commerce boilerplate provides an integrated set of drop-in components; see [Create your storefront](/get-started/create-storefront/) to get started.
 
-## Storefront
-
-The storefront is the front-end layer of your Adobe Commerce site. It is responsible for rendering the user interface and providing a seamless shopping experience for customers. The storefront is built using a combination of drop-in components and front-end blocks that are connected to Adobe Commerce and other services through APIs and hosted on Edge Delivery Services.
-
-The Commerce boilerplate provides an integrated set of drop-in components that you can use to build a headless Adobe Commerce storefront on Edge Delivery Services. See the [Quick Start overview](/get-started/) for more information.
-
-<Aside type="note" title="Already have an Adobe Commerce storefront?">
-  You can reuse parts of an existing storefront with an Edge Delivery Services storefront by
-  connecting them with [Luma Bridge](/setup/discovery/luma-bridge/).
+<Aside type="note" title="API Mesh">
+<Link href="https://developer.adobe.com/graphql-mesh-gateway/" text="API Mesh for Adobe Developer App Builder" /> can aggregate multiple APIs into a single GraphQL endpoint. Use it when you need to combine data from several sources for your storefront.
 </Aside>
+
+## How it works
+
+<Diagram type="mermaid" code={`
+graph LR
+    A["<b>Author</b><br/><small>Creates table in document</small>"]
+    B["<b>Edge Delivery Services</b><br/><small>Server-side transform</small>"]
+    C["<b>Browser</b><br/><small>Loads HTML</small>"]
+    D["<b>Block decorator</b><br/><small>Client-side JS</small>"]
+    E["<b>Drop-in</b><br/><small>Renders UI</small>"]
+    F["<b>Commerce API</b><br/><small>GraphQL data</small>"]
+    
+    A -->|"Document"| B
+    B -->|"HTML with divs"| C
+    C -->|"Runs scripts"| D
+    D -->|"Initialize"| E
+    E -->|"Fetch"| F
+    F -->|"Response"| E
+    
+    style A fill:#E3F2FD,stroke:#2196F3,stroke-width:2px
+    style B fill:#F3E5F5,stroke:#9C27B0,stroke-width:2px
+    style C fill:#FFF9C4,stroke:#FBC02D,stroke-width:2px
+    style D fill:#E8F5E9,stroke:#4CAF50,stroke-width:2px
+    style E fill:#FFE0B2,stroke:#FF9800,stroke-width:2px
+    style F fill:#FFCDD2,stroke:#F44336,stroke-width:2px
+`} caption="Flow from authoring to rendering: document table → HTML → block decoration → drop-in initialization → GraphQL fetch." />
+
+An author creates a table (for example, Commerce Cart) in a document or uses in-context editing. Edge Delivery Services transforms it to HTML (`<div class="commerce-cart">`). The browser loads the HTML, the block decorator initializes the drop-in, and the drop-in fetches from the Commerce API to render UI.
+
+<Steps>
+1. **Author** creates a cart page with a "Commerce Cart" table in their document.
+2. **Edge Delivery Services** transforms the document server-side into HTML with a `<div class="commerce-cart">` element.
+3. **Browser** loads the HTML page and client-side JavaScript decorates the blocks.
+4. **Block decorator** (`blocks/commerce-cart/commerce-cart.js`) dynamically loads and initializes the Cart drop-in.
+5. **Drop-in** connects to the Commerce backend via API and renders the cart UI.
+</Steps>
+
+<Aside type="tip" title="What you'll touch">
+Your storefront project has three moving parts: the **boilerplate** (config + blocks), **drop-in components** (commerce UI), and **Commerce services** (APIs). The sections below explain each one.
+</Aside>
+
+## Boilerplate and blocks
+
+**Blocks** are the fundamental parts of a page delivered by Edge Delivery Services. Each block encapsulates styling and code that drives a logical component. Code is managed in GitHub and deployed to Edge Delivery Services, where it is hosted and served to end users.
+
+- **Content blocks** — Provide content and layout for non-commerce pages (Cards, Columns, Headers, Footers, and more). See the <Link href="https://www.aem.live/developer/block-collection" text="Block Collection" /> for details.
+- **Commerce blocks** — Enable Adobe Commerce functionality (cart, checkout, account) and can become quite complex. They use the same authoring model as content blocks but dynamically render client-side UI based on configuration in the authored tables.
+
+The <Link href="https://github.com/hlxsites/aem-boilerplate-commerce" text="Commerce Boilerplate" /> has four layers that build on each other:
+
+- **scripts.js** — Foundation. Core AEM page loading, block decoration, font loading, and orchestration of eager, lazy, and delayed loading. Aligns with the upstream AEM Boilerplate.
+- **commerce.js** — Commerce engine. Backend connections, template handling, page type detection, Adobe Data Layer initialization, and commerce utilities.
+- **initializers** — Scripts that bootstrap drop-in components (account, cart, order, personalization, and more). Each wires its feature to the storefront.
+- **blocks** — Authored in DA.live, Google Docs, or Microsoft Word using tables. Rendered server-side as HTML and decorated client-side. Commerce blocks extend content blocks with drop-in components.
+
+Commerce blocks use Commerce APIs; the boilerplate uses <Link href="https://preactjs.com/" text="Preact" />/HTM for complex state. Use Preact/HTM only for blocks that need complex state management with different render states—otherwise use plain JavaScript. React is possible but not recommended; it is usually too heavy to achieve perfect Lighthouse scores. See [Getting started](/boilerplate/getting-started/) for file structure.
+
+#### Customize
+
+[Blocks reference](/boilerplate/blocks-reference/) · [Blocks configuration](/boilerplate/configuration/) · [Storefront configuration](/setup/configuration/commerce-configuration/)
 
 ## Drop-in components
 
-[Drop-in components](/dropins/all/introduction/) are domain-driven commerce components that provide specific functionality for your storefront. They are designed to be reusable and can be shared across multiple projects. Drop-in components are connected to Adobe Commerce and other services through APIs and can be developed, tested, and deployed independently for faster development cycles.
-
-You can find the integration patterns for drop-in components as pull requests in the [Commerce boilerplate repository](https://github.com/hlxsites/aem-boilerplate-commerce).
-The source code of drop-in components is private. You can add them to your project as NPM packages:
+[Drop-ins](/dropins/all/introduction/) are domain-driven commerce components that provide specific functionality for your storefront. They are reusable across projects, connect to Adobe Commerce and other services through APIs, and can be developed and deployed independently. Install from NPM:
 
 - `@dropins/storefront-account`
 - `@dropins/storefront-auth`
@@ -59,177 +135,111 @@ The source code of drop-in components is private. You can add them to your proje
 - `@dropins/storefront-personalization`
 - `@dropins/storefront-product-discovery`
 
-:::note
-Adobe recommends using the documented [extension](/dropins/all/extending/) patterns for drop-in components.
-:::
+Use the [extension](/dropins/all/extending/) patterns when customizing. Integration examples appear as pull requests in the Commerce boilerplate repository.
 
-## Front-end blocks
-
-Blocks are the fundamental parts of a page delivered by Edge Delivery Services. A block encapsulates styling and code that drives the logical components of pages.
-
-Edge Delivery Services comes with a comprehensive library of predefined "content" and "commerce" blocks, which can be customized to meet your project needs. Code for Edge Delivery Services projects is managed in GitHub. The code is then deployed to the Edge Delivery Services platform, where it is hosted and served to end users.
-
-### Content blocks
-
-The Edge Delivery Services components that provide the content and layout for non-commerce pages on the storefront. These include Cards, Columns, Headers, Footers, and many more. See [block collection](https://www.aem.live/developer/block-collection) for more information.
-
-### Commerce blocks
-
-Compared to content blocks, commerce blocks enable Adobe Commerce functionality (such as cart, checkout, and account) and can become quite complex. They are built using the same principles as content blocks but are more tightly integrated with Adobe Commerce APIs.
-
-Using a frontend framework can help manage the complexity. In the Commerce boilerplate, you can find examples of blocks that use a buildless version of [Preact](https://preactjs.com/) and [HTM](https://github.com/developit/htm). You should only use it for blocks that require complex state management with different render states. Otherwise, stick with plain JavaScript.
-
-Use the [existing blocks](/boilerplate/getting-started/) in the Commerce boilerplate as a reference (for example, teaser and product recommendations). If you want to use React, it's possible, but not recommended. React is usually too heavy (size + execution) to achieve perfect Lighthouse scores.
-
-## Runtime flow
-
-Understanding how content transforms into rendered commerce experiences helps developers know where to customize and integrate. The following diagram illustrates the complete flow from authoring to rendering:
+<Aside type="note" title="Existing storefront?">
+Reuse parts of an existing Luma storefront with an Edge Delivery Services storefront by connecting them with [Luma Bridge](/setup/discovery/luma-bridge/). Luma Bridge works without an Adobe Commerce Optimizer license or the Adobe Commerce Optimizer Connector. It is the session bridge between EDS and Luma/PHP pages.
+</Aside>
 
 <Diagram type="mermaid" code={`
+graph TB
+    subgraph S1["PaaS + Luma"]
+        A1["EDS"]
+        B1["Luma Bridge"]
+        C1["Luma"]
+        A1 <--> B1
+        B1 <--> C1
+    end
+    subgraph S2["PaaS + Luma + Adobe Commerce Optimizer"]
+        A2["EDS"]
+        B2["Luma Bridge"]
+        C2["Luma"]
+        D2["Adobe Commerce Optimizer Connector"]
+        A2 <--> B2
+        B2 <--> C2
+        A2 -.-> D2
+    end
+    subgraph S3["Adobe Commerce as a Cloud Service + Adobe Commerce Optimizer"]
+        A3["EDS"]
+        B3["Adobe Commerce Optimizer"]
+        C3["Adobe Commerce as a Cloud Service"]
+        A3 --> B3
+        A3 --> C3
+    end
+    classDef eds fill:#e8f5e9,stroke:#4caf50
+    classDef bridge fill:#fff3e0,stroke:#ff9800
+    classDef luma fill:#e3f2fd,stroke:#2196f3
+    classDef aco fill:#f3e5f5,stroke:#9c27b0
+    classDef accs fill:#f3e5f5,stroke:#9c27b0
+    class A1,A2,A3 eds
+    class B1,B2 bridge
+    class C1,C2 luma
+    class D2,B3 aco
+    class C3 accs
+`} caption="Luma Bridge scenarios: PaaS + Luma can use Luma Bridge without Adobe Commerce Optimizer. PaaS + Adobe Commerce Optimizer can also use Luma Bridge while migrating. Adobe Commerce as a Cloud Service + Adobe Commerce Optimizer has no Luma storefront, so Luma Bridge does not apply." />
+
+## Event system
+
+Drop-ins communicate through a shared event bus (`@dropins/tools/event-bus.js`) using a publish-subscribe pattern. This keeps components loosely coupled. No drop-in depends directly on another.
+
+<Diagram type="mermaid" code={`
+%%{init: {'theme':'base', 'themeVariables': { 'edgeLabelBackground':'#ffffff'}}}%%
 graph LR
-    A["Author<br/><small>Creates table</small>"]
-    B["Edge Delivery<br/><small>Server-side transform</small>"]
-    C["Browser<br/><small>Loads HTML</small>"]
-    D["Block Decorator<br/><small>Client-side JS</small>"]
-    E["Drop-in<br/><small>Renders UI</small>"]
-    F["Commerce API<br/><small>Data</small>"]
-    
-    A -->|"Document"| B
-    B -->|"HTML with divs"| C
-    C -->|"Decorates blocks"| D
-    D -->|"Initialize"| E
-    E -->|"Fetch"| F
-    F -->|"Response"| E
-    
-    style A fill:#E3F2FD,stroke:#2196F3,stroke-width:2px
-    style B fill:#F3E5F5,stroke:#9C27B0,stroke-width:2px
-    style C fill:#FFF9C4,stroke:#FBC02D,stroke-width:2px
-    style D fill:#E8F5E9,stroke:#4CAF50,stroke-width:2px
-    style E fill:#FFE0B2,stroke:#FF9800,stroke-width:2px
-    style F fill:#FFCDD2,stroke:#F44336,stroke-width:2px
-`} />
+    Auth(User Auth)
+    PDP(Product Details)
+    Cart(Cart)
+    Checkout(Checkout)
+    Order(Order)
+    Account(User Account)
+    EB(Event Bus)
+    YourCode(Your Code)
 
-The flow demonstrates how a simple table in a document becomes a fully functional commerce component:
+    Auth -->|"authenticated"| EB
+    PDP -->|"pdp/data"| EB
+    Cart -->|"cart/updated, cart/data"| EB
+    Checkout -->|"checkout/updated"| EB
+    Order -->|"order/placed, cart/reset"| EB
+    YourCode -->|"locale, authenticated"| EB
 
-1. **Author creates** a cart page with a "Commerce Cart" table in their document.
-2. **Edge Delivery Services** transforms the document server-side into HTML with a `<div class="commerce-cart">` element.
-3. **Browser loads** the HTML page and client-side JavaScript decorates the blocks.
-4. **Block decorator** (`blocks/commerce-cart/commerce-cart.js`) dynamically loads and initializes the Cart drop-in.
-5. **Drop-in** connects to Commerce backend via API and renders the cart UI.
+    EB -.->|"authenticated"| Cart
+    EB -.->|"authenticated"| Checkout
+    EB -.->|"cart/updated, cart/data"| Checkout
+    EB -.->|"cart/initialized"| Checkout
+    EB -.->|"order/placed"| Cart
+    EB -.->|"cart/updated"| Account
 
-## Adobe Commerce or Adobe Commerce as a Cloud Service
+    linkStyle 0,1,2,3,4,5 stroke:#3b82f6,stroke-width:2px
+    linkStyle 6,7,8,9,10,11 stroke:#6366f1,stroke-width:1.5px,stroke-dasharray:5
 
-Adobe Commerce or [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) is the backend system that powers your Commerce storefront. On Adobe Commerce, you must use version 2.4.7 or later with the storefront compatibility package installed.
+    style EB fill:#fef3c7,stroke:#f59e0b,stroke-width:3px
+    style Auth fill:#f3e8ff,stroke:#a855f7,stroke-width:2px
+    style PDP fill:#dbeafe,stroke:#3b82f6,stroke-width:2px
+    style Cart fill:#dbeafe,stroke:#3b82f6,stroke-width:2px
+    style Checkout fill:#e0e7ff,stroke:#6366f1,stroke-width:2px
+    style Order fill:#e0e7ff,stroke:#6366f1,stroke-width:2px
+    style Account fill:#f3e8ff,stroke:#a855f7,stroke-width:2px
+    style YourCode fill:#fce7f3,stroke:#ec4899,stroke-width:2px
+`} caption="Solid arrows: events emitted. Dashed arrows: events consumed. Your custom code (pink) can emit and listen to events alongside drop-ins." />
 
-Adobe Commerce as a Cloud Service is the recommended deployment option for Adobe Commerce. It provides a fully managed, scalable, and secure environment for running your Commerce storefront. All product requirements and services are automatically managed and updated by Adobe.
+- **`events.on(name, handler)`** — subscribe to an event
+- **`events.emit(name, payload)`** — publish an event
+- **`subscription.off()`** — unsubscribe
 
-Before starting the project, ensure that your Commerce backend meets the following requirements:
+Each drop-in indicates which events it emits and listens to. See the [event bus API reference](/sdk/reference/events/) and the [drop-in events overview](/dropins/all/events/) for details.
 
-- **Product license**: Adobe Commerce as a Cloud Service, Cloud, or on-premises (Magento Open Source is not supported)
-- **Version**: v2.4.7 or later
-- **PHP**: 8.3/8.2 for Adobe Commerce 2.4.7
-- **Storefront services**: Ensure that the latest version of following services are installed and configured:
-  - Data Connection service
-  - Services Connector
-  - Catalog Service
-  - Live Search
-  - Product Recommendations
+<Aside type="tip" title="Events vs. analytics">
+The event bus handles **internal** communication between drop-ins on the page. It is separate from [ACDL analytics events](/setup/analytics/instrumentation/), which send user behavior data to Adobe Commerce services (Live Search, Product Recommendations).
+</Aside>
 
-:::note
-The following links provide the requirements and installation procedures for your Adobe Commerce backend:
+## Commerce services
 
-- [System requirements for cloud infrastructure](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements)
-- [Setup for Commerce on cloud infrastructure](https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/overview)
-  :::
+Storefront services (Catalog Service, Live Search, Product Recommendations) are multi-tenant GraphQL APIs that provide read-only catalog data. They are fast, not tied to Commerce environment scaling, and stored in a SaaS data space via Adobe IMS. These services are required for high Lighthouse scores—only they provide the performance needed for a 100 Lighthouse score.
 
-## Storefront Compatibility package
+The **Storefront Compatibility package** extends the Adobe Commerce GraphQL schema with new mutations and fields needed for low-funnel drop-ins (cart, checkout, account, order). See [Backend options](/get-started/backends/) for setup by backend type.
 
-The [Storefront Compatibility package](/setup/configuration/storefront-compatibility/v248/) extends the GraphQL schema provided with Adobe Commerce. It provides new mutations and adds missing fields that are needed to implement low-funnel drop-in components, such as the cart, checkout, user account, and order drop-in components.
+## Backend options and next steps
 
-## Storefront services
+Storefront supports three backend types: **Commerce PaaS**, **Adobe Commerce as a Cloud Service**, and **Adobe Commerce Optimizer**. Prerequisites and setup differ by backend.
 
-When connecting your storefront drop-in components to your own instance of Adobe Commerce, you must ensure that your Commmerce backend is configured with the services described here. These services are required for Commerce drop-in components to function properly.
-
-:::note[Adobe Commerce Services Guides]
-For a complete list of merchandising services available for your Adobe Commerce storefront, refer to the [Adobe Commerce Services Guides](https://experienceleague.adobe.com/en/docs/commerce/user-guides/home). Direct links to the required services are provided below.
-:::
-
-Storefront services are a set of multi-tenant services (shared app, many users, separate data) that provide access to storefront data via GraphQL APIs. These services are very fast and are not tied to scaling constraints of a Commerce environment. They provide read-only access to catalog data, which can drive product detail and list pages, search, navigation, and product recommendations. [Synchronized data](https://experienceleague.adobe.com/en/docs/commerce/user-guides/integration-services/saas) is stored in a "SaaS data space" available through Adobe IMS.
-
-Availability and setup of these services are a hard requirement for building a storefront on Edge Delivery Services because only these APIs provide the performance to build sites with a 100 Lighthouse score. The storefront services APIs are available in addition to the core Adobe Commerce [GraphQL APIs](https://developer.adobe.com/commerce/webapi/graphql/).
-
-This page provides an overview of the services required for your Adobe Commerce storefront.
-
-<Tasks>
-
-<Task>
-
-### Data Connection service
-
-The Data Connection extension connects your Adobe Commerce storefront to the Adobe Experience Platform and the Edge Network so that you can enrich and personalize the shopping experience for your customers. Refer to the [Data Connection Guide](https://experienceleague.adobe.com/en/docs/commerce/data-connection/overview) for details and installation instructions.
-
-</Task>
-
-<Task>
-
-### Services Connector
-
-The Services Connector connects your Commerce storefront to the Commerce backend services listed below. Refer to the [Commerce Services Connector Guide](https://experienceleague.adobe.com/en/docs/commerce/user-guides/integration-services/saas) for details and installation instructions.
-
-</Task>
-
-<Task>
-### Catalog Service
-
-The Catalog Service module provides fast read-only access to Commerce catalog data. The product details drop-in component requires this service to render product data in the storefront. Refer to the [Catalog Service Guide](https://experienceleague.adobe.com/en/docs/commerce/catalog-service/guide-overview) for details and installation instructions.
-
-</Task>
-
-<Task>
-### Live Search
-
-The [Live Search](https://experienceleague.adobe.com/en/docs/commerce/live-search/overview) service replaces the default Commerce catalog search. This service powers the [Product Discovery](/dropins/product-discovery/) drop-in component, which provides a variety of customizable controls to showcase your products and build interactive experiences that engage customers.
-
-Live Search uses events to power search algorithms such as "Most Viewed" and "Viewed This, Viewed That". For headless implementations, learn how to [set up eventing](https://experienceleague.adobe.com/en/docs/commerce/live-search/events) for your storefront.
-
-:::caution[Multiple stores in a single Adobe Commerce environment]
-When using a single Adobe Commerce environment for multiple stores and only a single store should be migrated to Edge Delivery Services, you may need to contact Adobe Commerce Support to ensure that Live Search is activated without disabling Elasticsearch, which should continue to drive the search of the other stores.
-:::
-
-</Task>
-
-<Task>
-### Product Recommendations
-
-Product Recommendations uses artificial intelligence and machine-learning algorithms ([Adobe Sensei](https://business.adobe.com/products/sensei/adobe-sensei.html)) to create personalized storefront experiences. While not a strict requirement, we recommended it for Commerce storefronts. Refer to the [Product Recommendations setup](/merchants/blocks/product-recommendations/) for details.
-
-It provides data for product recommendations for the current shopper context and surfaces "units" such as "Customers who viewed this product also viewed" and can be placed in several areas of the site. You can configure the behavior of the service in Adobe Commerce Admin.
-
-Similar to Live Search, Product Recommendations uses events for collecting data to power recommendations. Learn how to [implement eventing](https://experienceleague.adobe.com/en/docs/commerce/product-recommendations/developer/events) for your storefront.
-
-</Task>
-</Tasks>
-
-## Edge Delivery Services
-
-Edge Delivery Services is a cloud-based content delivery network (CDN) that provides a scalable, secure, and high-performance platform for delivering your Adobe Commerce storefront to customers around the world. It is designed to deliver dynamic content at the edge, close to the end user, to reduce latency and improve performance.
-
-## Commerce Boilerplate Architecture
-
-The Commerce Boilerplate follows a modular architecture that separates core AEM functionality from commerce-specific features. This separation ensures maintainability and alignment with the upstream AEM Boilerplate while providing robust commerce capabilities.
-
-### From Core Scripts to Commerce Blocks
-
-The [Commerce Boilerplate](https://github.com/hlxsites/aem-boilerplate-commerce) is organized into four main layers that build on each other to deliver a modular, maintainable storefront architecture:
-
-1. **scripts.js** – The foundation. Handles core AEM page loading, block decoration, font loading, and orchestration of eager, lazy, and delayed loading. This file aligns closely with the upstream [AEM Boilerplate](https://github.com/adobe/aem-boilerplate) and is designed for global, site-wide functionality. It also supports extensibility for developers who want to introduce global DOM decorators, integrate third-party plugins such as experimentation tools, or run eager code on page load.
-
-2. **commerce.js** – The commerce engine. Contains all Commerce Boilerplate-specific logic and tooling, including backend connections, template handling, page type detection, Adobe Data Layer initialization, and commerce utilities. This layer centralizes all commerce features and keeps them distinct from core AEM logic.
-
-3. **Initializers** – A directory of scripts that initialize commerce drop-in components (such as account, cart, order, personalization, etc.). Each script is responsible for bootstrapping its respective feature, wiring it to the storefront, and ensuring it integrates with the rest of the application.
-
-4. **Blocks**
-   - **AEM Blocks**: Authored in **DA.live**, Google Docs, or Microsoft Word using tables. Rendered server-side as basic HTML `<divs>` and decorated client-side. Developers can enrich these blocks with semantic HTML, accessibility attributes, and dynamic DOM transformations.
-   - **Commerce Blocks**: Extend the AEM Blocks with Commerce drop-in components. They use the same authoring model but dynamically render the client-side UI based on the configuration provided in the authored tables.
-
-For a detailed breakdown of the file structure and where to find specific files, see the [Getting started](/boilerplate/getting-started/) page.
+1. [Backend options](/get-started/backends/) — Comparison table, prerequisites by backend
+2. [Storefront Setup](/get-started/create-storefront/) — Create your storefront and configure your backend

--- a/src/content/docs/get-started/architecture.mdx
+++ b/src/content/docs/get-started/architecture.mdx
@@ -1,127 +1,51 @@
 ---
-title: Storefront Architecture
+title: Learn the Storefront architecture
 description: Learn how to plan, develop, and launch a headless Adobe Commerce storefront with Edge Delivery Services.
 ---
 
 import Aside from '@components/Aside.astro';
+import { CardGrid, Card, Tabs, TabItem } from '@astrojs/starlight/components';
+import Callouts from '@components/Callouts.astro';
 import Diagram from '@components/Diagram.astro';
-import Link from '@components/Link.astro';
-import { Steps } from '@astrojs/starlight/components';
+import Task from '@components/Task.astro';
+import Tasks from '@components/Tasks.astro';
 
-This overview guides you to the right resources for building headless Adobe Commerce storefronts with Edge Delivery Services.
+This overview guides you to the right resources for building headless Adobe Commerce storefronts with [Edge Delivery Services](https://www.aem.live/).
 
-Headless Adobe Commerce storefronts on Edge Delivery Services use a **composable architecture** with domain-driven [drop-in components](/dropins/all/introduction/) that connect through APIs and integrate with the <Link href="https://github.com/hlxsites/aem-boilerplate-commerce" text="Commerce boilerplate" />. Drop-in components are reusable across projects, can be developed and deployed independently for faster cycles, and integrate out-of-the-box with Edge Delivery Services. Doc-based authoring enables business users to manage content without developer help.
+## Big picture
 
-Content is authored in documents (DA.live, Google Docs, SharePoint), in-context (Universal Editor, Storefront Builder), or AEM Sites—and rendered as blocks. See the <Link href="https://www.aem.live/docs/authoring-guide" text="AEM authoring guide" /> for details.
+Headless Adobe Commerce storefronts on Edge Delivery Services are built using a composable architecture with domain-driven commerce components called [drop-in components](/dropins/all/introduction/). This architecture allows you to build and deploy a storefront that is composed of multiple Adobe services, each with its own responsibility. Drop-in components are connected through APIs and can be developed, tested, and deployed independently for faster development cycles.
 
-This page explains the architecture, then points you to [Backend options](/get-started/backends/) to identify your backend and confirm prerequisites.
+Drop-in components use [Adobe Commerce](https://experienceleague.adobe.com/en/docs/commerce/catalog-service/installation#access-the-service) APIs to provide data and functionality. These components are reusable across projects and integrate out-of-the-box with Edge Delivery Services through the [Commerce boilerplate](https://github.com/hlxsites/aem-boilerplate-commerce). Adobe Commerce storefronts on Edge Delivery Services support doc-based authoring, enabling business users to manage content without developer help.
 
-## Architecture overview
+The following diagram illustrates the composable architecture of a headless Adobe Commerce storefront on Edge Delivery Services:
 
-<Diagram type="mermaid" code={`
-graph TB
-    EDS["<b>Edge Delivery Services</b><br/>Hosting & CDN"]
-    Blocks["<b>Blocks</b><br/>Author in DA.live"]
-    CommerceBlocks["<b>Commerce Blocks</b><br/>Author in DA.live"]
-    EDS --> Blocks
-    EDS --> CommerceBlocks
-    Blocks --> Boilerplate["<b>Commerce Boilerplate</b><br/>config.json + API clients"]
-    CommerceBlocks --> B2CGroup["<b>B2C Drop-ins</b><br/>Cart, Checkout, Account, and more"]
-    CommerceBlocks --> B2BGroup["<b>B2B Drop-ins</b><br/>Company, Quote, PO, and more"]
-    B2CGroup --> Boilerplate
-    B2BGroup --> Boilerplate
-    Boilerplate --> BackendChoice{Backend}
-    BackendChoice -->|"API Keys Required"| PaaS["<b>Commerce PaaS</b>"]
-    BackendChoice -->|"No API Keys"| CloudService["<b>Adobe Commerce as a Cloud Service</b>"]
-    BackendChoice -->|"Optimizer Headers"| Optimizer["<b>Adobe Commerce Optimizer</b>"]
-    subgraph Services["Commerce Services"]
-        CS["Catalog Service"]
-        LS["Live Search"]
-        PR["Product Recommendations"]
-        GraphQL["Core GraphQL"]
-    end
-    PaaS -.-> Services
-    CloudService -.-> Services
-    Optimizer -.-> Services
-    classDef storefront fill:#e8f5e9,stroke:#4caf50
-    classDef paas fill:#e3f2fd,stroke:#2196f3
-    classDef cloudService fill:#f3e5f5,stroke:#9c27b0
-    classDef optimizer fill:#fff3e0,stroke:#ff9800
-    class EDS,Blocks,CommerceBlocks,Boilerplate storefront
-    class PaaS paas
-    class CloudService cloudService
-    class Optimizer optimizer
-`} caption="Storefront architecture: blocks and drop-ins connect to the Commerce boilerplate, which routes to your backend (PaaS, Adobe Commerce as a Cloud Service, or Adobe Commerce Optimizer) and Commerce services." />
+<Diagram caption="Composable architecture of a headless Adobe Commerce storefront on Edge Delivery Services.">
+  ![Composable architecture of a headless Adobe Commerce storefront on Edge Delivery
+  Services.](@images/implementation/Architecture.svg)
+</Diagram>
 
-The storefront is the front-end layer that renders the user interface and provides a seamless shopping experience. It is built from drop-in components and blocks connected to Adobe Commerce and other services through APIs and hosted on **Edge Delivery Services**—a cloud-based CDN that delivers content at the edge for low latency and high performance. The Commerce boilerplate provides an integrated set of drop-in components; see [Create your storefront](/get-started/create-storefront/) to get started.
+:::note
+Although not represented in this diagram, [API Mesh for Adobe Developer App Builder](https://developer.adobe.com/graphql-mesh-gateway/) is an option for integrating multiple APIs into a single API endpoint. It can be used to aggregate data from multiple APIs and provide a single endpoint for the storefront to consume.
+:::
 
-<Aside type="note" title="API Mesh">
-<Link href="https://developer.adobe.com/graphql-mesh-gateway/" text="API Mesh for Adobe Developer App Builder" /> can aggregate multiple APIs into a single GraphQL endpoint. Use it when you need to combine data from several sources for your storefront.
+## Storefront
+
+The storefront is the front-end layer of your Adobe Commerce site. It is responsible for rendering the user interface and providing a seamless shopping experience for customers. The storefront is built using a combination of drop-in components and front-end blocks that are connected to Adobe Commerce and other services through APIs and hosted on Edge Delivery Services.
+
+The Commerce boilerplate provides an integrated set of drop-in components that you can use to build a headless Adobe Commerce storefront on Edge Delivery Services. See the [Quick Start overview](/get-started/) for more information.
+
+<Aside type="note" title="Already have an Adobe Commerce storefront?">
+  You can reuse parts of an existing storefront with an Edge Delivery Services storefront by
+  connecting them with [Luma Bridge](/setup/discovery/luma-bridge/).
 </Aside>
-
-## How it works
-
-<Diagram type="mermaid" code={`
-graph LR
-    A["<b>Author</b><br/><small>Creates table in document</small>"]
-    B["<b>Edge Delivery Services</b><br/><small>Server-side transform</small>"]
-    C["<b>Browser</b><br/><small>Loads HTML</small>"]
-    D["<b>Block decorator</b><br/><small>Client-side JS</small>"]
-    E["<b>Drop-in</b><br/><small>Renders UI</small>"]
-    F["<b>Commerce API</b><br/><small>GraphQL data</small>"]
-    
-    A -->|"Document"| B
-    B -->|"HTML with divs"| C
-    C -->|"Runs scripts"| D
-    D -->|"Initialize"| E
-    E -->|"Fetch"| F
-    F -->|"Response"| E
-    
-    style A fill:#E3F2FD,stroke:#2196F3,stroke-width:2px
-    style B fill:#F3E5F5,stroke:#9C27B0,stroke-width:2px
-    style C fill:#FFF9C4,stroke:#FBC02D,stroke-width:2px
-    style D fill:#E8F5E9,stroke:#4CAF50,stroke-width:2px
-    style E fill:#FFE0B2,stroke:#FF9800,stroke-width:2px
-    style F fill:#FFCDD2,stroke:#F44336,stroke-width:2px
-`} caption="Flow from authoring to rendering: document table → HTML → block decoration → drop-in initialization → GraphQL fetch." />
-
-An author creates a table (for example, Commerce Cart) in a document or uses in-context editing. Edge Delivery Services transforms it to HTML (`<div class="commerce-cart">`). The browser loads the HTML, the block decorator initializes the drop-in, and the drop-in fetches from the Commerce API to render UI.
-
-<Steps>
-1. **Author** creates a cart page with a "Commerce Cart" table in their document.
-2. **Edge Delivery Services** transforms the document server-side into HTML with a `<div class="commerce-cart">` element.
-3. **Browser** loads the HTML page and client-side JavaScript decorates the blocks.
-4. **Block decorator** (`blocks/commerce-cart/commerce-cart.js`) dynamically loads and initializes the Cart drop-in.
-5. **Drop-in** connects to the Commerce backend via API and renders the cart UI.
-</Steps>
-
-<Aside type="tip" title="What you'll touch">
-Your storefront project has three moving parts: the **boilerplate** (config + blocks), **drop-in components** (commerce UI), and **Commerce services** (APIs). The sections below explain each one.
-</Aside>
-
-## Boilerplate and blocks
-
-**Blocks** are the fundamental parts of a page delivered by Edge Delivery Services. Each block encapsulates styling and code that drives a logical component. Code is managed in GitHub and deployed to Edge Delivery Services, where it is hosted and served to end users.
-
-- **Content blocks** — Provide content and layout for non-commerce pages (Cards, Columns, Headers, Footers, and more). See the <Link href="https://www.aem.live/developer/block-collection" text="Block Collection" /> for details.
-- **Commerce blocks** — Enable Adobe Commerce functionality (cart, checkout, account) and can become quite complex. They use the same authoring model as content blocks but dynamically render client-side UI based on configuration in the authored tables.
-
-The <Link href="https://github.com/hlxsites/aem-boilerplate-commerce" text="Commerce Boilerplate" /> has four layers that build on each other:
-
-- **scripts.js** — Foundation. Core AEM page loading, block decoration, font loading, and orchestration of eager, lazy, and delayed loading. Aligns with the upstream AEM Boilerplate.
-- **commerce.js** — Commerce engine. Backend connections, template handling, page type detection, Adobe Data Layer initialization, and commerce utilities.
-- **initializers** — Scripts that bootstrap drop-in components (account, cart, order, personalization, and more). Each wires its feature to the storefront.
-- **blocks** — Authored in DA.live, Google Docs, or Microsoft Word using tables. Rendered server-side as HTML and decorated client-side. Commerce blocks extend content blocks with drop-in components.
-
-Commerce blocks use Commerce APIs; the boilerplate uses <Link href="https://preactjs.com/" text="Preact" />/HTM for complex state. Use Preact/HTM only for blocks that need complex state management with different render states—otherwise use plain JavaScript. React is possible but not recommended; it is usually too heavy to achieve perfect Lighthouse scores. See [Getting started](/boilerplate/getting-started/) for file structure.
-
-#### Customize
-
-[Blocks reference](/boilerplate/blocks-reference/) · [Blocks configuration](/boilerplate/configuration/) · [Storefront configuration](/setup/configuration/commerce-configuration/)
 
 ## Drop-in components
 
-[Drop-ins](/dropins/all/introduction/) are domain-driven commerce components that provide specific functionality for your storefront. They are reusable across projects, connect to Adobe Commerce and other services through APIs, and can be developed and deployed independently. Install from NPM:
+[Drop-in components](/dropins/all/introduction/) are domain-driven commerce components that provide specific functionality for your storefront. They are designed to be reusable and can be shared across multiple projects. Drop-in components are connected to Adobe Commerce and other services through APIs and can be developed, tested, and deployed independently for faster development cycles.
+
+You can find the integration patterns for drop-in components as pull requests in the [Commerce boilerplate repository](https://github.com/hlxsites/aem-boilerplate-commerce).
+The source code of drop-in components is private. You can add them to your project as NPM packages:
 
 - `@dropins/storefront-account`
 - `@dropins/storefront-auth`
@@ -135,111 +59,177 @@ Commerce blocks use Commerce APIs; the boilerplate uses <Link href="https://prea
 - `@dropins/storefront-personalization`
 - `@dropins/storefront-product-discovery`
 
-Use the [extension](/dropins/all/extending/) patterns when customizing. Integration examples appear as pull requests in the Commerce boilerplate repository.
+:::note
+Adobe recommends using the documented [extension](/dropins/all/extending/) patterns for drop-in components.
+:::
 
-<Aside type="note" title="Existing storefront?">
-Reuse parts of an existing Luma storefront with an Edge Delivery Services storefront by connecting them with [Luma Bridge](/setup/discovery/luma-bridge/). Luma Bridge works without an Adobe Commerce Optimizer license or the Adobe Commerce Optimizer Connector. It is the session bridge between EDS and Luma/PHP pages.
-</Aside>
+## Front-end blocks
 
-<Diagram type="mermaid" code={`
-graph TB
-    subgraph S1["PaaS + Luma"]
-        A1["EDS"]
-        B1["Luma Bridge"]
-        C1["Luma"]
-        A1 <--> B1
-        B1 <--> C1
-    end
-    subgraph S2["PaaS + Luma + Adobe Commerce Optimizer"]
-        A2["EDS"]
-        B2["Luma Bridge"]
-        C2["Luma"]
-        D2["Adobe Commerce Optimizer Connector"]
-        A2 <--> B2
-        B2 <--> C2
-        A2 -.-> D2
-    end
-    subgraph S3["Adobe Commerce as a Cloud Service + Adobe Commerce Optimizer"]
-        A3["EDS"]
-        B3["Adobe Commerce Optimizer"]
-        C3["Adobe Commerce as a Cloud Service"]
-        A3 --> B3
-        A3 --> C3
-    end
-    classDef eds fill:#e8f5e9,stroke:#4caf50
-    classDef bridge fill:#fff3e0,stroke:#ff9800
-    classDef luma fill:#e3f2fd,stroke:#2196f3
-    classDef aco fill:#f3e5f5,stroke:#9c27b0
-    classDef accs fill:#f3e5f5,stroke:#9c27b0
-    class A1,A2,A3 eds
-    class B1,B2 bridge
-    class C1,C2 luma
-    class D2,B3 aco
-    class C3 accs
-`} caption="Luma Bridge scenarios: PaaS + Luma can use Luma Bridge without Adobe Commerce Optimizer. PaaS + Adobe Commerce Optimizer can also use Luma Bridge while migrating. Adobe Commerce as a Cloud Service + Adobe Commerce Optimizer has no Luma storefront, so Luma Bridge does not apply." />
+Blocks are the fundamental parts of a page delivered by Edge Delivery Services. A block encapsulates styling and code that drives the logical components of pages.
 
-## Event system
+Edge Delivery Services comes with a comprehensive library of predefined "content" and "commerce" blocks, which can be customized to meet your project needs. Code for Edge Delivery Services projects is managed in GitHub. The code is then deployed to the Edge Delivery Services platform, where it is hosted and served to end users.
 
-Drop-ins communicate through a shared event bus (`@dropins/tools/event-bus.js`) using a publish-subscribe pattern. This keeps components loosely coupled. No drop-in depends directly on another.
+### Content blocks
+
+The Edge Delivery Services components that provide the content and layout for non-commerce pages on the storefront. These include Cards, Columns, Headers, Footers, and many more. See [block collection](https://www.aem.live/developer/block-collection) for more information.
+
+### Commerce blocks
+
+Compared to content blocks, commerce blocks enable Adobe Commerce functionality (such as cart, checkout, and account) and can become quite complex. They are built using the same principles as content blocks but are more tightly integrated with Adobe Commerce APIs.
+
+Using a frontend framework can help manage the complexity. In the Commerce boilerplate, you can find examples of blocks that use a buildless version of [Preact](https://preactjs.com/) and [HTM](https://github.com/developit/htm). You should only use it for blocks that require complex state management with different render states. Otherwise, stick with plain JavaScript.
+
+Use the [existing blocks](/boilerplate/getting-started/) in the Commerce boilerplate as a reference (for example, teaser and product recommendations). If you want to use React, it's possible, but not recommended. React is usually too heavy (size + execution) to achieve perfect Lighthouse scores.
+
+## Runtime flow
+
+Understanding how content transforms into rendered commerce experiences helps developers know where to customize and integrate. The following diagram illustrates the complete flow from authoring to rendering:
 
 <Diagram type="mermaid" code={`
-%%{init: {'theme':'base', 'themeVariables': { 'edgeLabelBackground':'#ffffff'}}}%%
 graph LR
-    Auth(User Auth)
-    PDP(Product Details)
-    Cart(Cart)
-    Checkout(Checkout)
-    Order(Order)
-    Account(User Account)
-    EB(Event Bus)
-    YourCode(Your Code)
+    A["Author<br/><small>Creates table</small>"]
+    B["Edge Delivery<br/><small>Server-side transform</small>"]
+    C["Browser<br/><small>Loads HTML</small>"]
+    D["Block Decorator<br/><small>Client-side JS</small>"]
+    E["Drop-in<br/><small>Renders UI</small>"]
+    F["Commerce API<br/><small>Data</small>"]
+    
+    A -->|"Document"| B
+    B -->|"HTML with divs"| C
+    C -->|"Decorates blocks"| D
+    D -->|"Initialize"| E
+    E -->|"Fetch"| F
+    F -->|"Response"| E
+    
+    style A fill:#E3F2FD,stroke:#2196F3,stroke-width:2px
+    style B fill:#F3E5F5,stroke:#9C27B0,stroke-width:2px
+    style C fill:#FFF9C4,stroke:#FBC02D,stroke-width:2px
+    style D fill:#E8F5E9,stroke:#4CAF50,stroke-width:2px
+    style E fill:#FFE0B2,stroke:#FF9800,stroke-width:2px
+    style F fill:#FFCDD2,stroke:#F44336,stroke-width:2px
+`} />
 
-    Auth -->|"authenticated"| EB
-    PDP -->|"pdp/data"| EB
-    Cart -->|"cart/updated, cart/data"| EB
-    Checkout -->|"checkout/updated"| EB
-    Order -->|"order/placed, cart/reset"| EB
-    YourCode -->|"locale, authenticated"| EB
+The flow demonstrates how a simple table in a document becomes a fully functional commerce component:
 
-    EB -.->|"authenticated"| Cart
-    EB -.->|"authenticated"| Checkout
-    EB -.->|"cart/updated, cart/data"| Checkout
-    EB -.->|"cart/initialized"| Checkout
-    EB -.->|"order/placed"| Cart
-    EB -.->|"cart/updated"| Account
+1. **Author creates** a cart page with a "Commerce Cart" table in their document.
+2. **Edge Delivery Services** transforms the document server-side into HTML with a `<div class="commerce-cart">` element.
+3. **Browser loads** the HTML page and client-side JavaScript decorates the blocks.
+4. **Block decorator** (`blocks/commerce-cart/commerce-cart.js`) dynamically loads and initializes the Cart drop-in.
+5. **Drop-in** connects to Commerce backend via API and renders the cart UI.
 
-    linkStyle 0,1,2,3,4,5 stroke:#3b82f6,stroke-width:2px
-    linkStyle 6,7,8,9,10,11 stroke:#6366f1,stroke-width:1.5px,stroke-dasharray:5
+## Adobe Commerce or Adobe Commerce as a Cloud Service
 
-    style EB fill:#fef3c7,stroke:#f59e0b,stroke-width:3px
-    style Auth fill:#f3e8ff,stroke:#a855f7,stroke-width:2px
-    style PDP fill:#dbeafe,stroke:#3b82f6,stroke-width:2px
-    style Cart fill:#dbeafe,stroke:#3b82f6,stroke-width:2px
-    style Checkout fill:#e0e7ff,stroke:#6366f1,stroke-width:2px
-    style Order fill:#e0e7ff,stroke:#6366f1,stroke-width:2px
-    style Account fill:#f3e8ff,stroke:#a855f7,stroke-width:2px
-    style YourCode fill:#fce7f3,stroke:#ec4899,stroke-width:2px
-`} caption="Solid arrows: events emitted. Dashed arrows: events consumed. Your custom code (pink) can emit and listen to events alongside drop-ins." />
+Adobe Commerce or [Adobe Commerce as a Cloud Service](https://experienceleague.adobe.com/en/docs/commerce/cloud-service/overview) is the backend system that powers your Commerce storefront. On Adobe Commerce, you must use version 2.4.7 or later with the storefront compatibility package installed.
 
-- **`events.on(name, handler)`** — subscribe to an event
-- **`events.emit(name, payload)`** — publish an event
-- **`subscription.off()`** — unsubscribe
+Adobe Commerce as a Cloud Service is the recommended deployment option for Adobe Commerce. It provides a fully managed, scalable, and secure environment for running your Commerce storefront. All product requirements and services are automatically managed and updated by Adobe.
 
-Each drop-in indicates which events it emits and listens to. See the [event bus API reference](/sdk/reference/events/) and the [drop-in events overview](/dropins/all/events/) for details.
+Before starting the project, ensure that your Commerce backend meets the following requirements:
 
-<Aside type="tip" title="Events vs. analytics">
-The event bus handles **internal** communication between drop-ins on the page. It is separate from [ACDL analytics events](/setup/analytics/instrumentation/), which send user behavior data to Adobe Commerce services (Live Search, Product Recommendations).
-</Aside>
+- **Product license**: Adobe Commerce as a Cloud Service, Cloud, or on-premises (Magento Open Source is not supported)
+- **Version**: v2.4.7 or later
+- **PHP**: 8.3/8.2 for Adobe Commerce 2.4.7
+- **Storefront services**: Ensure that the latest version of following services are installed and configured:
+  - Data Connection service
+  - Services Connector
+  - Catalog Service
+  - Live Search
+  - Product Recommendations
 
-## Commerce services
+:::note
+The following links provide the requirements and installation procedures for your Adobe Commerce backend:
 
-Storefront services (Catalog Service, Live Search, Product Recommendations) are multi-tenant GraphQL APIs that provide read-only catalog data. They are fast, not tied to Commerce environment scaling, and stored in a SaaS data space via Adobe IMS. These services are required for high Lighthouse scores—only they provide the performance needed for a 100 Lighthouse score.
+- [System requirements for cloud infrastructure](https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/system-requirements)
+- [Setup for Commerce on cloud infrastructure](https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/overview)
+  :::
 
-The **Storefront Compatibility package** extends the Adobe Commerce GraphQL schema with new mutations and fields needed for low-funnel drop-ins (cart, checkout, account, order). See [Backend options](/get-started/backends/) for setup by backend type.
+## Storefront Compatibility package
 
-## Backend options and next steps
+The [Storefront Compatibility package](/setup/configuration/storefront-compatibility/v248/) extends the GraphQL schema provided with Adobe Commerce. It provides new mutations and adds missing fields that are needed to implement low-funnel drop-in components, such as the cart, checkout, user account, and order drop-in components.
 
-Storefront supports three backend types: **Commerce PaaS**, **Adobe Commerce as a Cloud Service**, and **Adobe Commerce Optimizer**. Prerequisites and setup differ by backend.
+## Storefront services
 
-1. [Backend options](/get-started/backends/) — Comparison table, prerequisites by backend
-2. [Storefront Setup](/get-started/create-storefront/) — Create your storefront and configure your backend
+When connecting your storefront drop-in components to your own instance of Adobe Commerce, you must ensure that your Commmerce backend is configured with the services described here. These services are required for Commerce drop-in components to function properly.
+
+:::note[Adobe Commerce Services Guides]
+For a complete list of merchandising services available for your Adobe Commerce storefront, refer to the [Adobe Commerce Services Guides](https://experienceleague.adobe.com/en/docs/commerce/user-guides/home). Direct links to the required services are provided below.
+:::
+
+Storefront services are a set of multi-tenant services (shared app, many users, separate data) that provide access to storefront data via GraphQL APIs. These services are very fast and are not tied to scaling constraints of a Commerce environment. They provide read-only access to catalog data, which can drive product detail and list pages, search, navigation, and product recommendations. [Synchronized data](https://experienceleague.adobe.com/en/docs/commerce/user-guides/integration-services/saas) is stored in a "SaaS data space" available through Adobe IMS.
+
+Availability and setup of these services are a hard requirement for building a storefront on Edge Delivery Services because only these APIs provide the performance to build sites with a 100 Lighthouse score. The storefront services APIs are available in addition to the core Adobe Commerce [GraphQL APIs](https://developer.adobe.com/commerce/webapi/graphql/).
+
+This page provides an overview of the services required for your Adobe Commerce storefront.
+
+<Tasks>
+
+<Task>
+
+### Data Connection service
+
+The Data Connection extension connects your Adobe Commerce storefront to the Adobe Experience Platform and the Edge Network so that you can enrich and personalize the shopping experience for your customers. Refer to the [Data Connection Guide](https://experienceleague.adobe.com/en/docs/commerce/data-connection/overview) for details and installation instructions.
+
+</Task>
+
+<Task>
+
+### Services Connector
+
+The Services Connector connects your Commerce storefront to the Commerce backend services listed below. Refer to the [Commerce Services Connector Guide](https://experienceleague.adobe.com/en/docs/commerce/user-guides/integration-services/saas) for details and installation instructions.
+
+</Task>
+
+<Task>
+### Catalog Service
+
+The Catalog Service module provides fast read-only access to Commerce catalog data. The product details drop-in component requires this service to render product data in the storefront. Refer to the [Catalog Service Guide](https://experienceleague.adobe.com/en/docs/commerce/catalog-service/guide-overview) for details and installation instructions.
+
+</Task>
+
+<Task>
+### Live Search
+
+The [Live Search](https://experienceleague.adobe.com/en/docs/commerce/live-search/overview) service replaces the default Commerce catalog search. This service powers the [Product Discovery](/dropins/product-discovery/) drop-in component, which provides a variety of customizable controls to showcase your products and build interactive experiences that engage customers.
+
+Live Search uses events to power search algorithms such as "Most Viewed" and "Viewed This, Viewed That". For headless implementations, learn how to [set up eventing](https://experienceleague.adobe.com/en/docs/commerce/live-search/events) for your storefront.
+
+:::caution[Multiple stores in a single Adobe Commerce environment]
+When using a single Adobe Commerce environment for multiple stores and only a single store should be migrated to Edge Delivery Services, you may need to contact Adobe Commerce Support to ensure that Live Search is activated without disabling Elasticsearch, which should continue to drive the search of the other stores.
+:::
+
+</Task>
+
+<Task>
+### Product Recommendations
+
+Product Recommendations uses artificial intelligence and machine-learning algorithms ([Adobe Sensei](https://business.adobe.com/products/sensei/adobe-sensei.html)) to create personalized storefront experiences. While not a strict requirement, we recommended it for Commerce storefronts. Refer to the [Product Recommendations setup](/merchants/blocks/product-recommendations/) for details.
+
+It provides data for product recommendations for the current shopper context and surfaces "units" such as "Customers who viewed this product also viewed" and can be placed in several areas of the site. You can configure the behavior of the service in Adobe Commerce Admin.
+
+Similar to Live Search, Product Recommendations uses events for collecting data to power recommendations. Learn how to [implement eventing](https://experienceleague.adobe.com/en/docs/commerce/product-recommendations/developer/events) for your storefront.
+
+</Task>
+</Tasks>
+
+## Edge Delivery Services
+
+Edge Delivery Services is a cloud-based content delivery network (CDN) that provides a scalable, secure, and high-performance platform for delivering your Adobe Commerce storefront to customers around the world. It is designed to deliver dynamic content at the edge, close to the end user, to reduce latency and improve performance.
+
+## Commerce Boilerplate Architecture
+
+The Commerce Boilerplate follows a modular architecture that separates core AEM functionality from commerce-specific features. This separation ensures maintainability and alignment with the upstream AEM Boilerplate while providing robust commerce capabilities.
+
+### From Core Scripts to Commerce Blocks
+
+The [Commerce Boilerplate](https://github.com/hlxsites/aem-boilerplate-commerce) is organized into four main layers that build on each other to deliver a modular, maintainable storefront architecture:
+
+1. **scripts.js** – The foundation. Handles core AEM page loading, block decoration, font loading, and orchestration of eager, lazy, and delayed loading. This file aligns closely with the upstream [AEM Boilerplate](https://github.com/adobe/aem-boilerplate) and is designed for global, site-wide functionality. It also supports extensibility for developers who want to introduce global DOM decorators, integrate third-party plugins such as experimentation tools, or run eager code on page load.
+
+2. **commerce.js** – The commerce engine. Contains all Commerce Boilerplate-specific logic and tooling, including backend connections, template handling, page type detection, Adobe Data Layer initialization, and commerce utilities. This layer centralizes all commerce features and keeps them distinct from core AEM logic.
+
+3. **Initializers** – A directory of scripts that initialize commerce drop-in components (such as account, cart, order, personalization, etc.). Each script is responsible for bootstrapping its respective feature, wiring it to the storefront, and ensuring it integrates with the rest of the application.
+
+4. **Blocks**
+   - **AEM Blocks**: Authored in **DA.live**, Google Docs, or Microsoft Word using tables. Rendered server-side as basic HTML `<divs>` and decorated client-side. Developers can enrich these blocks with semantic HTML, accessibility attributes, and dynamic DOM transformations.
+   - **Commerce Blocks**: Extend the AEM Blocks with Commerce drop-in components. They use the same authoring model but dynamically render the client-side UI based on the configuration provided in the authored tables.
+
+For a detailed breakdown of the file structure and where to find specific files, see the [Getting started](/boilerplate/getting-started/) page.

--- a/src/content/docs/sdk/index.mdx
+++ b/src/content/docs/sdk/index.mdx
@@ -3,6 +3,10 @@ title: Introduction to the Drop-in SDK
 description: The Drop-in SDK is a set of tools and resources that help you build and customize your storefront.
 ---
 
+<div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
+<strong>Version: 1.7.0</strong> (`@dropins/tools`)
+</div>
+
 Welcome to the Drop-in SDK Documentation! This SDK provides the tools and resources to help you build and customize your storefront. Whether you're new to drop-in components or looking to optimize your store, this SDK should provide the resources you need. If it doesn't, please reach out to the Commerce team.
 
 ## Big picture


### PR DESCRIPTION
## Purpose of this pull request

This pull request updates version numbers across the Commerce Storefront documentation to align with the latest releases from the [Commerce boilerplate](https://github.com/hlxsites/aem-boilerplate-commerce) (main branch) and [B2B boilerplate](https://github.com/hlxsites/aem-boilerplate-commerce/tree/b2b) branch.

## Summary of changes

**Boilerplate & SDK**
- Boilerplate version: 4.0.1 → **6.0.0** (configuration, getting-started, blocks-reference, customizing-blocks, updates, index)
- Drop-in SDK (`@dropins/tools`): Added version banner **1.7.0** to SDK introduction page

**B2C drop-ins** (from boilerplate main branch)
- Cart, Checkout, Order, User Account, User Auth, Wishlist, Personalization: **3.1.0**
- Product Details (PDP): **3.0.1**
- Product Discovery, Recommendations: **3.0.0**
- Payment Services: **3.0.1**
- Product Discovery container descriptions: v2.0.0 → v3.0.0 (facets, pagination, search-results, sort-by)

**B2B drop-ins** (from boilerplate b2b branch)
- Company Management, Company Switcher, Purchase Order, Quote Management, Requisition List: **1.1.0**