### PR TITLE
removed ac-scope-locale form demo config as it is not required

### DIFF
--- a/src/content/docs/setup/configuration/commerce-configuration.mdx
+++ b/src/content/docs/setup/configuration/commerce-configuration.mdx
@@ -531,8 +531,7 @@ This example shows the configuration for Adobe Commerce Optimizer (ACO), which u
       "headers": {
         "cs": {
           "ac-view-id": "0d3eebf7-b5fb-4904-9ccf-f35fcc61862b",
-          "ac-price-book-id": "west_coast_inc",
-          "ac-scope-locale": "en-US"
+          "ac-price-book-id": "west_coast_inc"
         }
       },
       "analytics": {


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) removes the header "ac-scope-locale" from ACO demo configuration as it is no longer required.

### Associated JIRA ticket


### Staging preview


## Affected pages

https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/commerce-configuration/

## Links to source code

<!--OPTIONAL Link to any associated source code PRs related to update-->

### What's New highlights

<!--  _OPTIONAL - REMOVE THIS SECTION IF NOT USED._

If this pull request introduces changes that should be highlighted in What's New documentation reports.
-->

