### PR TITLE
Revert "Add reCAPTCHA Enterprise info to UserAuth"

### DIFF
--- a/src/content/docs/dropins/user-auth/recaptcha.mdx
+++ b/src/content/docs/dropins/user-auth/recaptcha.mdx
@@ -8,9 +8,9 @@ import Tasks from '@components/Tasks.astro';
 import Task from '@components/Task.astro';
 import Screenshot from '@components/Screenshot.astro';
 
-The reCAPTCHA module enables reCAPTCHA protection, which is natively supported by Adobe Commerce. It also provides an API allowing merchants to integrate reCAPTCHA protection into custom implementations. The current version of the module supports only reCAPTCHA v3 Invisible and reCAPTCHA Enterprise V3 Invisible.
+The reCAPTCHA module enables reCAPTCHA protection, which is natively supported by Adobe Commerce. It also provides an API allowing merchants to integrate reCAPTCHA protection into custom implementations. The current version of the module supports only reCAPTCHA v3 Invisible.
 
-[Google reCAPTCHA V3](https://experienceleague.adobe.com/en/docs/commerce-admin/systems/security/captcha/security-google-recaptcha) and [Google reCAPTCHA Enterprise](https://experienceleague.adobe.com/en/docs/commerce-admin/systems/security/captcha/security-google-recaptcha-enterprise)in the _Admin Systems Guide_ describes how to configure Adobe Commerce.
+[Google reCAPTCHA](https://experienceleague.adobe.com/en/docs/commerce-admin/systems/security/captcha/security-google-recaptcha) in the _Admin Systems Guide_ describes how to configure Adobe Commerce.
 
 :::note[Using the Commerce Boilerplate?]
 The reCAPTCHA module is implemented in the [Commerce Boilerplate](https://experienceleague.adobe.com/developer/commerce/storefront/get-started/boilerplate-project/) within the `/scripts/initializers/index.js` file.


### PR DESCRIPTION
Reverts commerce-docs/microsite-commerce-storefront#699

ACCS support for reCAPTCHA Enterprise was added in January, but it's not actually in the boilerplate yet.