### PR TITLE
USF-3743 Add storeCode parameter to wishlist initialization

### DIFF
--- a/src/content/docs/dropins/wishlist/initialization.mdx
+++ b/src/content/docs/dropins/wishlist/initialization.mdx
@@ -25,7 +25,7 @@ The following table describes the configuration options available for the **Wish
 
 | Parameter | Type | Req? | Description |
 |---|---|---|---|
-| `langDefinitions` | [`LangDefinitions`](#langdefinitions) | No | Language definitions for internationalization (i18n). Override dictionary keys for localization or branding. |
+| `langDefinitions` | [`LangDefinitions`](#langdefinitions) | No | Provides language definitions for internationalization (i18n). Overrides dictionary keys for localization or branding. |
 | `isGuestWishlistEnabled` | `boolean` | No | When set to \`true\`, allows guest users to create and manage wishlists without authentication. Guest wishlists are typically stored in browser storage. |
 | `storeCode` | `string` | No | Scopes wishlist data (cookies and browser storage) per store. Shares wishlist data across all stores when omitted or set to `default`. |
 

--- a/src/content/docs/dropins/wishlist/initialization.mdx
+++ b/src/content/docs/dropins/wishlist/initialization.mdx
@@ -27,6 +27,7 @@ The following table describes the configuration options available for the **Wish
 |---|---|---|---|
 | `langDefinitions` | [`LangDefinitions`](#langdefinitions) | No | Language definitions for internationalization (i18n). Override dictionary keys for localization or branding. |
 | `isGuestWishlistEnabled` | `boolean` | No | When set to \`true\`, allows guest users to create and manage wishlists without authentication. Guest wishlists are typically stored in browser storage. |
+| `storeCode` | `string` | No | The store view code used to scope wishlist data (cookies and browser storage) per store. When omitted or set to \`'default'\`, wishlist data is shared across all stores. |
 
 </TableWrapper>
 

--- a/src/content/docs/dropins/wishlist/initialization.mdx
+++ b/src/content/docs/dropins/wishlist/initialization.mdx
@@ -27,7 +27,7 @@ The following table describes the configuration options available for the **Wish
 |---|---|---|---|
 | `langDefinitions` | [`LangDefinitions`](#langdefinitions) | No | Language definitions for internationalization (i18n). Override dictionary keys for localization or branding. |
 | `isGuestWishlistEnabled` | `boolean` | No | When set to \`true\`, allows guest users to create and manage wishlists without authentication. Guest wishlists are typically stored in browser storage. |
-| `storeCode` | `string` | No | The store view code used to scope wishlist data (cookies and browser storage) per store. When omitted or set to \`'default'\`, wishlist data is shared across all stores. |
+| `storeCode` | `string` | No | Scopes wishlist data (cookies and browser storage) per store. Shares wishlist data across all stores when omitted or set to `default`. |
 
 </TableWrapper>
 

--- a/src/content/docs/dropins/wishlist/initialization.mdx
+++ b/src/content/docs/dropins/wishlist/initialization.mdx
@@ -26,7 +26,7 @@ The following table describes the configuration options available for the **Wish
 | Parameter | Type | Req? | Description |
 |---|---|---|---|
 | `langDefinitions` | [`LangDefinitions`](#langdefinitions) | No | Provides language definitions for internationalization (i18n). Overrides dictionary keys for localization or branding. |
-| `isGuestWishlistEnabled` | `boolean` | No | When set to \`true\`, allows guest users to create and manage wishlists without authentication. Guest wishlists are typically stored in browser storage. |
+| `isGuestWishlistEnabled` | `boolean` | No | Allows guest users to create and manage wishlists without authentication when set to true. Stores guest wishlists in browser storage. |
 | `storeCode` | `string` | No | Scopes wishlist data (cookies and browser storage) per store. Shares wishlist data across all stores when omitted or set to `default`. |
 
 </TableWrapper>


### PR DESCRIPTION
## Purpose of this pull request

Add `storeCode` parameter documentation for wishlist multi-store support
Documents the new `storeCode` configuration parameter in the wishlist initialization guide. This parameter enables scoping wishlist data per store view for multi-store setups.

### Associated JIRA ticket

[USF-3743](https://jira.corp.adobe.com/browse/USF-3743)