### PR TITLE
docs: update drop-ins introduction with B2C/B2B and customization tables

### DIFF
--- a/src/content/docs/dropins/all/introduction.mdx
+++ b/src/content/docs/dropins/all/introduction.mdx
@@ -1,93 +1,70 @@
 ---
 title: Introduction to Drop-In Components
 description: Learn what drop-in components are and how to use them.
+sidebar:
+  label: Introduction
+  order: 1
 ---
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
-import LinkCard from '@components/LinkCard.astro';
-import CardGrid from '@components/CardGrid.astro';
-import Card from '@components/Card.astro';
-import Aside from '@components/Aside.astro';
-import { Badge } from '@astrojs/starlight/components';
+import TableWrapper from '@components/TableWrapper.astro';
 
-Drop-in components (with Commerce services) make up the entire storefront experience. They are equivalent to small apps that you can mix and match to create a storefront that fits your needs.
+Drop-in components (with Commerce services) make up the entire storefront experience. They are equivalent to small apps you can mix and match. You can customize and combine B2C and B2B drop-ins to fit your business needs.
 
 ## What are drop-in components?
 
-Drop-in components are full-featured shopping components. They are not primitive components like Carousels and Galleries. drop-in components _define_ the storefront shopping experience. Our drop-in components include product details, carts, checkout, user authentication, user accounts, with more on the way. This section introduces these drop-in components and provides links to their details.
+Drop-in components are full-featured shopping components (not primitives like Carousels or Galleries) that _define_ the storefront experience. The tables below list available B2C and B2B drop-ins with links to their details.
 
-### Cart
+### B2C drop-ins
 
-The [cart](/dropins/cart/) drop-in
-provides a summary of the items that the user has added to their cart. It allows users to view and
-manage their cart contents, update quantities, and proceed to checkout. The cart is a critical
-component of the e-commerce experience, providing users with a convenient way to review and adjust
-their selections before completing their purchase.
+<TableWrapper nowrap={[0]}>
 
-### Checkout
+| Drop-in | Description |
+| ------- | ----------- |
+| [Cart](/dropins/cart/) | Summary of items in the cart; view and manage cart contents, update quantities, and proceed to checkout. |
+| [Checkout](/dropins/checkout/) | Streamlined process for completing a purchase: shipping and payment information, order review, and confirmation. |
+| [Order](/dropins/order/) | Tools and containers to manage and display order-related data across pages; supports customer accounts and guest workflows. |
+| [Payment Services](/dropins/payment-services/) | Renders the credit card form and Apple Pay button for payment details; supports credit/debit cards and Apple Pay. |
+| [Personalization](/dropins/personalization/) | Displays content conditionally based on Adobe Commerce customer groups, segments, and cart price rules. |
+| [Product Details](/dropins/product-details/) | Detailed product information: SKUs, pricing, descriptions, options; supports internationalization and accessibility. |
+| [Product Discovery](/dropins/product-discovery/) | Search results, category listings, and faceted navigation so customers can find and explore products. |
+| [Recommendations](/dropins/recommendations/) | Suggests products from browsing patterns (e.g. "Customers who viewed this also viewed"); manageable from Adobe Commerce Admin. |
+| [User Account](/dropins/user-account/) | Personalized experience: order history, account settings, and other account-related features. |
+| [User Authentication](/dropins/user-auth/) | Sign up, sign in, and log out; supports account confirmation, password reset, and optional ReCAPTCHA. |
+| [Wishlist](/dropins/wishlist/) | Lets guests and registered customers save products to purchase later. |
 
-The [checkout](/dropins/checkout/)
-drop-in component is a key component of the e-commerce experience, providing users with a streamlined process
-for completing their purchase. It allows users to enter shipping and payment information, review
-their order details, and confirm their purchase.
+</TableWrapper>
 
-### Order
+### B2B drop-ins
 
-The [order](/dropins/order/) drop-in component provides a comprehensive set of tools and containers designed to manage and display order-related data across various pages and scenarios. It simplifies the implementation of order management functionality and supports seamless integration with both customer accounts and guest user workflows.
+<TableWrapper nowrap={[0]}>
 
-### Payment Services
+| Drop-in | Description |
+| ------- | ----------- |
+| [Company Management](/dropins-b2b/company-management/) | Company profile management, role-based permissions, legal address and contact information. |
+| [Company Switcher](/dropins-b2b/company-switcher/) | Switch between multiple companies a user is associated with; company context and GraphQL header management. |
+| [Purchase Order](/dropins-b2b/purchase-order/) | Purchase order workflows, approval rules, and purchase order history for B2B transactions. |
+| [Quote Management](/dropins-b2b/quote-management/) | Negotiable quotes: request, negotiation, approval, and tracking for B2B customers. |
+| [Requisition List](/dropins-b2b/requisition-list/) | Create and manage requisition lists for repeat and bulk ordering; multiple lists per account. |
 
-The [Payment Services](/dropins/payment-services/) drop-in renders the credit card form, allowing shoppers to efficiently enter their payment details. The drop-in currently supports credit/debit cards only.
-
-### Product details
-
-The [product details](/dropins/product-details/) drop-in component renders detailed information about products
-and services, including SKUs, pricing, descriptions, and customizable options, with built-in support
-for internationalization and accessibility. This drop-in component is a key component of the e-commerce
-experience, providing users with essential product information to enable informed
-purchasing decisions.
-
-### Product Discovery
-
-The [product discovery](/dropins/product-discovery/) drop-in component you can create a seamless and engaging shopping experience for your customers by allowing them to easily find and explore products that match their interests.
-
-### Recommendations
-
-The [recommendations](/dropins/recommendations/) drop-in component provides a powerful way to suggest products to customers based on their browsing patterns and behaviors. These recommendations are displayed as units with descriptive labels such as "Customers who viewed this product also viewed" or "Customers who bought this product also bought". The component can be managed and deployed across different store views directly from the Adobe Commerce Admin.
-
-### User account
-
-The [user account](/dropins/user-account/) drop-in component
-provides users with a personalized experience, allowing them to view their order history, manage
-their account settings, and access other account-related features.
-
-### User authentication
-
-The [user authentication](/dropins/user-auth/) drop-in component provides users with a secure and seamless way to log in
-or create an account on your e-commerce platform. It supports various authentication methods,
-including email, social media, and single sign-on (SSO), ensuring a smooth user experience across
-devices and platforms.
-
-### Wishlist
-
-The [wishlist](/dropins/wishlist/) drop-in component provides both guests and registered customers with a mechanism to store products they are interested in purchasing later.
+</TableWrapper>
 
 ## How can I customize drop-in components?
 
-All drop-in components can be customized in five ways: design tokens, CSS classes, slots, content enrichment, and localization. In this section, you'll learn how to use each approach.
+Drop-in components support many customization approaches. The table below lists each approach with links to details.
 
-### Design tokens
+<TableWrapper nowrap={[0]}>
 
-[Design tokens](/dropins/all/branding/) are the quickest way to customize your storefront. By changing the default token values with your own brand colors, typography, spacing, and shapes, you can make quick, global brand changes to your entire storefront.
+| Approach | Description |
+| -------- | ----------- |
+| [Design tokens](/dropins/all/branding/) | Override Adobe Commerce design tokens (colors, typography, spacing, shapes) for quick, global brand changes. |
+| [CSS classes](/dropins/all/styling/) | Override or add CSS classes to restyle specific areas of a drop-in beyond what tokens provide. |
+| [Slots](/dropins/all/slots/) | Use built-in extension points to add or replace UI and behavior in drop-in components. |
+| [Content enrichment](/merchants/content-customizations/enrichment/) | Add content above or below commerce blocks by product SKU, category, and the physical position on the page. |
+| [Localization](/dropins/all/labeling/) | Use the placeholder system to override default drop-in text and support multiple languages. |
+| [Dictionaries](/dropins/all/dictionaries/) | Customize drop-in dictionaries (deep-merge) for localization, branding, and multi-language support. |
+| [Extending](/dropins/all/extending/) | Add new features and Commerce API integrations to existing drop-ins (for example, gift messages in checkout). |
+| [Layouts](/dropins/all/layouts/) | Configure where drop-in containers appear on the page via HTML fragments and block layout. |
+| [Localizing links](/dropins/all/linking/) | Manage localized internal links in the boilerplate so users stay within their chosen locale. |
+| [Extend, substitute, or create?](/dropins/all/extend-or-create/) | Decide when to extend an existing drop-in, substitute with a third-party solution, or create a new one. |
 
-### CSS classes
-
-[CSS classes](/dropins/all/styling/) provide deeper style changes for drop-in components than design tokens. Overriding or adding new CSS classes allows you to restyle specific areas of the drop-in component. You'll find best practices for styling here.
-
-### Slots
-
-[Slots](/dropins/all/extending/) provide the deepest level of customization. Slots are built-in extension points in the drop-in component to add your own UI components and functions. You'll learn how powerful slots can be.
-
-### Localization
-
-[Localization](/dropins/all/labeling/) is one of the easiest ways to customize drop-in components for a region. This topic shows you how to add and use a second language file in your drop-in components.
+</TableWrapper>


### PR DESCRIPTION
## Purpose of this pull request

This pull request updates the **Introduction to Drop-In Components** topic so it lists all B2C and B2B drop-ins and all customization approaches in tables with links, and tightens the copy for clarity and accuracy.

### Associated JIRA ticket
Jira is down. No ticket.

## Affected pages

https://experienceleague.adobe.com/developer/commerce/storefront/dropins/all/introduction/

### What's New highlights

whatsnew
Updated [Introduction to Drop-In Components](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/all/introduction/) with B2C and B2B drop-in tables (all 11 B2C and 5 B2B drop-ins with links and descriptions) and a customization table (design tokens, CSS classes, slots, content enrichment, localization, dictionaries, extending, layouts, localizing links, extend/substitute/create).