### PR TITLE
USF-3704 Add ShippingMethodItem slot documentation

### DIFF
--- a/src/content/docs/dropins/checkout/containers/shipping-methods.mdx
+++ b/src/content/docs/dropins/checkout/containers/shipping-methods.mdx
@@ -24,7 +24,7 @@ The `ShippingMethods` container provides the following configuration options:
     ['autoSync', 'boolean', 'No', 'Synchronizes/does not synchronize the container local state with the backend (default value is true).'],
     ['onCartSyncError', 'function', 'No', 'A function that takes a ShippingMethod object and an error as arguments. It is called when the setShippingMethodsOnCart() API throws an error when a shipping method is selected to be stored to the backend.'],
     ['onSelectionChange', 'function', 'No', 'A function that takes a ShippingMethod object as an argument. It is called when a shipping method is selected.'],
-    ['slots (*)', 'object', 'No', 'Object with the title to be displayed on the ShippingMethods container.'],
+    ['slots (*)', 'object', 'No', 'Object with the title to be displayed on the ShippingMethods container and optional ShippingMethodItem slot for custom UI. See [ShippingMethods slots](/dropins/checkout/slots/#shippingmethods-slots).'],
     ['UIComponentType', 'string', 'No', 'String with the UI component type to be used as selector (default value is \'RadioButton\').'],
   ]}
 />
@@ -49,6 +49,9 @@ export interface ShippingMethodsProps extends HTMLAttributes<HTMLDivElement>, Ti
   onCartSyncError?: (error: CartSyncError) => void;
   onSelectionChange?: (method: ShippingMethod) => void;
   UIComponentType?: UIComponentType;
+  slots?: {
+    ShippingMethodItem?: SlotProps<ShippingMethodItemContext>;
+  } & TitleProps['slots'];
 }
 ```
 
@@ -60,6 +63,7 @@ export interface ShippingMethodsProps extends HTMLAttributes<HTMLDivElement>, Ti
 - The `UIComponentType` property is a string containing the name of the UI component type to be used as a selector for each shipping method. The available UI components are: `ToggleButton` or `RadioButton`.
 - The `slots (*)` property is inherited from the `TitleProps` interface. It is an object that contains the following properties:
   - Use the `Title (*)` property to render a custom title. This property is inherited from `TitleProps` interface.
+  - Use the `ShippingMethodItem` property to fully replace the default UI for each shipping method. See [ShippingMethods slots](/dropins/checkout/slots/#shippingmethods-slots) for details and examples.
 
 ## Example
 

--- a/src/content/docs/dropins/checkout/containers/shipping-methods.mdx
+++ b/src/content/docs/dropins/checkout/containers/shipping-methods.mdx
@@ -24,7 +24,7 @@ The `ShippingMethods` container provides the following configuration options:
     ['autoSync', 'boolean', 'No', 'Synchronizes/does not synchronize the container local state with the backend (default value is true).'],
     ['onCartSyncError', 'function', 'No', 'A function that takes a ShippingMethod object and an error as arguments. It is called when the setShippingMethodsOnCart() API throws an error when a shipping method is selected to be stored to the backend.'],
     ['onSelectionChange', 'function', 'No', 'A function that takes a ShippingMethod object as an argument. It is called when a shipping method is selected.'],
-    ['slots (*)', 'object', 'No', 'Object with the title to be displayed on the ShippingMethods container and optional ShippingMethodItem slot for custom UI. See [ShippingMethods slots](/dropins/checkout/slots/#shippingmethods-slots).'],
+    ['slots (*)', 'object', 'No', 'Object with the title to be displayed on the `ShippingMethods` container and optional `ShippingMethodItem` slot for custom UI. See [ShippingMethods slots](/dropins/checkout/slots/#shippingmethods-slots).'],
     ['UIComponentType', 'string', 'No', 'String with the UI component type to be used as selector (default value is \'RadioButton\').'],
   ]}
 />

--- a/src/content/docs/dropins/checkout/slots.mdx
+++ b/src/content/docs/dropins/checkout/slots.mdx
@@ -25,6 +25,7 @@ The Checkout drop-in exposes slots for customizing specific UI sections. Use slo
 | [`LoginForm`](#loginform-slots) | `Heading` |
 | [`PaymentMethods`](#paymentmethods-slots) | None |
 | [`PlaceOrder`](#placeorder-slots) | `Content` |
+| [`ShippingMethods`](#shippingmethods-slots) | `ShippingMethodItem` |
 | [`TermsAndConditions`](#termsandconditions-slots) | `Agreements` |
 
 </TableWrapper>
@@ -110,6 +111,78 @@ await provider.render(PlaceOrder, {
       ctx.appendChild(element);
     }
   }
+})(block);
+```
+
+## ShippingMethods slots
+
+The slots for the `ShippingMethods` container allow you to fully replace the default shipping method UI with a custom implementation.
+
+```typescript
+interface ShippingMethodsProps {
+  slots?: {
+    ShippingMethodItem?: SlotProps<{
+      method: ShippingMethod;
+      isSelected: boolean;
+      onSelect: () => void;
+    }>;
+  };
+}
+```
+
+### ShippingMethodItem slot
+
+The ShippingMethodItem slot allows you to replace the default RadioButton or ToggleButton UI for each shipping method with a completely custom element. Use `ctx.replaceWith()` to provide your own UI and `ctx.onRender()` to update it when the context changes.
+
+The slot receives a context with the following properties:
+
+- `method` - The shipping method data (`ShippingMethod` model with carrier, amount, title, etc.)
+- `isSelected` - Whether this method is currently selected
+- `onSelect` - Callback that selects this shipping method and triggers the API call to set it on the cart
+
+#### Example
+
+```js
+import { render as provider } from '@dropins/storefront-checkout/render.js';
+import ShippingMethods from '@dropins/storefront-checkout/containers/ShippingMethods.js';
+
+function buildShippingMethodCard(ctx) {
+  const { method, isSelected } = ctx;
+  const price = method.amount.value === 0
+    ? 'FREE'
+    : `$${method.amount.value.toFixed(2)}`;
+
+  const card = document.createElement('label');
+  card.className = `custom-shipping-card ${isSelected ? 'custom-shipping-card--selected' : ''}`;
+  card.innerHTML = `
+    <input type="radio" name="shipping-method" value="${method.value}"
+      ${isSelected ? 'checked' : ''} style="display:none" />
+    <div>
+      <strong>${method.carrier.title}</strong>
+      <span>${method.title}</span>
+      <span>${price}</span>
+    </div>
+  `;
+
+  card.querySelector('input').addEventListener('change', () => {
+    ctx.onSelect();
+  });
+
+  return card;
+}
+
+await provider.render(ShippingMethods, {
+  slots: {
+    ShippingMethodItem: (ctx) => {
+      const card = buildShippingMethodCard(ctx);
+      ctx.replaceWith(card);
+
+      ctx.onRender((updatedCtx) => {
+        card.className = `custom-shipping-card ${updatedCtx.isSelected ? 'custom-shipping-card--selected' : ''}`;
+        card.querySelector('input').checked = updatedCtx.isSelected;
+      });
+    },
+  },
 })(block);
 ```
 

--- a/src/content/docs/dropins/checkout/slots.mdx
+++ b/src/content/docs/dropins/checkout/slots.mdx
@@ -136,7 +136,7 @@ The ShippingMethodItem slot allows you to replace the default RadioButton or Tog
 
 The slot receives a context with the following properties:
 
-- `method` - The shipping method data (`ShippingMethod` model with carrier, amount, title, etc.)
+- `method` - The shipping method data (`ShippingMethod` model with carrier, amount, title, and so on.)
 - `isSelected` - Whether this method is currently selected
 - `onSelect` - Callback that selects this shipping method and triggers the API call to set it on the cart
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request adds comprehensive documentation for the new `ShippingMethodItem` slot in the Checkout dropin's ShippingMethods container. The slot enables merchants to fully replace the default RadioButton/ToggleButton UI for individual shipping methods with completely custom implementations.

### Associated JIRA ticket

[USF-3704](https://jira.corp.adobe.com/browse/USF-3704)