### PR TITLE
March 2026 release notes and changelog

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,19 +9,23 @@ To generate release notes and changelog for a new release (e.g. March 2026), the
 ### How to run it
 
 1. **Authenticate** (required for private repos): run `gh auth login` in your terminal.
-2. **In Cursor**, ask the AI to add the new release. For example:
-   - *"Add the March 2026 release. Use B2C PR https://github.com/hlxsites/aem-boilerplate-commerce/pull/XXXX and B2B PR https://github.com/hlxsites/aem-boilerplate-commerce/pull/YYYY."*
-3. **Optionally** supply a **code comparison URL** so the AI knows exactly which changes to analyze (especially for boilerplate). For example:
+2. **In Cursor**, prompt the agent to add the new release. For example:
+
+"Add the March 2026 release. Use these urls to parse all the code changes:
+- B2C changes: https://github.com/hlxsites/aem-boilerplate-commerce/pull/1152 and 
+- B2B changes: https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156/changes"
+
+3. **Optionally** supply a **code comparison URL** so the Cursor knows exactly which changes to analyze (especially for boilerplate). For example:
    - *"Use this comparison for the boilerplate: https://github.com/hlxsites/aem-boilerplate-commerce/compare/january-2026...b2c-february-2026"*
-   If you don't supply comparison URLs, the AI will derive version ranges from the previous release and the PRs' package.json; if it can't find a comparison for a repo, it will ask you to supply the URL or refs.
+   If you don't supply comparison URLs, Cursor will derive version ranges from the previous release and the PRs' package.json; if it can't find a comparison for a repo, it will ask you to supply the URL or refs.
 4. The AI runs the skill, analyzes code changes, and adds a new suite section and changelog entries in `src/content/docs/releases/`.
 
 **Optional:** To update only one file, say so (e.g. *"Update only the changelog for March 2026"* or *"Update only the release index for March 2026"*). The same analysis runs but only the requested file is written.
 
-**Example PRs** (February 2026):
+**Example PRs** (March 2026):
 
-- B2C: https://github.com/hlxsites/aem-boilerplate-commerce/pull/1096  
-- B2B: https://github.com/hlxsites/aem-boilerplate-commerce/pull/1107
+- B2C: https://github.com/hlxsites/aem-boilerplate-commerce/pull/1152  
+- B2B: https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156
 
 ### Manual updates required
 
@@ -32,8 +36,31 @@ These sections are **not** filled from code and must be updated manually before 
 | **Known issues** | Each suite’s `### Known issues` | Add bullets from release notes or your team, or use: “There are no known issues for this release suite.” |
 | **Adobe Commerce version(s)** | Component compatibility → first table, left column (e.g. `2.4.7`, `2.4.8`) | Confirm supported versions from release/product spec or team; add one row per version. |
 | **Adobe Commerce B2B version** | Component compatibility → second table, left column (e.g. `1.5.2`) | Confirm supported B2B version from release/product spec or team; add the single row. |
+| **Storefront Compatibility Package versions** | Component compatibility → right column of both tables | **Source:** Branch names in the SCP repos (not GitHub Releases). B2C: [storefront-compatibility](https://github.com/magento-commerce/storefront-compatibility) branches — use latest `4.7.x` and `4.8.x`. B2B: [storefront-compatibility-b2b](https://github.com/magento-commerce/storefront-compatibility-b2b) branches — use latest `1.0.x`. Example: `gh api "repos/magento-commerce/storefront-compatibility/branches?per_page=100" --jq ".[].name" | grep -E '^4\\.(7|8)\\.' | sort -V`. |
 
-See the [release-notes skill](.cursor/skills/release-notes/SKILL.md) for full details (including “Sections that cannot be confirmed from code”).
+See the [release-notes skill](.cursor/skills/release-notes/SKILL.md) for full details (including “Sections that cannot be confirmed from code” and **§3 SCP** for how to find latest compatibility package versions).
+
+### Testing the skill (compare your version with a from-scratch run)
+
+To test the skill by regenerating the release notes from scratch and comparing with your current version:
+
+1. **Stash only the release files** (keeps other uncommitted changes in place):
+   ```bash
+   git stash push -m "Release notes before skill test" -- src/content/docs/releases/changelog.mdx src/content/docs/releases/index.mdx
+   ```
+
+2. **Run the skill from scratch** in Cursor. For example: *"Add the March 2026 release from scratch. Use B2C PR #1152 and B2B PR #1156."* (Supply the same comparison URLs or PRs you used for your current version so the run is comparable.)
+
+3. **Compare stashed version (yours) with the new version (skill output):**
+   ```bash
+   git diff stash@{0} -- src/content/docs/releases/changelog.mdx src/content/docs/releases/index.mdx
+   ```
+   - The diff shows: **stashed** = your version, **current working tree** = what the skill just wrote.
+   - To save the diff to a file: `git diff stash@{0} -- src/content/docs/releases/changelog.mdx src/content/docs/releases/index.mdx > release-notes-test.diff`
+
+4. **Restore your version** if you want to keep it: `git stash pop`. Or keep the skill's version and drop the stash: `git stash drop`.
+
+**Alternative (backup copies):** Before running the skill, copy the files to `.current` (for example `changelog.mdx.current`, `index.mdx.current`). After the skill runs, compare with `diff -u src/content/docs/releases/changelog.mdx.current src/content/docs/releases/changelog.mdx` and the same for `index.mdx`.
 
 ## Custom components
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,39 @@
 
 Welcome to the storefront documentation site! To contribute documentation to this site follow the instructions below to install the prerequisites, configure your local environment, create new pages, submit PRs.
 
+## Release notes
+
+To generate release notes and changelog for a new release (e.g. March 2026), the AI uses the [release-notes skill](.cursor/skills/release-notes/SKILL.md). The skill uses the **previous** release as a structural template only, analyzes **code changes** (Files changed) between release versions for boilerplate, drop-ins, SDK, and tools, and updates both `index.mdx` and `changelog.mdx`.
+
+### How to run it
+
+1. **Authenticate** (required for private repos): run `gh auth login` in your terminal.
+2. **In Cursor**, ask the AI to add the new release. For example:
+   - *"Add the March 2026 release. Use B2C PR https://github.com/hlxsites/aem-boilerplate-commerce/pull/XXXX and B2B PR https://github.com/hlxsites/aem-boilerplate-commerce/pull/YYYY."*
+3. **Optionally** supply a **code comparison URL** so the AI knows exactly which changes to analyze (especially for boilerplate). For example:
+   - *"Use this comparison for the boilerplate: https://github.com/hlxsites/aem-boilerplate-commerce/compare/january-2026...b2c-february-2026"*
+   If you don't supply comparison URLs, the AI will derive version ranges from the previous release and the PRs' package.json; if it can't find a comparison for a repo, it will ask you to supply the URL or refs.
+4. The AI runs the skill, analyzes code changes, and adds a new suite section and changelog entries in `src/content/docs/releases/`.
+
+**Optional:** To update only one file, say so (e.g. *"Update only the changelog for March 2026"* or *"Update only the release index for March 2026"*). The same analysis runs but only the requested file is written.
+
+**Example PRs** (February 2026):
+
+- B2C: https://github.com/hlxsites/aem-boilerplate-commerce/pull/1096  
+- B2B: https://github.com/hlxsites/aem-boilerplate-commerce/pull/1107
+
+### Manual updates required
+
+These sections are **not** filled from code and must be updated manually before publishing:
+
+| Section | Where it appears | What to do |
+|---------|------------------|------------|
+| **Known issues** | Each suite’s `### Known issues` | Add bullets from release notes or your team, or use: “There are no known issues for this release suite.” |
+| **Adobe Commerce version(s)** | Component compatibility → first table, left column (e.g. `2.4.7`, `2.4.8`) | Confirm supported versions from release/product spec or team; add one row per version. |
+| **Adobe Commerce B2B version** | Component compatibility → second table, left column (e.g. `1.5.2`) | Confirm supported B2B version from release/product spec or team; add the single row. |
+
+See the [release-notes skill](.cursor/skills/release-notes/SKILL.md) for full details (including “Sections that cannot be confirmed from code”).
+
 ## Custom components
 
 This documentation site includes a collection of custom Astro components that enhance content presentation and interactivity. Below is a complete list of available components with links to examples of their usage:

--- a/src/content/docs/releases/changelog.mdx
+++ b/src/content/docs/releases/changelog.mdx
@@ -19,7 +19,30 @@ import Link from '@components/Link.astro';
 ***************/}
 
     <ChangelogEntry
-      date="2026-02-17"
+      date="2026-03-11"
+      title="Boilerplate Updates"
+      components={['Boilerplate']}
+    >
+      The Commerce boilerplate has been updated with PDP video support, PLP page size configuration, 404 handling, layout improvements, multi-store wishlist integration, and B2B Quick Order and cart fixes:
+
+      **Infrastructure**
+      - **Build tools**: `@dropins/build-tools` upgraded from ~1.0.1 to ~1.1.0 ([#1152](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1152)).
+      - **Default assets**: Assets enabled flag now defaults to true ([#1114](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1114)).
+      - **Site config**: Removed folders ref from default-site.json ([#1148](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1148)).
+
+      **Fixes and improvements**
+      - **PDP block**: Video support out of the box for product media ([#1100](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1100)).
+      - **PLP block**: Page size configurable via block configuration; defaults to 9 ([#1143](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1143)).
+      - **404 handling**: Non-existent pages now return a correct server-rendered 404 so crawlers and tools receive the right HTTP status ([#1134](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1134)).
+      - **Layout**: Full-width sections and padding-based gutters in columns ([#1133](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1133)).
+      - **URL manipulation**: URL handling moved to boilerplate ([#1119](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1119)).
+      - **Wishlist**: Multi-store wishlist drop-in integration ([#1139](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1139)).
+      - **Demo config**: Adobe Commerce Optimizer flag added to demo-config-aco.json ([#1124](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1124)).
+      - **B2B (Cart)**: View wishlist link includes store code prefix in PDP and Cart blocks ([#1130](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1130)); cart state cleared when switching websites to prevent 403 errors ([#1137](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1137)).
+      - **B2B (Quick Order)**: Quick Order drop-in integrated into boilerplate ([#1125](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1125), [#1156](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156)).
+    </ChangelogEntry>
+
+    <ChangelogEntry
       title="Boilerplate Updates"
       components={['Boilerplate']}
     >
@@ -230,6 +253,18 @@ import Link from '@components/Link.astro';
 {/****** 
 **Cart** 
 ********/}
+
+    <ChangelogEntry
+      date="2026-03-11"
+      title="Cart v3.2.0"
+      components={['Cart']}
+    >
+      The Cart drop-in has been updated with the following changes:
+
+      - **Out-of-stock and insufficient-quantity items in the main list** - The `CartSummaryList` container now accepts an optional `includeOutOfStockItems` prop (default `false`). When set to `true`, out-of-stock and insufficient-quantity items appear in the main cart item list alongside in-stock items; the alert banner remains visible with its heading, description, and actions (for example, "Remove all out of stock items"), but the item rows inside the banner are hidden from view and marked for screen readers. Default behavior is unchanged ([#102](https://github.com/adobe-commerce/storefront-cart/pull/102)).
+      - **Multi-store wishlist integration** - The boilerplate now wires the multi-store wishlist drop-in into the Cart block ([#1139](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1139)).
+      - **B2B** - The View wishlist link includes the store code prefix in the PDP and Cart blocks; cart state is cleared when users switch websites to prevent 403 errors ([#1130](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1130), [#1137](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1137)).
+    </ChangelogEntry>
 
     <ChangelogEntry
       date="2026-02-17"
@@ -1221,6 +1256,18 @@ import Link from '@components/Link.astro';
 ************************/}
 
     <ChangelogEntry
+      date="2026-03-11"
+      title="Product details page v3.0.2"
+      components={['Product details page']}
+    >
+      The Product Details Page drop-in has been updated with the following changes:
+
+      - **Video support** - Out-of-the-box video support in the Product Gallery. The `ProductGallery` container now accepts a `videos` prop: use `videos={true}` or `videos={{ position: 'last' }}` for videos after images, or `videos={{ position: 'first' }}` for videos before images; omit or set `videos={false}` for backward compatibility. Supports direct video files (for example .mp4, .webm), YouTube, Vimeo, and AEM Assets. The `CarouselMainImage` and `CarouselThumbnail` slots receive `mediaType` ('image' | 'video') and `previewUrl` for custom rendering ([#57](https://github.com/adobe-commerce/storefront-pdp/pull/57)). Boilerplate integration ([#1100](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1100)).
+      - **ProductOptions transformer prop** - New `transformer` prop on the ProductOptions container lets you modify product options data before rendering, enabling conversion of dropdown options to radio swatches (text, image, or color) at the container level ([#51](https://github.com/adobe-commerce/storefront-pdp/pull/51)).
+      - **getProductsData API** - New `getProductsData` API method for the Quick Order (B2B) drop-in, using the same data model and GraphQL fragment as `getProductData` ([#56](https://github.com/adobe-commerce/storefront-pdp/pull/56)).
+    </ChangelogEntry>
+
+    <ChangelogEntry
       date="2026-02-17"
       title="Product details page v3.0.1"
       components={['Product details page']}
@@ -1282,6 +1329,18 @@ import Link from '@components/Link.astro';
 {/******************* 
 **Product discovery** 
 *********************/}
+
+    <ChangelogEntry
+      date="2026-03-11"
+      title="Product Discovery v3.1.0"
+      components={['Product Discovery']}
+    >
+      The Product Discovery drop-in has been updated with the following changes:
+
+      - **Pathname with store code** - Pathname handling is fixed when the store code is present in the URL. The condition that checks whether the pathname ends with `search` was corrected, so category detection and quick search work correctly in multi-store setups ([#88](https://github.com/adobe-commerce/storefront-search-dropin/pull/88), [#91](https://github.com/adobe-commerce/storefront-search-dropin/pull/91)).
+      - **Filter state and pagination** - URL manipulation has been moved out of the drop-in into the boilerplate. Filter state resets to page 1 when filters change, and the function defaults to page one for consistent pagination ([#86](https://github.com/adobe-commerce/storefront-search-dropin/pull/86)). Boilerplate integration ([#1119](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1119)).
+      - **PLP page size** - Page size is configurable via block configuration and defaults to 9; includes instrumentation for Universal Editor ([#1143](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1143)).
+    </ChangelogEntry>
 
     <ChangelogEntry
       date="2026-02-17"
@@ -1490,6 +1549,16 @@ import Link from '@components/Link.astro';
 {/********** 
 **Wishlist** 
 ************/}
+
+    <ChangelogEntry
+      date="2026-03-11"
+      title="Wishlist v3.2.0"
+      components={['Wishlist']}
+    >
+      The Wishlist drop-in has been updated with the following changes:
+
+      - **Multi-store wishlist** - The drop-in now supports multi-store scenarios. Pass an optional `storeCode` config prop during initialization (the boilerplate reads it from the AEM config system and passes it into the drop-in). When `storeCode` is set and not `'default'`, localStorage and sessionStorage keys and wishlist ID cookies are scoped per store (for example `DROPIN__WISHLIST__WISHLIST__DATA__` plus the store code), so guest and authenticated wishlist data stay isolated between store views. Single-store setups and the `'default'` store continue using the original unscoped keys for backward compatibility ([#73](https://github.com/adobe-commerce/storefront-wishlist/pull/73)). Boilerplate integration ([#1139](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1139)).
+    </ChangelogEntry>
 
     <ChangelogEntry
       date="2026-02-17"
@@ -1868,6 +1937,26 @@ import Link from '@components/Link.astro';
 {/******************** 
 **Requisition List** 
 *********************/}
+
+    <ChangelogEntry
+      date="2026-03-11"
+      title="Quick Order v1.0.0"
+      components={['Requisition List']}
+    >
+      **New Quick Order drop-in** for B2B bulk ordering. The Quick Order drop-in has been integrated into the boilerplate, enabling B2B users to add products to cart by SKU or product name in bulk ([#1125](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1125), [#1156](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156)).
+    </ChangelogEntry>
+
+    <ChangelogEntry
+      date="2026-03-11"
+      title="Requisition List v1.2.0"
+      components={['Requisition List']}
+    >
+      The Requisition List drop-in has been updated with the following changes:
+
+      - **API catalog replaced with props** - The drop-in no longer calls API catalog functions directly. Product data is now provided via props injected from the integration layer, so implementers control how product data is sourced ([storefront-requisition-list](https://github.com/adobe-commerce/storefront-requisition-list)).
+      - **Requisition list selector disabled state** - The requisition list selector now correctly respects the disabled state in Storybook and at runtime ([#120](https://github.com/adobe-commerce/storefront-requisition-list/pull/120)).
+      - **Boilerplate integration** - The drop-in is integrated into the March 2026 B2B suite ([#1156](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156)).
+    </ChangelogEntry>
 
     <ChangelogEntry
       date="2026-02-17"

--- a/src/content/docs/releases/index.mdx
+++ b/src/content/docs/releases/index.mdx
@@ -11,6 +11,127 @@ Adobe organizes storefront application releases into logical suite versions and 
 
 The following sections provide high-level summaries of each release suite and details about the compatibility between storefront components. To see more details about each drop-in component by version, go to the [changelog](/releases/changelog/).
 
+## March 2026 suite
+
+This suite adds Product Details Page video support, multi-store wishlist, configurable PLP page size, Quick Order (B2B), and boilerplate improvements including correct 404 responses for non-existent pages, layout updates, and multi-website cart behavior. For per-component version details, see the [changelog](/releases/changelog/).
+
+<Aside type="caution" title="Breaking changes">
+There are no breaking changes in this release suite.
+</Aside>
+
+### Highlights
+
+- **Product Details Page**: Out-of-the-box video support for product media ([#1100](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1100)).
+- **Wishlist**: Multi-store wishlist drop-in support ([#1139](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1139)).
+- **Product List Page**: Page size configurable via block configuration; defaults to 9 ([#1143](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1143)).
+- **Navigation**: Non-existent pages now return a correct 404 response so crawlers and tools receive the right HTTP status ([#1134](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1134)).
+- **Layout**: Full-width sections and padding-based gutters in columns ([#1133](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1133)).
+- **B2B**: Quick Order drop-in integration ([#1125](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1125)); View wishlist link uses store code prefix in PDP and Cart ([#1130](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1130)); cart state cleared when switching websites to prevent 403 errors ([#1137](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1137)).
+- **B2C drop-ins**: Account, Auth, Cart, Checkout, Order, Wishlist updated to v3.2.0; PDP to v3.0.2; Product Discovery to v3.1.0.
+- **B2B drop-ins**: Requisition List updated to v1.2.0; new Quick Order drop-in v1.0.0.
+
+### Updated boilerplate
+
+#### Infrastructure
+
+- **Build tools**: `@dropins/build-tools` upgraded from ~1.0.1 to ~1.1.0 ([#1152](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1152)).
+- **Default assets**: Assets enabled flag defaults to true ([#1114](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1114)).
+- **Site config**: Removed folders ref from default-site.json ([#1148](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1148)).
+
+#### Document Authoring
+
+No Document Authoring changes in this release suite.
+
+#### Fixes and improvements
+
+- **PDP block**: Video support out of the box for product media ([#1100](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1100)).
+- **PLP block**: Page size configurable via block configuration; defaults to 9 ([#1143](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1143)).
+- **404 handling**: Non-existent pages now return a correct server-rendered 404 so crawlers and tools receive the right HTTP status ([#1134](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1134)).
+- **Layout**: Full-width sections and padding-based gutters in columns ([#1133](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1133)).
+- **URL manipulation**: URL handling moved to boilerplate ([#1119](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1119)).
+- **Wishlist**: Multi-store wishlist drop-in integration ([#1139](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1139)).
+- **Demo config**: Adobe Commerce Optimizer flag added to demo-config-aco.json ([#1124](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1124)).
+- **B2B (Cart)**: View wishlist link includes store code prefix in PDP and Cart blocks ([#1130](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1130)); cart state cleared when switching websites to prevent 403 errors ([#1137](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1137)).
+- **B2B (Quick Order)**: Quick Order drop-in integrated into boilerplate ([#1125](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1125), [#1156](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156)).
+
+### Updated Drop-in SDK
+
+No Drop-in SDK changes in this release suite.
+
+### Updated B2C drop-in components
+
+| Component | Improvements |
+|-----------|--------------|
+| [**Cart**](/dropins/cart/) v3.2.0 | Optional `includeOutOfStockItems` prop on CartSummaryList so out-of-stock and insufficient-quantity items can appear in the main list; multi-store wishlist integration ([#102](https://github.com/adobe-commerce/storefront-cart/pull/102), [#1139](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1139)). |
+| [**Checkout**](/dropins/checkout/) v3.2.0 | No user-facing changes in this release |
+| [**Order**](/dropins/order/) v3.2.0 | No user-facing changes in this release |
+| [**Product Details Page**](/dropins/product-details/) v3.0.2 | Out-of-the-box video support for product media ([#1100](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1100)) |
+| [**User Account**](/dropins/user-account/) v3.2.0 | No user-facing changes in this release |
+| [**User Auth**](/dropins/user-auth/) v3.2.0 | No user-facing changes in this release |
+| [**Wishlist**](/dropins/wishlist/) v3.2.0 | Multi-store support: optional `storeCode` config prop; storage and cookies scoped per store; backward compatible for single-store and `'default'` ([#73](https://github.com/adobe-commerce/storefront-wishlist/pull/73), [#1139](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1139)) |
+| [**Personalization**](/dropins/personalization/) v3.1.0 | No user-facing changes in this release |
+| [**Product Discovery**](/dropins/product-discovery/) v3.1.0 | Pathname handling is fixed when the store code appears in the URL; filter state resets to page 1 when filters change; URL manipulation moved to boilerplate ([#86](https://github.com/adobe-commerce/storefront-search-dropin/pull/86), [#88](https://github.com/adobe-commerce/storefront-search-dropin/pull/88)). PLP page size configurable via block config, defaults to 9 ([#1143](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1143)). |
+| [**Product Recommendations**](/dropins/recommendations/) v3.0.0 | No user-facing changes in this release |
+| [**Payment Services**](/dropins/payment-services/) v3.0.0 | No user-facing changes in this release |
+
+### Updated B2B drop-in components
+
+| Component | Improvements |
+|-----------|--------------|
+| [**Company Management**](/dropins-b2b/company-management/) v1.1.0 | No new release in this suite; remains at v1.1.0 from February 2026 |
+| [**Company Switcher**](/dropins-b2b/company-switcher/) v1.1.0 | No new release in this suite; remains at v1.1.0 from February 2026 |
+| [**Purchase Order**](/dropins-b2b/purchase-order/) v1.1.0 | No new release in this suite; remains at v1.1.0 from February 2026 |
+| [**Quote Management**](/dropins-b2b/quote-management/) v1.1.0 | No new release in this suite; remains at v1.1.0 from February 2026 |
+| [**Requisition List**](/dropins-b2b/requisition-list/) v1.2.0 | API catalog replaced with props from the integration layer; requisition list selector disabled state fixed. Boilerplate integration ([#120](https://github.com/adobe-commerce/storefront-requisition-list/pull/120), [#1156](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156)). |
+| [**Quick Order**](/dropins-b2b/quick-order/) v1.0.0 | New Quick Order drop-in integrated for B2B bulk ordering ([#1125](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1125), [#1156](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156)) |
+
+### Known issues
+
+There are no known issues for this release suite.
+
+### Component compatibility
+
+Adobe has tested and verified the following component versions for this release suite.
+
+**Commerce Foundation**
+
+| Adobe Commerce | Storefront Compatibility Package |
+|----------------|----------------------------------|
+| `2.4.7`        | `4.7.11`                         |
+| `2.4.8`        | `4.8.17`                         |
+
+| Adobe Commerce B2B | Storefront Compatibility B2B Package |
+|--------------------|--------------------------------------|
+| `1.5.2`            | `1.0.18`                             |
+
+**Drop-in SDK**
+
+- `@dropins/tools@~1.7.0`
+- `@dropins/build-tools@~1.1.0`
+
+**B2C drop-ins**
+
+- `@dropins/storefront-account@~3.2.0`
+- `@dropins/storefront-auth@~3.2.0`
+- `@dropins/storefront-cart@~3.2.0`
+- `@dropins/storefront-checkout@~3.2.0`
+- `@dropins/storefront-order@~3.2.0`
+- `@dropins/storefront-payment-services@~3.0.0`
+- `@dropins/storefront-pdp@~3.0.2`
+- `@dropins/storefront-personalization@~3.1.0`
+- `@dropins/storefront-product-discovery@~3.1.0`
+- `@dropins/storefront-recommendations@~3.0.0`
+- `@dropins/storefront-wishlist@~3.2.0`
+
+**B2B drop-ins**
+
+- `@dropins/storefront-company-management@~1.1.0`
+- `@dropins/storefront-company-switcher@~1.1.0`
+- `@dropins/storefront-purchase-order@~1.1.0`
+- `@dropins/storefront-quote-management@~1.1.0`
+- `@dropins/storefront-requisition-list@~1.2.0`
+- `@dropins/storefront-quick-order@~1.0.0`
+
 ## February 2026 suite
 
 This suite builds on the January 2026 foundation with Document Authoring improvements, Universal Editor model v2 upgrade, and drop-in updates for B2C and B2B. For per-component version details, see the [changelog](/releases/changelog/).

--- a/src/content/docs/releases/test-changelog.mdx
+++ b/src/content/docs/releases/test-changelog.mdx
@@ -1,0 +1,51 @@
+---
+title: "Test: Changelog"
+description: "Test: Track changes and updates to Adobe Commerce Storefront components. Use for testing the release-notes skill with PRs 1096 (B2C) and 1107 (B2B). Content in this file is derived only from those PRs—not from existing changelog."
+---
+
+import ChangelogFilter from '@components/changelog/ChangelogFilter.astro';
+import ChangelogEntry from '@components/changelog/ChangelogEntry.astro';
+
+<div class="changelog-page">
+
+  <ChangelogFilter />
+
+  <div class="changelog-entries">
+
+{/************* 
+**Boilerplate** 
+***************/}
+
+    <ChangelogEntry
+      date="2026-02-19"
+      title="Boilerplate updates (B2C Suite6 / B2B Suite2)"
+      components={['Boilerplate']}
+    >
+      Content derived only from PR [#1096](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1096) (B2C → main) and PR [#1107](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1107) (B2B → b2b). No content copied from existing changelog.
+
+      **Breaking changes:**
+
+      - **Fragment block** - DOM replacement simplified to preserve block wrapper ([#576](https://github.com/hlxsites/aem-boilerplate-commerce/pull/576)); protocol-relative URLs in fragment loader prevented ([#577](https://github.com/hlxsites/aem-boilerplate-commerce/pull/577)).
+
+      **Infrastructure:**
+
+      - **@dropins/tools** - Upgraded to ~1.7.0 ([#1113](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1113)). Drop-in packages upgraded to stable releases (B2C [#1096](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1096), B2B [#1107](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1107)).
+
+      **Document Authoring:**
+
+      - **Universal Editor** - UE instrumentation for the rest of the blocks ([#1086](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1086)).
+
+      **Fixes and improvements:**
+
+      - **Fragment** - Preserve block wrapper; prevent protocol-relative URLs ([#576](https://github.com/hlxsites/aem-boilerplate-commerce/pull/576), [#577](https://github.com/hlxsites/aem-boilerplate-commerce/pull/577)).
+      - **Header** - Null guard for empty nav ([#581](https://github.com/hlxsites/aem-boilerplate-commerce/pull/581)).
+      - **Scripts/aem.js** - Updated to aem.js@2.10.6 ([#582](https://github.com/hlxsites/aem-boilerplate-commerce/pull/582)).
+      - **Enrichment** - When enrichment is after PLP, get urlpath another way instead of block config ([#1118](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1118)).
+      - **B2B address** - Use addressUid to avoid duplications ([#1112](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1112)).
+
+      **Merged PRs referenced in consolidation:** [#1057](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1057), [#1071](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1071), [#576](https://github.com/hlxsites/aem-boilerplate-commerce/pull/576), [#577](https://github.com/hlxsites/aem-boilerplate-commerce/pull/577), [#581](https://github.com/hlxsites/aem-boilerplate-commerce/pull/581), [#582](https://github.com/hlxsites/aem-boilerplate-commerce/pull/582), [#1040](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1040), [#1086](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1086), [#1095](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1095), [#1112](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1112), [#1113](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1113), [#1118](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1118).
+
+    </ChangelogEntry>
+
+  </div>
+</div>

--- a/src/content/docs/releases/test-index.mdx
+++ b/src/content/docs/releases/test-index.mdx
@@ -1,0 +1,143 @@
+---
+title: "Test: Release information"
+description: "Test: Learn about the compatibility, code changes, and public APIs for Commerce Storefront releases. Use for testing the release-notes skill with PRs 1096 (B2C) and 1107 (B2B)."
+---
+
+import Aside from '@components/Aside.astro';
+
+## Release suites
+
+Adobe organizes storefront application releases into logical suite versions and follows a regular release schedule (about twice a month). Adobe may release updates more frequently to address critical issues.
+
+The following sections provide high-level summaries of each release suite and details about the compatibility between storefront components. To see more details about each drop-in component by version, go to the [changelog](/releases/changelog/).
+
+## February 2026 suite (test)
+
+This suite builds on the January 2026 foundation with Document Authoring improvements, Universal Editor model v2 upgrade, and drop-in updates for B2C and B2B. For per-component version details, see the [changelog](/releases/changelog/). *(Test target: content derived from PRs [#1096](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1096) and [#1107](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1107) plus StorefrontSDK and manual Commerce Foundation data.)*
+
+<Aside type="caution" title="Breaking changes">
+- **Cards List block removed**: The `cards-list` block has been removed. Use the `cards` block instead.
+- **Fragment block behavior**: Fragment blocks now replace their content directly instead of the entire section wrapper, which may affect existing implementations.
+
+</Aside>
+
+### Highlights
+
+- **Document Authoring and Universal Editor**: Commerce blocks include JSON definitions with semantic field names, model v2 component definitions, automated Sidekick configuration, and support for visual authoring in Universal Editor and Document Authoring.
+- **Cart**: New `RowTotalFooter` slot for custom content after item row totals (loyalty points, rewards, custom pricing).
+- **Checkout**: Discounted shipping methods show original price with strikethrough; PlaceOrder supports async validation.
+- **User Account**: New translation keys for multi-line street address fields (`street`, `street_multiline_2`).
+- **User Auth**: Custom API error message overrides; enhanced Adobe Commerce Optimizer support.
+- **Order**: `gift_wrapping_available` field in product details for conditional gift options.
+- **Product Details Page**: Improved validation; downloadable product options support.
+- **B2B drop-ins**: All B2B components updated from v1.0.0 to v1.1.0 with SDK improvements and enhanced functionality.
+
+### Updated boilerplate
+
+#### Infrastructure
+
+- **GitHub Actions**: Workflow actions updated (checkout@v6, setup-node@v6).
+- **Sidekick**: Configuration is now automated; no manual setup required.
+- **Drop-in SDK upgrade**: `@dropins/tools` upgraded from ~1.6.0 to ~1.7.0 ([#1113](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1113)).
+
+#### Document Authoring
+
+- **Universal Editor model v2**: Upgraded component definitions ([#1086](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1086)).
+- **Commerce block definitions**: JSON definitions for Account Header, Account Sidebar, Addresses, Cart, Checkout, Mini Cart, Orders List, Wishlist, and more ([#1086](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1086)).
+- **Field naming**: Semantic names (`image`, `text`, `summary`) instead of CSS selector-based names ([#1086](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1086)).
+- **Enrichment block**: Category enrichment reads URL path from PLP block configuration and preserves wrapper in Universal Editor for continued authoring ([#1086](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1086)).
+- **PDP block**: `defaultSku` support in JSON definitions ([#1086](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1086)).
+- **PLP block**: `urlpath` configuration for category detection; no longer requires dataset attributes ([#1086](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1086)).
+
+#### Fixes and improvements
+
+- **Fragment block**: Replaces content directly, preserves wrapper ([#576](https://github.com/hlxsites/aem-boilerplate-commerce/pull/576)); handles external URLs correctly ([#577](https://github.com/hlxsites/aem-boilerplate-commerce/pull/577)).
+- **Header**: Null checks for missing navigation sections. Navigation closes on focusout for improved keyboard accessibility ([#581](https://github.com/hlxsites/aem-boilerplate-commerce/pull/581)).
+- **AEM Assets**: `createOptimizedPicture` handles protocol-relative URLs (`//`) ([#582](https://github.com/hlxsites/aem-boilerplate-commerce/pull/582)).
+- **PDP block**: Validates product data before rendering.
+- **B2B address handling**: Uses `addressUid` to prevent duplicate address entries during checkout ([#1112](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1112)).
+
+### Updated Drop-in SDK
+
+<Aside type="note" title="Internal Links">
+    The links to the StorefrontSDK repository will not resolve unless you have access to this repository.
+</Aside>
+
+The Drop-in SDK has been updated to include several new features and improvements.
+
+- **Custom content below row total** - Allow custom content below cart item row total price ([#162](https://github.com/adobe-commerce/StorefrontSDK/pull/162)).
+- **Price display fix** - Resolved issue with displaying prices.
+- **RadioButton icon support** - Added icon support to the RadioButton component.
+- **Picker component behavior** - Picker component is now disabled when only one option is available.
+
+### Updated drop-in components
+
+| Component | Improvements |
+|-----------|--------------|
+| [**Cart**](/dropins/cart/) v3.1.0 | New `RowTotalFooter` slot for custom content after item row totals ([#1095](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1095)) |
+| [**Checkout**](/dropins/checkout/) v3.1.0 | `Preferences` slot in LoginForm; discounted shipping shows original price with strikethrough; custom form field placeholders and floating labels; async `PlaceOrder.handleValidation`; Adyen Bancontact and payment extensions support ([#1095](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1095)) |
+| [**Order**](/dropins/order/) v3.1.0 | `gift_wrapping_available` field for conditional gift options ([#1095](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1095)) |
+| [**Product Details Page**](/dropins/product-details/) v3.0.1 | New `transform` and `transformer` props for options handling; downloadable product options; improved validation ([#1071](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1071)) |
+| [**User Account**](/dropins/user-account/) v3.1.0 | Address UID in create response; dynamic i18n for field labels and placeholders; improved accessibility ([#1057](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1057)) |
+| [**User Auth**](/dropins/user-auth/) v3.1.0 | `apiErrorMessageOverride` prop; Adobe Commerce Optimizer support ([#1095](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1095), [#1040](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1040)) |
+| [**Wishlist**](/dropins/wishlist/) v3.1.0 | Event bus package upgrade ([#1095](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1095)) |
+| [**Personalization**](/dropins/personalization/) v3.1.0 | Drop-in SDK ~1.7.0 upgrade; no user-facing changes |
+| [**Product Discovery**](/dropins/product-discovery/) v3.0.0 | Drop-in SDK ~1.7.0 upgrade; no user-facing changes |
+| [**Product Recommendations**](/dropins/recommendations/) v3.0.0 | Drop-in SDK ~1.7.0 upgrade; no user-facing changes |
+| [**Payment Services**](/dropins/payment-services/) v3.0.1 | Error handler resilience: promises now properly rejected when handler is not defined ([#38](https://github.com/adobe-commerce/storefront-payment-services/pull/38)) |
+
+### Updated B2B drop-in components
+
+| Component | Improvements |
+|-----------|--------------|
+| [**Company Management**](/dropins-b2b/company-management/) v1.1.0 | Drop-in SDK ~1.7.0 upgrade; no user-facing changes |
+| [**Company Switcher**](/dropins-b2b/company-switcher/) v1.1.0 | Drop-in SDK ~1.7.0 upgrade; no user-facing changes |
+| [**Purchase Order**](/dropins-b2b/purchase-order/) v1.1.0 | Event bus and Drop-in SDK ~1.7.0 upgrade |
+| [**Quote Management**](/dropins-b2b/quote-management/) v1.1.0 | `setQuoteTemplateExpirationDate` API; `ExpirationDateModal` component; `row_catalog_discount` field for catalog discounts; fixed dropdown selection in quote template items |
+| [**Requisition List**](/dropins-b2b/requisition-list/) v1.1.0 | Event bus and Drop-in SDK ~1.7.0 upgrade |
+
+### Known issues
+
+There are no known issues for this release suite.
+
+### Component compatibility
+
+Adobe has tested and verified the following component versions for this release suite. Commerce Foundation versions are from release/product spec (manual); drop-in versions from consolidation PRs and package.json.
+
+**Commerce Foundation**
+
+| Adobe Commerce | Storefront Compatibility Package |
+|----------------|----------------------------------|
+| `2.4.7`        | `4.7.11`                         |
+| `2.4.8`        | `4.8.15`                         |
+
+| Adobe Commerce B2B | Storefront Compatibility B2B Package |
+|--------------------|--------------------------------------|
+| `1.5.2`            | `1.0.16`                             |
+
+**Drop-in SDK**
+
+- `@dropins/tools@~1.7.0`
+- `@dropins/build-tools@~1.0.1`
+
+**B2C drop-ins**
+
+- `@dropins/storefront-account@~3.1.0`
+- `@dropins/storefront-auth@~3.1.0`
+- `@dropins/storefront-cart@~3.1.0`
+- `@dropins/storefront-checkout@~3.1.0`
+- `@dropins/storefront-order@~3.1.0`
+- `@dropins/storefront-payment-services@~3.0.1`
+- `@dropins/storefront-pdp@~3.0.1`
+- `@dropins/storefront-personalization@~3.1.0`
+- `@dropins/storefront-product-discovery@~3.0.0`
+- `@dropins/storefront-recommendations@~3.0.0`
+- `@dropins/storefront-wishlist@~3.1.0`
+
+**B2B drop-ins**
+
+- `@dropins/storefront-company-management@~1.1.0`
+- `@dropins/storefront-company-switcher@~1.1.0`
+- `@dropins/storefront-purchase-order@~1.1.0`
+- `@dropins/storefront-quote-management@~1.1.0`
+- `@dropins/storefront-requisition-list@~1.1.0`


### PR DESCRIPTION
Adds the March 2026 release suite and changelog entries.

**index.mdx**
- New March 2026 suite: highlights, updated boilerplate, B2C/B2B drop-in tables, component compatibility (SCP 4.7.11, 4.8.17, 1.0.18).
- Benefit-focused 404 wording for implementers.

**changelog.mdx**
- March entries for: Boilerplate, Cart, Product details page, Product Discovery, Wishlist, Quick Order, Requisition List.
- No entries for version-alignment-only components (Checkout, Order, User account, User auth).

**README.md**
- "Testing the skill" section: how to stash release files, regenerate from scratch, and compare with `git diff stash@{0} -- …`.

Made with [Cursor](https://cursor.com)

## Associated Jira Ticket

COMDOX-1663