### PR TITLE
Checkout: add additionalData fields to PaymentMethodRenderCtx

### DIFF
--- a/src/content/docs/dropins/checkout/containers/payment-methods.mdx
+++ b/src/content/docs/dropins/checkout/containers/payment-methods.mdx
@@ -85,6 +85,8 @@ export interface PaymentMethodsProps extends HTMLAttributes<HTMLDivElement>, Tit
   export interface PaymentMethodRenderCtx {
     cartId: string;
     replaceHTML: (domElement: HTMLElement) => void;
+    additionalData?: Record<string, unknown>;
+    setAdditionalData: (data: Record<string, unknown>) => void;
   }
 
   export interface PaymentMethodConfig {


### PR DESCRIPTION
## Purpose of this pull request

This pull request (PR) Adds additionalData (optional) and setAdditionalData to the PaymentMethodRenderCtx interface in the Payment Methods container documentation.

### Associated JIRA ticket

https://jira.corp.adobe.com/browse/ACCS-364

## Affected pages

https://experienceleague.adobe.com/developer/commerce/storefront/dropins/checkout/containers/payment-methods/

## Links to source code

https://github.com/adobe-commerce/storefront-checkout/pull/311 
