### PR TITLE
Recent updates to release notes changelog

### DIFF
--- a/src/components/changelog/ChangelogFilter.astro
+++ b/src/components/changelog/ChangelogFilter.astro
@@ -13,6 +13,7 @@ const allComponents = [
   'Product Discovery',
   'Product Recommendations',
   'Purchase Order',
+  'Quick Order',
   'Quote Management',
   'Requisition List',
   'Storefront Compatibility Package',

--- a/src/content/docs/dropins/checkout/containers/shipping-methods.mdx
+++ b/src/content/docs/dropins/checkout/containers/shipping-methods.mdx
@@ -70,7 +70,7 @@ export interface ShippingMethodsProps extends HTMLAttributes<HTMLDivElement>, Ti
 - The `UIComponentType` property is a string containing the name of the UI component type to be used as a selector for each shipping method. The available UI components are: `ToggleButton` or `RadioButton`.
 - The `slots (*)` property is inherited from the `TitleProps` interface. It is an object that contains the following properties:
   - Use the `Title (*)` property to render a custom title. This property is inherited from `TitleProps` interface.
-  - Use the `ShippingMethodItem` property to fully replace the default UI for each shipping method (for example, add an icon, description, or badge next to the price). The slot receives `method`, `isSelected`, and `onSelect`, and at runtime **`busy`** while the option list is in a loading or sync state—disable custom controls when `busy` is true. See [ShippingMethods slots](/dropins/checkout/slots/#shippingmethods-slots) for details and examples.
+  - Use the `ShippingMethodItem` property to fully replace the default UI for each shipping method (for example, add an icon, description, or badge next to the price). The slot receives `method`, `isSelected`, and `onSelect`, and at runtime **`busy`** while pending checkout updates or a pending shipping estimate would block interaction—disable custom controls when `busy` is true. The published TypeScript type for the slot context may omit `busy`; it is still set at runtime. See [ShippingMethods slots](/dropins/checkout/slots/#shippingmethods-slots) for details and examples.
 
 ### ShippingMethod model
 

--- a/src/content/docs/dropins/checkout/containers/shipping-methods.mdx
+++ b/src/content/docs/dropins/checkout/containers/shipping-methods.mdx
@@ -24,7 +24,7 @@ The `ShippingMethods` container provides the following configuration options:
     ['autoSync', 'boolean', 'No', 'Synchronizes/does not synchronize the container local state with the backend (default value is true).'],
     ['onCartSyncError', 'function', 'No', 'A function that takes a ShippingMethod object and an error as arguments. It is called when the setShippingMethodsOnCart() API throws an error when a shipping method is selected to be stored to the backend.'],
     ['onSelectionChange', 'function', 'No', 'A function that takes a ShippingMethod object as an argument. It is called when a shipping method is selected.'],
-    ['slots (*)', 'object', 'No', 'Object with the title to be displayed on the `ShippingMethods` container and optional `ShippingMethodItem` slot for custom UI. See [ShippingMethods slots](/dropins/checkout/slots/#shippingmethods-slots).'],
+    ['slots (*)', 'object', 'No', 'Object with the title to be displayed on the `ShippingMethods` container and optional `ShippingMethodItem` slot for a fully custom row per method (icons, descriptions, badges, layout) while keeping selection behavior. See [ShippingMethods slots](/dropins/checkout/slots/#shippingmethods-slots).'],
     ['UIComponentType', 'string', 'No', 'String with the UI component type to be used as selector (default value is \'RadioButton\').'],
   ]}
 />
@@ -43,6 +43,13 @@ interface CartSyncError {
   error: Error;
 }
 
+/** Context for the ShippingMethodItem slot (see published .d.ts; runtime may include additional fields such as `busy`). */
+export interface ShippingMethodItemContext {
+  method: ShippingMethod;
+  isSelected: boolean;
+  onSelect: () => void;
+}
+
 export interface ShippingMethodsProps extends HTMLAttributes<HTMLDivElement>, TitleProps {
   active?: boolean;
   autoSync?: boolean;
@@ -59,11 +66,11 @@ export interface ShippingMethodsProps extends HTMLAttributes<HTMLDivElement>, Ti
 - Set the `active` property to _true_ to have the container in reactive mode (it is visible and responds to system events). If it is set to _false_, the container is deactivated (it does not subscribe to system events and is not rendered).
 - Set the `autoSync` property to _true_ to automatically synchronize the container state changes with the backend via API calls. If it is set to _false_ the container does not automatically synchronize its state, but still maintains local updates.
 - The `onCartSyncError` property is a handler used to perform actions called when a shipping method is selected and the setShippingMethodsOnCart() API throws an error. It could be used in the integration layer by the merchant to show errors.
--The `onSelectionChange` property is a handler used to perform actions called when a shipping method is selected.
+- The `onSelectionChange` property is a handler used to perform actions called when a shipping method is selected.
 - The `UIComponentType` property is a string containing the name of the UI component type to be used as a selector for each shipping method. The available UI components are: `ToggleButton` or `RadioButton`.
 - The `slots (*)` property is inherited from the `TitleProps` interface. It is an object that contains the following properties:
   - Use the `Title (*)` property to render a custom title. This property is inherited from `TitleProps` interface.
-  - Use the `ShippingMethodItem` property to fully replace the default UI for each shipping method. See [ShippingMethods slots](/dropins/checkout/slots/#shippingmethods-slots) for details and examples.
+  - Use the `ShippingMethodItem` property to fully replace the default UI for each shipping method (for example, add an icon, description, or badge next to the price). The slot receives `method`, `isSelected`, and `onSelect`, and at runtime **`busy`** while the option list is in a loading or sync state—disable custom controls when `busy` is true. See [ShippingMethods slots](/dropins/checkout/slots/#shippingmethods-slots) for details and examples.
 
 ### ShippingMethod model
 

--- a/src/content/docs/dropins/checkout/containers/shipping-methods.mdx
+++ b/src/content/docs/dropins/checkout/containers/shipping-methods.mdx
@@ -43,7 +43,7 @@ interface CartSyncError {
   error: Error;
 }
 
-/** Context for the ShippingMethodItem slot (see published .d.ts; runtime may include additional fields such as `busy`). */
+/** Context for the ShippingMethodItem slot (published `ShippingMethodItemContext`). */
 export interface ShippingMethodItemContext {
   method: ShippingMethod;
   isSelected: boolean;
@@ -70,7 +70,7 @@ export interface ShippingMethodsProps extends HTMLAttributes<HTMLDivElement>, Ti
 - The `UIComponentType` property is a string containing the name of the UI component type to be used as a selector for each shipping method. The available UI components are: `ToggleButton` or `RadioButton`.
 - The `slots (*)` property is inherited from the `TitleProps` interface. It is an object that contains the following properties:
   - Use the `Title (*)` property to render a custom title. This property is inherited from `TitleProps` interface.
-  - Use the `ShippingMethodItem` property to fully replace the default UI for each shipping method (for example, add an icon, description, or badge next to the price). The slot receives `method`, `isSelected`, and `onSelect`, and at runtime **`busy`** while pending checkout updates or a pending shipping estimate would block interaction—disable custom controls when `busy` is true. The published TypeScript type for the slot context may omit `busy`; it is still set at runtime. See [ShippingMethods slots](/dropins/checkout/slots/#shippingmethods-slots) for details and examples.
+  - Use the `ShippingMethodItem` property to fully replace the default UI for each shipping method (for example, add an icon, description, or badge next to the price). The slot context provides `method`, `isSelected`, and `onSelect` per `ShippingMethodItemContext`. See [ShippingMethods slots](/dropins/checkout/slots/#shippingmethods-slots) for details, including how `busy` relates to the internal presentation component rather than the slot context.
 
 ### ShippingMethod model
 

--- a/src/content/docs/dropins/checkout/extending.mdx
+++ b/src/content/docs/dropins/checkout/extending.mdx
@@ -20,13 +20,27 @@ export {
   BILLING_CART_ADDRESS_FRAGMENT,
   SHIPPING_CART_ADDRESS_FRAGMENT,
 } from '@/checkout/api/graphql/CartAddressFragment.graphql';
+export { CHECKOUT_DATA_FRAGMENT } from '@/checkout/api/graphql/CheckoutDataFragment.graphql';
+export { CUSTOMER_FRAGMENT } from '@/checkout/api/graphql/CustomerFragment.graphql';
+export {
+  NEGOTIABLE_QUOTE_BILLING_ADDRESS_FRAGMENT,
+  NEGOTIABLE_QUOTE_SHIPPING_ADDRESS_FRAGMENT,
+} from '@/checkout/api/graphql/NegotiableQuoteAddressFragment.graphql';
+export { NEGOTIABLE_QUOTE_FRAGMENT } from '@/checkout/api/graphql/NegotiableQuoteFragment.graphql';
 export {
   AVAILABLE_PAYMENT_METHOD_FRAGMENT,
   SELECTED_PAYMENT_METHOD_FRAGMENT,
-} from '@/checkout/api/graphql/CartPaymentMethodFragment.graphql';
-export { CHECKOUT_DATA_FRAGMENT } from '@/checkout/api/graphql/CheckoutDataFragment.graphql';
-export { CUSTOMER_FRAGMENT } from '@/checkout/api/graphql/CustomerFragment.graphql';
+} from '@/checkout/api/graphql/PaymentMethodFragment.graphql';
+export {
+  AVAILABLE_SHIPPING_METHOD_FRAGMENT,
+  ESTIMATE_SHIPPING_METHOD_FRAGMENT,
+  SELECTED_SHIPPING_METHOD_FRAGMENT,
+} from '@/checkout/api/graphql/ShippingMethodFragment.graphql';
 ```
+
+The fragment **names** above match the symbols exported from **`@dropins/storefront-checkout`** (for example the package **`fragments`** entry). The **`@/checkout/...` import paths** reflect the checkout drop-in **source** layout; in your storefront, point **`build.mjs`** at the same fragment **names** using whatever **`fragments.ts`** path and re-exports your scaffold provides.
+
+The **`ESTIMATE_SHIPPING_METHOD_FRAGMENT`** applies to the **`estimateShippingMethods`** mutation. Pair it with the **`EstimateShippingModel`** initializer model when you need to transform extended fields from the shipping estimate response. **`AVAILABLE_SHIPPING_METHOD_FRAGMENT`** and **`SELECTED_SHIPPING_METHOD_FRAGMENT`** cover cart shipping methods on the main checkout flow.
 
 ### Extend or customize a fragment
 

--- a/src/content/docs/dropins/checkout/extending.mdx
+++ b/src/content/docs/dropins/checkout/extending.mdx
@@ -38,9 +38,9 @@ export {
 } from '@/checkout/api/graphql/ShippingMethodFragment.graphql';
 ```
 
-The fragment **names** above match the symbols exported from **`@dropins/storefront-checkout`** (for example the package **`fragments`** entry). The **`@/checkout/...` import paths** reflect the checkout drop-in **source** layout; in your storefront, point **`build.mjs`** at the same fragment **names** using whatever **`fragments.ts`** path and re-exports your scaffold provides.
+The fragment names above match the symbols exported from `@dropins/storefront-checkout` (for example the package `fragments` entry). The `@/checkout/...` import paths reflect the checkout drop-in source layout; in your storefront, point `build.mjs` at the same fragment names using whatever `fragments.ts` path and re-exports your scaffold provides.
 
-The **`ESTIMATE_SHIPPING_METHOD_FRAGMENT`** applies to the **`estimateShippingMethods`** mutation. Pair it with the **`EstimateShippingModel`** initializer model when you need to transform extended fields from the shipping estimate response. **`AVAILABLE_SHIPPING_METHOD_FRAGMENT`** and **`SELECTED_SHIPPING_METHOD_FRAGMENT`** cover cart shipping methods on the main checkout flow.
+The `ESTIMATE_SHIPPING_METHOD_FRAGMENT` applies to the `estimateShippingMethods` mutation. Pair it with the `EstimateShippingModel` initializer model when you need to transform extended fields from the shipping estimate response. `AVAILABLE_SHIPPING_METHOD_FRAGMENT` and `SELECTED_SHIPPING_METHOD_FRAGMENT` cover cart shipping methods on the main checkout flow.
 
 ### Extend or customize a fragment
 

--- a/src/content/docs/dropins/checkout/slots.mdx
+++ b/src/content/docs/dropins/checkout/slots.mdx
@@ -161,7 +161,6 @@ interface ShippingMethodsProps {
     ShippingMethodItem?: SlotProps<{
       method: ShippingMethod;
       isSelected: boolean;
-      busy?: boolean;
       onSelect: () => void;
     }>;
   };
@@ -172,12 +171,13 @@ interface ShippingMethodsProps {
 
 The ShippingMethodItem slot allows you to replace the default RadioButton or ToggleButton UI for each shipping method with a completely custom element. Use `ctx.replaceWith()` to provide your own UI and `ctx.onRender()` to update it when the context changes.
 
-The slot receives a context with the following properties:
+The slot receives a `ShippingMethodItemContext` with the following properties:
 
 - `method` - The shipping method data (`ShippingMethod` model with carrier, amount, title, and so on.)
 - `isSelected` - Whether this method is currently selected
-- `busy` - When true, the container is waiting on pending checkout updates or a pending shipping estimate; disable interaction in custom UI to match the default behavior (the published `.d.ts` may not list this property, but the runtime context includes it)
 - `onSelect` - Callback that selects this shipping method and triggers the API call to set it on the cart
+
+The internal presentation component that renders the list also accepts a `busy` flag (see the checkout drop-in `ShippingMethods` UI props) when the flow is waiting on pending checkout updates or a shipping estimate. That state is not part of `ShippingMethodItemContext`.
 
 #### Example
 

--- a/src/content/docs/dropins/checkout/slots.mdx
+++ b/src/content/docs/dropins/checkout/slots.mdx
@@ -161,6 +161,7 @@ interface ShippingMethodsProps {
     ShippingMethodItem?: SlotProps<{
       method: ShippingMethod;
       isSelected: boolean;
+      busy?: boolean;
       onSelect: () => void;
     }>;
   };
@@ -175,6 +176,7 @@ The slot receives a context with the following properties:
 
 - `method` - The shipping method data (`ShippingMethod` model with carrier, amount, title, and so on.)
 - `isSelected` - Whether this method is currently selected
+- `busy` - When true, the list is in a loading or synchronization state; disable interaction in custom UI to match the default behavior
 - `onSelect` - Callback that selects this shipping method and triggers the API call to set it on the cart
 
 #### Example

--- a/src/content/docs/dropins/checkout/slots.mdx
+++ b/src/content/docs/dropins/checkout/slots.mdx
@@ -176,7 +176,7 @@ The slot receives a context with the following properties:
 
 - `method` - The shipping method data (`ShippingMethod` model with carrier, amount, title, and so on.)
 - `isSelected` - Whether this method is currently selected
-- `busy` - When true, the list is in a loading or synchronization state; disable interaction in custom UI to match the default behavior
+- `busy` - When true, the container is waiting on pending checkout updates or a pending shipping estimate; disable interaction in custom UI to match the default behavior (the published `.d.ts` may not list this property, but the runtime context includes it)
 - `onSelect` - Callback that selects this shipping method and triggers the API call to set it on the cart
 
 #### Example

--- a/src/content/docs/releases/changelog.mdx
+++ b/src/content/docs/releases/changelog.mdx
@@ -353,9 +353,9 @@ import Link from '@components/Link.astro';
     >
       The Checkout drop-in has been updated with the following changes:
 
-      - **ShippingMethods** ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)) - New **`ShippingMethodItem` slot** to replace the default radio/toggle UI per method while keeping selection wired to the API (`replaceWith`, `onSelect`, `onRender`). Use it to add icons, descriptions, badges, or fully custom layout. The slot context includes **`busy`** at runtime when pending checkout updates or a shipping estimate would block interaction. See [Shipping methods](/dropins/checkout/containers/shipping-methods/) and [ShippingMethods slots](/dropins/checkout/slots/#shippingmethods-slots).
+      - **ShippingMethods** ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)) - New `ShippingMethodItem` slot to replace the default radio/toggle UI per method while keeping selection wired to the API (`replaceWith`, `onSelect`, `onRender`). Use it to add icons, descriptions, badges, or a fully custom layout. Slot context follows `ShippingMethodItemContext` (`method`, `isSelected`, `onSelect`). A separate `busy` flag is applied on the internal shipping-methods UI component when updates or an estimate are pending, not on the slot context. See [Shipping methods](/dropins/checkout/containers/shipping-methods/) and [ShippingMethods slots](/dropins/checkout/slots/#shippingmethods-slots).
 
-      - **estimateShippingMethods** ([#307](https://github.com/adobe-commerce/storefront-checkout/pull/307)) - GraphQL extensibility for the **`estimateShippingMethods`** mutation via the **`EstimateShippingModel`** model and **`ESTIMATE_SHIPPING_METHOD_FRAGMENT`**, so you can extend the shipping estimate payload at build time. See [Extending the checkout drop-in](/dropins/checkout/extending/).
+      - **estimateShippingMethods** ([#307](https://github.com/adobe-commerce/storefront-checkout/pull/307)) - GraphQL extensibility for the `estimateShippingMethods` mutation via the `EstimateShippingModel` model and `ESTIMATE_SHIPPING_METHOD_FRAGMENT`, so you can extend the shipping estimate payload at build time. See [Extending the checkout drop-in](/dropins/checkout/extending/).
 
     </ChangelogEntry>
 

--- a/src/content/docs/releases/changelog.mdx
+++ b/src/content/docs/releases/changelog.mdx
@@ -27,19 +27,19 @@ import Link from '@components/Link.astro';
 
       **Infrastructure**
       - **Build tools**: `@dropins/build-tools` upgraded from ~1.0.1 to ~1.1.0 ([#1152](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1152)).
-      - **Default assets**: Assets enabled flag now defaults to true ([#1114](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1114)).
-      - **Site config**: Removed folders ref from default-site.json ([#1148](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1148)).
+      - **Default assets**: The assets enabled flag now defaults to true ([#1114](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1114)).
+      - **Site config**: Removed the `folders` reference from default-site.json ([#1148](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1148)).
 
       **Fixes and improvements**
       - **PDP block**: Video support out of the box for product media ([#1100](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1100)).
-      - **PLP block**: Page size configurable via block configuration; defaults to 9 ([#1143](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1143)).
+      - **PLP block**: The page size is configurable via the block configuration; defaults to 9 ([#1143](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1143)).
       - **404 handling**: Non-existent pages now return a correct server-rendered 404 so crawlers and tools receive the right HTTP status ([#1134](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1134)).
       - **Layout**: Full-width sections and padding-based gutters in columns ([#1133](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1133)).
-      - **URL manipulation**: URL handling moved to boilerplate ([#1119](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1119)).
+      - **URL manipulation**: URL handling moved to the boilerplate ([#1119](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1119)).
       - **Wishlist**: Multi-store wishlist drop-in integration ([#1139](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1139)).
-      - **Demo config**: Adobe Commerce Optimizer flag added to demo-config-aco.json ([#1124](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1124)).
-      - **B2B (Cart)**: View wishlist link includes store code prefix in PDP and Cart blocks ([#1130](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1130)); cart state cleared when switching websites to prevent 403 errors ([#1137](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1137)).
-      - **B2B (Quick Order)**: Quick Order drop-in integrated into boilerplate ([#1125](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1125), [#1156](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156)).
+      - **Demo config**: The Adobe Commerce Optimizer flag was added to demo-config-aco.json ([#1124](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1124)).
+      - **B2B (Cart)**: The View wishlist link includes the store code prefix in the PDP and Cart blocks ([#1130](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1130)). The cart state is cleared when switching websites to prevent 403 errors ([#1137](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1137)).
+      - **B2B (Quick Order)**: The Quick Order drop-in is integrated into the boilerplate ([#1125](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1125), [#1156](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156)).
     </ChangelogEntry>
 
     <ChangelogEntry
@@ -364,7 +364,7 @@ import Link from '@components/Link.astro';
     >
       The Checkout drop-in has been updated with the following changes:
 
-      - **ShippingMethods** ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)) - New `ShippingMethodItem` slot replaces the default radio/toggle UI per method while keeping selection wired to the API (`replaceWith`, `onSelect`, `onRender`). Slot context is `ShippingMethodItemContext` (`method`, `isSelected`, `onSelect`). The `busy` flag applies to the internal shipping-methods UI when updates or an estimate are pending, not to the slot context. See [Shipping methods](/dropins/checkout/containers/shipping-methods/) and [ShippingMethods slots](/dropins/checkout/slots/#shippingmethods-slots).
+      - **ShippingMethods** ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)) - A new `ShippingMethodItem` slot replaces the default radio/toggle UI per method while keeping selection wired to the API (`replaceWith`, `onSelect`, `onRender`). The slot context is `ShippingMethodItemContext` (`method`, `isSelected`, `onSelect`). The `busy` flag applies to the internal shipping-methods UI when updates or an estimate are pending, not to the slot context. See [Shipping methods](/dropins/checkout/containers/shipping-methods/) and [ShippingMethods slots](/dropins/checkout/slots/#shippingmethods-slots).
 
       - **estimateShippingMethods** ([#307](https://github.com/adobe-commerce/storefront-checkout/pull/307)) - Extend the shipping estimate payload at build time using `ESTIMATE_SHIPPING_METHOD_FRAGMENT` and the `EstimateShippingModel` initializer. See [Extending the checkout drop-in](/dropins/checkout/extending/).
 
@@ -1342,9 +1342,9 @@ import Link from '@components/Link.astro';
     >
       The Product Details Page drop-in has been updated with the following changes:
 
-      - **Video support** - Out-of-the-box video support in the [ProductGallery](/dropins/product-details/containers/product-gallery/) container. The container now accepts a `videos` prop: use `videos={true}` or `videos={{ position: 'last' }}` for videos after images, or `videos={{ position: 'first' }}` for videos before images; omit or set `videos={false}` for backward compatibility. Supports direct video files (for example .mp4, .webm), YouTube, Vimeo, and AEM Assets. The `CarouselMainImage` and `CarouselThumbnail` slots receive `mediaType` ('image' | 'video') and `previewUrl` for custom rendering ([#57](https://github.com/adobe-commerce/storefront-pdp/pull/57)). Boilerplate integration ([#1100](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1100)).
-      - **ProductOptions transformer prop** - New `transformer` prop on the ProductOptions container lets you modify product options data before rendering, enabling conversion of dropdown options to radio swatches (text, image, or color) at the container level ([#51](https://github.com/adobe-commerce/storefront-pdp/pull/51)).
-      - **getProductsData API** - New `getProductsData` API method for the Quick Order (B2B) drop-in, using the same data model and GraphQL fragment as `getProductData` ([#56](https://github.com/adobe-commerce/storefront-pdp/pull/56)).
+      - **Video support** - Out-of-the-box video support in the [ProductGallery](/dropins/product-details/containers/product-gallery/) container. The container now accepts a `videos` prop: use `videos={true}` or `videos={{ position: 'last' }}` for videos after images, or `videos={{ position: 'first' }}` for videos before images; omit or set `videos={false}` for backward compatibility. Supports direct video files (for example, .mp4, .webm), YouTube, Vimeo, and AEM Assets. The `CarouselMainImage` and `CarouselThumbnail` slots receive `mediaType` ('image' | 'video') and `previewUrl` for custom rendering ([#57](https://github.com/adobe-commerce/storefront-pdp/pull/57)). Includes the boilerplate integration ([#1100](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1100)).
+      - **ProductOptions transformer prop** - A new `transformer` prop on the ProductOptions container lets you modify product options data before rendering, enabling conversion of dropdown options to radio swatches (text, image, or color) at the container level ([#51](https://github.com/adobe-commerce/storefront-pdp/pull/51)).
+      - **getProductsData API** - A new `getProductsData` API method for the Quick Order (B2B) drop-in, using the same data model and GraphQL fragment as `getProductData` ([#56](https://github.com/adobe-commerce/storefront-pdp/pull/56)).
     </ChangelogEntry>
 
     <ChangelogEntry
@@ -1418,9 +1418,9 @@ import Link from '@components/Link.astro';
       The Product Discovery drop-in has been updated with the following changes:
 
       - **Pathname with store code** - Pathname handling is fixed when the store code is present in the URL. The condition that checks whether the pathname ends with `search` was corrected, so category detection and quick search work correctly in multi-store setups ([#88](https://github.com/adobe-commerce/storefront-search-dropin/pull/88), [#91](https://github.com/adobe-commerce/storefront-search-dropin/pull/91)).
-      - **Filter state and pagination** - URL manipulation has been moved out of the drop-in into the boilerplate. Filter state resets to page 1 when filters change, and the function defaults to page one for consistent pagination ([#86](https://github.com/adobe-commerce/storefront-search-dropin/pull/86)). Boilerplate integration ([#1119](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1119)).
-      - **PLP page size** - Page size is configurable via block configuration and defaults to 9; includes instrumentation for Universal Editor ([#1143](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1143)).
-      - **Custom PLP attributes** - Add custom product attributes to the product listing page ([#89](https://github.com/adobe-commerce/storefront-search-dropin/pull/89)).
+      - **Filter state and pagination** - URL manipulation has been moved out of the drop-in into the boilerplate. Filter state resets to page one when filters change, and the function defaults to page one for consistent pagination ([#86](https://github.com/adobe-commerce/storefront-search-dropin/pull/86)). Includes the boilerplate integration ([#1119](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1119)).
+      - **PLP page size** - The page size is configurable via the block configuration and defaults to 9. It includes instrumentation for the Universal Editor ([#1143](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1143)).
+      - **Custom PLP attributes** - Custom product attributes can be added to the product listing page ([#89](https://github.com/adobe-commerce/storefront-search-dropin/pull/89)).
     </ChangelogEntry>
 
     <ChangelogEntry
@@ -1638,7 +1638,7 @@ import Link from '@components/Link.astro';
     >
       The Wishlist drop-in has been updated with the following changes:
 
-      - **Multi-store wishlist** - The drop-in now supports multi-store scenarios. Pass an optional `storeCode` config prop during [initialization](/dropins/wishlist/initialization/) (the boilerplate reads it from the AEM config system and passes it into the drop-in). When `storeCode` is set and not `'default'`, localStorage and sessionStorage keys and wishlist ID cookies are scoped per store (for example `DROPIN__WISHLIST__WISHLIST__DATA__` plus the store code), so guest and authenticated wishlist data stay isolated between store views. Single-store setups and the `'default'` store continue using the original unscoped keys for backward compatibility ([#73](https://github.com/adobe-commerce/storefront-wishlist/pull/73)). Boilerplate integration ([#1139](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1139)).
+      - **Multi-store wishlist** - The drop-in now supports multi-store scenarios. Pass an optional `storeCode` config prop during [initialization](/dropins/wishlist/initialization/) (the boilerplate reads it from the AEM config system and passes it into the drop-in). When `storeCode` is set and not `'default'`, localStorage and sessionStorage keys and wishlist ID cookies are scoped per store (for example, `DROPIN__WISHLIST__WISHLIST__DATA__` plus the store code), so guest and authenticated wishlist data stay isolated between store views. Single-store setups and the `'default'` store continue using the original unscoped keys for backward compatibility ([#73](https://github.com/adobe-commerce/storefront-wishlist/pull/73)). Includes the boilerplate integration ([#1139](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1139)).
     </ChangelogEntry>
 
     <ChangelogEntry
@@ -2069,7 +2069,7 @@ import Link from '@components/Link.astro';
       title="Quick Order v1.0.0"
       components={['Quick Order']}
     >
-      **New Quick Order drop-in** for B2B bulk ordering. The [Quick Order](/dropins-b2b/quick-order/) drop-in has been integrated into the boilerplate, enabling B2B users to add products to cart by SKU or product name in bulk ([#1125](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1125), [#1156](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156)).
+      **New Quick Order drop-in** for B2B bulk ordering. The [Quick Order](/dropins-b2b/quick-order/) drop-in has been integrated into the boilerplate, enabling B2B users to add products in bulk to the cart by SKU or product name. It has feature parity with Luma Quick Order and Grid Ordering for configurable products ([#1125](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1125), [#1156](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156)).
 
       - **Language definition merge fix** - User-provided `langDefinitions` passed to the initializer are now correctly merged with the drop-in's bundled defaults. Label and placeholder overrides take effect as expected ([#23](https://github.com/adobe-commerce/storefront-quick-order/pull/23)).
     </ChangelogEntry>

--- a/src/content/docs/releases/changelog.mdx
+++ b/src/content/docs/releases/changelog.mdx
@@ -353,7 +353,7 @@ import Link from '@components/Link.astro';
     >
       The Checkout drop-in has been updated with the following changes:
 
-      - **ShippingMethods** ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)) - New **`ShippingMethodItem` slot** to replace the default radio/toggle UI per method while keeping selection wired to the API (`replaceWith`, `onSelect`, `onRender`). Use it to add icons, descriptions, badges, or fully custom layout. The slot context includes **`busy`** at runtime while methods are loading or syncing. See [Shipping methods](/dropins/checkout/containers/shipping-methods/) and [ShippingMethods slots](/dropins/checkout/slots/#shippingmethods-slots).
+      - **ShippingMethods** ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)) - New **`ShippingMethodItem` slot** to replace the default radio/toggle UI per method while keeping selection wired to the API (`replaceWith`, `onSelect`, `onRender`). Use it to add icons, descriptions, badges, or fully custom layout. The slot context includes **`busy`** at runtime when pending checkout updates or a shipping estimate would block interaction. See [Shipping methods](/dropins/checkout/containers/shipping-methods/) and [ShippingMethods slots](/dropins/checkout/slots/#shippingmethods-slots).
 
       - **estimateShippingMethods** ([#307](https://github.com/adobe-commerce/storefront-checkout/pull/307)) - GraphQL extensibility for the **`estimateShippingMethods`** mutation via the **`EstimateShippingModel`** model and **`ESTIMATE_SHIPPING_METHOD_FRAGMENT`**, so you can extend the shipping estimate payload at build time. See [Extending the checkout drop-in](/dropins/checkout/extending/).
 

--- a/src/content/docs/releases/changelog.mdx
+++ b/src/content/docs/releases/changelog.mdx
@@ -353,7 +353,9 @@ import Link from '@components/Link.astro';
     >
       The Checkout drop-in has been updated with the following changes:
 
-      - **`PaymentMethodRenderCtx`** - The interface now includes `cartId: string`, `replaceHTML: (domElement: HTMLElement) => void`, `additionalData?: Record<string, unknown>`, and `setAdditionalData: (data: Record<string, unknown>) => void`. See [PaymentMethods](/dropins/checkout/containers/payment-methods/).
+      - **ShippingMethods** ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)) - New **`ShippingMethodItem` slot** to replace the default radio/toggle UI per method while keeping selection wired to the API (`replaceWith`, `onSelect`, `onRender`). Use it to add icons, descriptions, badges, or fully custom layout. The slot context includes **`busy`** at runtime while methods are loading or syncing. See [Shipping methods](/dropins/checkout/containers/shipping-methods/) and [ShippingMethods slots](/dropins/checkout/slots/#shippingmethods-slots).
+
+      - **estimateShippingMethods** ([#307](https://github.com/adobe-commerce/storefront-checkout/pull/307)) - GraphQL extensibility for the **`estimateShippingMethods`** mutation via the **`EstimateShippingModel`** model and **`ESTIMATE_SHIPPING_METHOD_FRAGMENT`**, so you can extend the shipping estimate payload at build time. See [Extending the checkout drop-in](/dropins/checkout/extending/).
 
     </ChangelogEntry>
 

--- a/src/content/docs/releases/changelog.mdx
+++ b/src/content/docs/releases/changelog.mdx
@@ -19,7 +19,7 @@ import Link from '@components/Link.astro';
 ***************/}
 
     <ChangelogEntry
-      date="2026-03-19"
+      date="2026-03-24"
       title="Boilerplate Updates"
       components={['Boilerplate']}
     >
@@ -256,7 +256,7 @@ import Link from '@components/Link.astro';
 ********/}
 
     <ChangelogEntry
-      date="2026-03-19"
+      date="2026-03-24"
       title="Cart v3.2.0"
       components={['Cart']}
     >
@@ -345,6 +345,17 @@ import Link from '@components/Link.astro';
 {/**********
 **Checkout** 
 ************/}
+
+    <ChangelogEntry
+      date="2026-03-24"
+      title="Checkout v3.2.0"
+      components={['Checkout']}
+    >
+      The Checkout drop-in has been updated with the following changes:
+
+      - **`PaymentMethodRenderCtx`** - The interface now includes `cartId: string`, `replaceHTML: (domElement: HTMLElement) => void`, `additionalData?: Record<string, unknown>`, and `setAdditionalData: (data: Record<string, unknown>) => void`. See [PaymentMethods](/dropins/checkout/containers/payment-methods/).
+
+    </ChangelogEntry>
 
     <ChangelogEntry
       date="2026-02-17"
@@ -590,7 +601,7 @@ import Link from '@components/Link.astro';
 ************************************/}
 
       <ChangelogEntry
-          date="2026-03-19"
+          date="2026-03-24"
           title="Storefront Compatibility Package v4.8.17"
           components={['Storefront Compatibility Package']}
       >
@@ -860,7 +871,7 @@ import Link from '@components/Link.astro';
 ************************************/}
 
       <ChangelogEntry
-          date="2026-03-19"
+          date="2026-03-24"
           title="Storefront Compatibility B2B Package v1.0.18"
           components={['Storefront Compatibility B2B Package']}
       >
@@ -1251,7 +1262,7 @@ import Link from '@components/Link.astro';
 *******************/}
 
     <ChangelogEntry
-      date="2026-03-19"
+      date="2026-03-24"
       title="Personalization v3.1.1"
       components={['Personalization']}
     >
@@ -1312,7 +1323,7 @@ import Link from '@components/Link.astro';
 ************************/}
 
     <ChangelogEntry
-      date="2026-03-19"
+      date="2026-03-24"
       title="Product details page v3.0.2"
       components={['Product details page']}
     >
@@ -1387,7 +1398,7 @@ import Link from '@components/Link.astro';
 *********************/}
 
     <ChangelogEntry
-      date="2026-03-19"
+      date="2026-03-24"
       title="Product Discovery v3.1.0"
       components={['Product Discovery']}
     >
@@ -1607,7 +1618,7 @@ import Link from '@components/Link.astro';
 ************/}
 
     <ChangelogEntry
-      date="2026-03-19"
+      date="2026-03-24"
       title="Wishlist v3.2.0"
       components={['Wishlist']}
     >
@@ -1786,7 +1797,7 @@ import Link from '@components/Link.astro';
 **********************/}
 
     <ChangelogEntry
-      date="2026-03-19"
+      date="2026-03-24"
       title="Company Management v1.2.0"
       components={['Company Management']}
     >
@@ -1852,7 +1863,7 @@ import Link from '@components/Link.astro';
 ********************/}
 
     <ChangelogEntry
-      date="2026-03-19"
+      date="2026-03-24"
       title="Company Switcher v1.1.1"
       components={['Company Switcher']}
     >
@@ -1906,7 +1917,7 @@ import Link from '@components/Link.astro';
 ******************/}
 
     <ChangelogEntry
-      date="2026-03-19"
+      date="2026-03-24"
       title="Purchase Order v1.1.1"
       components={['Purchase Order']}
     >
@@ -1964,7 +1975,7 @@ import Link from '@components/Link.astro';
 ********************/}
 
     <ChangelogEntry
-      date="2026-03-19"
+      date="2026-03-24"
       title="Quote Management v1.1.1"
       components={['Quote Management']}
     >
@@ -2040,7 +2051,7 @@ import Link from '@components/Link.astro';
 *********************/}
 
     <ChangelogEntry
-      date="2026-03-19"
+      date="2026-03-24"
       title="Quick Order v1.0.0"
       components={['Requisition List']}
     >
@@ -2050,7 +2061,7 @@ import Link from '@components/Link.astro';
     </ChangelogEntry>
 
     <ChangelogEntry
-      date="2026-03-19"
+      date="2026-03-24"
       title="Requisition List v1.2.0"
       components={['Requisition List']}
     >

--- a/src/content/docs/releases/changelog.mdx
+++ b/src/content/docs/releases/changelog.mdx
@@ -211,6 +211,17 @@ import Link from '@components/Link.astro';
 *****************/}
 
     <ChangelogEntry
+      date="2026-03-24"
+      title="Drop-in SDK (Elsie) v1.8.0"
+      components={['Drop-in SDK']}
+    >
+      The Drop-in SDK (Elsie) has been updated with the following changes:
+
+      - **Internal build pipeline** - Improvements to the build pipeline. There are no new user-facing SDK APIs in this release suite.
+
+    </ChangelogEntry>
+
+    <ChangelogEntry
       date="2026-02-17"
       title="Drop-in SDK (Elsie) v1.7.0"
       components={['Drop-in SDK']}
@@ -353,9 +364,9 @@ import Link from '@components/Link.astro';
     >
       The Checkout drop-in has been updated with the following changes:
 
-      - **ShippingMethods** ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)) - New `ShippingMethodItem` slot to replace the default radio/toggle UI per method while keeping selection wired to the API (`replaceWith`, `onSelect`, `onRender`). Use it to add icons, descriptions, badges, or a fully custom layout. Slot context follows `ShippingMethodItemContext` (`method`, `isSelected`, `onSelect`). A separate `busy` flag is applied on the internal shipping-methods UI component when updates or an estimate are pending, not on the slot context. See [Shipping methods](/dropins/checkout/containers/shipping-methods/) and [ShippingMethods slots](/dropins/checkout/slots/#shippingmethods-slots).
+      - **ShippingMethods** ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)) - New `ShippingMethodItem` slot replaces the default radio/toggle UI per method while keeping selection wired to the API (`replaceWith`, `onSelect`, `onRender`). Slot context is `ShippingMethodItemContext` (`method`, `isSelected`, `onSelect`). The `busy` flag applies to the internal shipping-methods UI when updates or an estimate are pending, not to the slot context. See [Shipping methods](/dropins/checkout/containers/shipping-methods/) and [ShippingMethods slots](/dropins/checkout/slots/#shippingmethods-slots).
 
-      - **estimateShippingMethods** ([#307](https://github.com/adobe-commerce/storefront-checkout/pull/307)) - GraphQL extensibility for the `estimateShippingMethods` mutation via the `EstimateShippingModel` model and `ESTIMATE_SHIPPING_METHOD_FRAGMENT`, so you can extend the shipping estimate payload at build time. See [Extending the checkout drop-in](/dropins/checkout/extending/).
+      - **estimateShippingMethods** ([#307](https://github.com/adobe-commerce/storefront-checkout/pull/307)) - Extend the shipping estimate payload at build time using `ESTIMATE_SHIPPING_METHOD_FRAGMENT` and the `EstimateShippingModel` initializer. See [Extending the checkout drop-in](/dropins/checkout/extending/).
 
     </ChangelogEntry>
 
@@ -1409,6 +1420,7 @@ import Link from '@components/Link.astro';
       - **Pathname with store code** - Pathname handling is fixed when the store code is present in the URL. The condition that checks whether the pathname ends with `search` was corrected, so category detection and quick search work correctly in multi-store setups ([#88](https://github.com/adobe-commerce/storefront-search-dropin/pull/88), [#91](https://github.com/adobe-commerce/storefront-search-dropin/pull/91)).
       - **Filter state and pagination** - URL manipulation has been moved out of the drop-in into the boilerplate. Filter state resets to page 1 when filters change, and the function defaults to page one for consistent pagination ([#86](https://github.com/adobe-commerce/storefront-search-dropin/pull/86)). Boilerplate integration ([#1119](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1119)).
       - **PLP page size** - Page size is configurable via block configuration and defaults to 9; includes instrumentation for Universal Editor ([#1143](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1143)).
+      - **Custom PLP attributes** - Add custom product attributes to the product listing page ([#89](https://github.com/adobe-commerce/storefront-search-dropin/pull/89)).
     </ChangelogEntry>
 
     <ChangelogEntry
@@ -2055,7 +2067,7 @@ import Link from '@components/Link.astro';
     <ChangelogEntry
       date="2026-03-24"
       title="Quick Order v1.0.0"
-      components={['Requisition List']}
+      components={['Quick Order']}
     >
       **New Quick Order drop-in** for B2B bulk ordering. The [Quick Order](/dropins-b2b/quick-order/) drop-in has been integrated into the boilerplate, enabling B2B users to add products to cart by SKU or product name in bulk ([#1125](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1125), [#1156](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156)).
 

--- a/src/content/docs/releases/index.mdx
+++ b/src/content/docs/releases/index.mdx
@@ -14,7 +14,7 @@ The following sections provide high-level summaries of each release suite and de
 
 ## March 2026 suite
 
-This suite brings Product Details Page video support, multi-store wishlist, configurable product listing page size, Quick Order for B2B, and boilerplate improvements that improve navigation, layout, and multi-website cart behavior. For per-component version details, see the [changelog](/releases/changelog/).
+This suite brings Product Details Page video support, multi-store wishlist, configurable product listing page size, Quick Order for B2B, checkout shipping UI customization and GraphQL extensibility for shipping estimates, and boilerplate improvements that improve navigation, layout, and multi-website cart behavior. For per-component version details, see the [changelog](/releases/changelog/).
 
 <Aside type="caution" title="Breaking changes">
 There are no breaking changes in this release suite.
@@ -29,6 +29,10 @@ The [ProductGallery](/dropins/product-details/containers/product-gallery/) conta
 #### Multi-store wishlist
 
 The Wishlist drop-in now supports multi-store deployments. Pass an optional `storeCode` during [initialization](/dropins/wishlist/initialization/) so wishlist data (localStorage, sessionStorage, and cookies) is scoped per store. This keeps guest and authenticated wishlists isolated between store views while remaining backward compatible for single-store or `'default'` store setups ([#73](https://github.com/adobe-commerce/storefront-wishlist/pull/73), [#1139](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1139)).
+
+#### Checkout shipping customization and GraphQL extensibility
+
+The [ShippingMethods](/dropins/checkout/containers/shipping-methods/) container adds a **`ShippingMethodItem`** slot for full custom row UI (icons, descriptions, badges, layout) while preserving selection behavior, including a **`busy`** flag in slot context during sync ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)). The **`estimateShippingMethods`** mutation supports GraphQL extension via **`ESTIMATE_SHIPPING_METHOD_FRAGMENT`** and **`EstimateShippingModel`** ([#307](https://github.com/adobe-commerce/storefront-checkout/pull/307)).
 
 #### Quick Order for B2B bulk ordering
 
@@ -83,7 +87,7 @@ The Drop-in SDK (`@dropins/tools`) was upgraded to ~1.8.0 in this release. The u
 | Component | Improvements |
 |-----------|--------------|
 | [**Cart**](/dropins/cart/) v3.2.0 | Optional `includeOutOfStockItems` prop on [CartSummaryList](/dropins/cart/containers/cart-summary-list/) so out-of-stock and insufficient-quantity items can appear in the main list. Multi-store wishlist integration ([#102](https://github.com/adobe-commerce/storefront-cart/pull/102), [#1139](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1139)). |
-| [**Checkout**](/dropins/checkout/) v3.2.0 | No user-facing changes in this release |
+| [**Checkout**](/dropins/checkout/) v3.2.0 | [ShippingMethods](/dropins/checkout/containers/shipping-methods/) **`ShippingMethodItem`** slot (custom row UI, **`busy`** in context) ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)). **`estimateShippingMethods`** extensibility via **`ESTIMATE_SHIPPING_METHOD_FRAGMENT`** and **`EstimateShippingModel`** ([#307](https://github.com/adobe-commerce/storefront-checkout/pull/307)). |
 | [**Order**](/dropins/order/) v3.2.0 | No user-facing changes in this release |
 | [**Product Details Page**](/dropins/product-details/) v3.0.2 | Out-of-the-box video support in [ProductGallery](/dropins/product-details/containers/product-gallery/) ([#1100](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1100)) |
 | [**User Account**](/dropins/user-account/) v3.2.0 | No user-facing changes in this release |

--- a/src/content/docs/releases/index.mdx
+++ b/src/content/docs/releases/index.mdx
@@ -32,7 +32,7 @@ The Wishlist drop-in now supports multi-store deployments. Pass an optional `sto
 
 #### Checkout shipping customization and GraphQL extensibility
 
-The [ShippingMethods](/dropins/checkout/containers/shipping-methods/) container adds a **`ShippingMethodItem`** slot for full custom row UI (icons, descriptions, badges, layout) while preserving selection behavior, including a **`busy`** flag in slot context during sync ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)). The **`estimateShippingMethods`** mutation supports GraphQL extension via **`ESTIMATE_SHIPPING_METHOD_FRAGMENT`** and **`EstimateShippingModel`** ([#307](https://github.com/adobe-commerce/storefront-checkout/pull/307)).
+The [ShippingMethods](/dropins/checkout/containers/shipping-methods/) container adds a **`ShippingMethodItem`** slot for full custom row UI (icons, descriptions, badges, layout) while preserving selection behavior, including a **`busy`** flag in slot context when checkout updates or a shipping estimate are pending ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)). The **`estimateShippingMethods`** mutation supports GraphQL extension via **`ESTIMATE_SHIPPING_METHOD_FRAGMENT`** and **`EstimateShippingModel`** ([#307](https://github.com/adobe-commerce/storefront-checkout/pull/307)).
 
 #### Quick Order for B2B bulk ordering
 
@@ -87,7 +87,7 @@ The Drop-in SDK (`@dropins/tools`) was upgraded to ~1.8.0 in this release. The u
 | Component | Improvements |
 |-----------|--------------|
 | [**Cart**](/dropins/cart/) v3.2.0 | Optional `includeOutOfStockItems` prop on [CartSummaryList](/dropins/cart/containers/cart-summary-list/) so out-of-stock and insufficient-quantity items can appear in the main list. Multi-store wishlist integration ([#102](https://github.com/adobe-commerce/storefront-cart/pull/102), [#1139](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1139)). |
-| [**Checkout**](/dropins/checkout/) v3.2.0 | [ShippingMethods](/dropins/checkout/containers/shipping-methods/) **`ShippingMethodItem`** slot (custom row UI, **`busy`** in context) ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)). **`estimateShippingMethods`** extensibility via **`ESTIMATE_SHIPPING_METHOD_FRAGMENT`** and **`EstimateShippingModel`** ([#307](https://github.com/adobe-commerce/storefront-checkout/pull/307)). |
+| [**Checkout**](/dropins/checkout/) v3.2.0 | [ShippingMethods](/dropins/checkout/containers/shipping-methods/) **`ShippingMethodItem`** slot (custom row UI; **`busy`** when updates or estimate pending) ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)). **`estimateShippingMethods`** extensibility via **`ESTIMATE_SHIPPING_METHOD_FRAGMENT`** and **`EstimateShippingModel`** ([#307](https://github.com/adobe-commerce/storefront-checkout/pull/307)). |
 | [**Order**](/dropins/order/) v3.2.0 | No user-facing changes in this release |
 | [**Product Details Page**](/dropins/product-details/) v3.0.2 | Out-of-the-box video support in [ProductGallery](/dropins/product-details/containers/product-gallery/) ([#1100](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1100)) |
 | [**User Account**](/dropins/user-account/) v3.2.0 | No user-facing changes in this release |

--- a/src/content/docs/releases/index.mdx
+++ b/src/content/docs/releases/index.mdx
@@ -14,7 +14,7 @@ The following sections provide high-level summaries of each release suite and de
 
 ## March 2026 suite
 
-This suite includes product details page video support, multi-store wishlist, configurable PLP page size, custom product attributes on the PLP, Quick Order for B2B, checkout updates (custom shipping method rows and extensible shipping estimates), and boilerplate improvements for navigation, layout, and multi-website cart behavior. For per-component version details, see the [changelog](/releases/changelog/).
+This suite includes product details page video support, multi-store wishlist, a configurable PLP page size, custom product attributes on the PLP, Quick Order for B2B, checkout updates (custom shipping method rows and extensible shipping estimates), and boilerplate improvements for navigation, layout, and multi-website cart behavior. For per-component version details, see the [changelog](/releases/changelog/).
 
 <Aside type="caution" title="Breaking changes">
 There are no breaking changes in this release suite.
@@ -36,11 +36,11 @@ The [ShippingMethods](/dropins/checkout/containers/shipping-methods/) container 
 
 #### Quick Order for B2B bulk ordering
 
-B2B customers can add products to cart by SKU or product name in bulk. The new [Quick Order](/dropins-b2b/quick-order/) drop-in has feature parity with Luma Quick Order and Grid Ordering for configurable products. It is integrated into the boilerplate and ready for use on B2B storefronts ([#1125](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1125), [#1156](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156)).
+B2B customers can add products to the cart by SKU or product name in bulk. The new [Quick Order](/dropins-b2b/quick-order/) drop-in has feature parity with Luma Quick Order and Grid Ordering for configurable products. It is integrated into the boilerplate and ready for use on B2B storefronts ([#1125](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1125), [#1156](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156)).
 
 #### Configurable product listing page size
 
-Product listing pages now allow merchants to control how many products appear per page. Page size is configurable via block configuration and defaults to 9, giving store owners flexibility without code changes ([#1143](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1143)). Custom product attributes can be added to the product listing ([#89](https://github.com/adobe-commerce/storefront-search-dropin/pull/89)).
+Product listing pages now allow merchants to control how many products appear per page. The page size is configurable via the block configuration and defaults to 9, giving store owners flexibility without code changes ([#1143](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1143)). Custom product attributes can be added to the product listing ([#89](https://github.com/adobe-commerce/storefront-search-dropin/pull/89)).
 
 #### Correct 404 responses for non-existent pages
 
@@ -56,8 +56,8 @@ Non-existent pages now return a proper server-rendered 404 response. Crawlers an
 #### Infrastructure
 
 - **Build tools**: `@dropins/build-tools` upgraded to ~1.1.0 ([#1152](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1152)).
-- **Default assets**: Assets enabled flag now defaults to true ([#1114](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1114)).
-- **Site config**: Removed folders ref from default-site.json ([#1148](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1148)).
+- **Default assets**: The assets enabled flag now defaults to true ([#1114](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1114)).
+- **Site config**: Removed the `folders` reference from default-site.json ([#1148](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1148)).
 
 #### Document authoring
 
@@ -66,14 +66,14 @@ No document authoring changes in this release suite.
 #### Fixes and improvements
 
 - **PDP block**: Merchants can display video alongside product images without custom code ([#1100](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1100)).
-- **PLP block**: Merchants can control how many products appear per page via block configuration. Defaults to 9 ([#1143](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1143)). Custom product attributes can be added to the product listing ([#89](https://github.com/adobe-commerce/storefront-search-dropin/pull/89)).
+- **PLP block**: Merchants can control how many products appear per page via the block configuration. Defaults to 9 ([#1143](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1143)). Custom product attributes can be added to the product listing ([#89](https://github.com/adobe-commerce/storefront-search-dropin/pull/89)).
 - **404 handling**: Crawlers and tools receive the correct HTTP status for non-existent pages ([#1134](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1134)).
 - **Layout**: Full-width sections and padding-based gutters in columns ([#1133](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1133)).
-- **URL manipulation**: URL handling moved to boilerplate. Filter state resets to page 1 when filters change. Pathname handling works correctly with store code in the URL ([#1119](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1119)).
+- **URL manipulation**: URL handling moved to the boilerplate. Filter state resets to page 1 when filters change. Pathname handling works correctly with the store code in the URL ([#1119](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1119)).
 - **Wishlist**: Guest and authenticated wishlists stay isolated between store views in multi-website deployments ([#1139](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1139)).
-- **Demo config**: Adobe Commerce Optimizer flag added to demo-config-aco.json ([#1124](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1124)).
+- **Demo config**: The Adobe Commerce Optimizer flag was added to demo-config-aco.json ([#1124](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1124)).
 - **B2B (Cart)**: B2B shoppers in multi-store setups navigate to the correct wishlist page. Cart state clears when switching websites to prevent errors ([#1130](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1130), [#1137](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1137)).
-- **B2B (Quick Order)**: B2B users can add products to cart by SKU or product name in bulk. The Quick Order drop-in has feature parity with Luma Quick Order and Grid Ordering for configurable products ([#1125](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1125), [#1156](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156)).
+- **B2B (Quick Order)**: B2B users can add products to the cart by SKU or product name in bulk. The Quick Order drop-in has feature parity with Luma Quick Order and Grid Ordering for configurable products ([#1125](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1125), [#1156](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156)).
 
 ### Updated Drop-in SDK
 
@@ -85,8 +85,8 @@ The Drop-in SDK (`@dropins/tools`) was upgraded to ~1.8.0 in this release. The u
 
 | Component | Improvements |
 |-----------|--------------|
-| [**Cart**](/dropins/cart/) v3.2.0 | Optional `includeOutOfStockItems` prop on [CartSummaryList](/dropins/cart/containers/cart-summary-list/) so out-of-stock and insufficient-quantity items can appear in the main list. Multi-store wishlist integration ([#102](https://github.com/adobe-commerce/storefront-cart/pull/102), [#1139](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1139)). |
-| [**Checkout**](/dropins/checkout/) v3.2.0 | `ShippingMethodItem` slot on [ShippingMethods](/dropins/checkout/containers/shipping-methods/) ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)). `estimateShippingMethods` extensibility: `ESTIMATE_SHIPPING_METHOD_FRAGMENT`, `EstimateShippingModel` ([#307](https://github.com/adobe-commerce/storefront-checkout/pull/307)). |
+| [**Cart**](/dropins/cart/) v3.2.0 | Optional `includeOutOfStockItems` property on the [CartSummaryList](/dropins/cart/containers/cart-summary-list/) container so out-of-stock and insufficient-quantity items can appear in the main list. Multi-store wishlist integration ([#102](https://github.com/adobe-commerce/storefront-cart/pull/102), [#1139](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1139)). |
+| [**Checkout**](/dropins/checkout/) v3.2.0 | New `ShippingMethodItem` slot on [ShippingMethods](/dropins/checkout/containers/shipping-methods/) ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)). `estimateShippingMethods` extensibility: `ESTIMATE_SHIPPING_METHOD_FRAGMENT`, `EstimateShippingModel` ([#307](https://github.com/adobe-commerce/storefront-checkout/pull/307)). |
 | [**Order**](/dropins/order/) v3.2.0 | No user-facing changes in this release |
 | [**Product Details Page**](/dropins/product-details/) v3.0.2 | Out-of-the-box video support in [ProductGallery](/dropins/product-details/containers/product-gallery/) ([#1100](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1100)) |
 | [**User Account**](/dropins/user-account/) v3.2.0 | No user-facing changes in this release |
@@ -109,8 +109,8 @@ The Drop-in SDK (`@dropins/tools`) was upgraded to ~1.8.0 in this release. The u
 | [**Company Switcher**](/dropins-b2b/company-switcher/) v1.1.1 | User-provided `langDefinitions` passed to the initializer are now correctly merged with the drop-in's defaults, so label and placeholder overrides take effect as expected ([#26](https://github.com/adobe-commerce/storefront-company-switcher/pull/26)). |
 | [**Purchase Order**](/dropins-b2b/purchase-order/) v1.1.1 | User-provided `langDefinitions` passed to the initializer are now correctly merged with the drop-in's defaults, so label and placeholder overrides take effect as expected ([#52](https://github.com/adobe-commerce/storefront-purchase-order/pull/52)). |
 | [**Quote Management**](/dropins-b2b/quote-management/) v1.1.1 | User-provided `langDefinitions` passed to the initializer are now correctly merged with the drop-in's defaults, so label and placeholder overrides take effect as expected ([#89](https://github.com/adobe-commerce/storefront-quote-management/pull/89)). |
-| [**Requisition List**](/dropins-b2b/requisition-list/) v1.2.0 | API catalog replaced with props from the integration layer. Requisition list selector disabled state fixed. See [RequisitionListView](/dropins-b2b/requisition-list/containers/requisition-list-view/) for setup. Boilerplate integration ([#120](https://github.com/adobe-commerce/storefront-requisition-list/pull/120), [#1156](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156)). |
-| [**Quick Order**](/dropins-b2b/quick-order/) v1.0.0 | New Quick Order drop-in integrated for B2B bulk ordering by SKU or product name. Feature parity with Luma Quick Order and Grid Ordering for configurable products ([#1125](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1125), [#1156](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156)). |
+| [**Requisition List**](/dropins-b2b/requisition-list/) v1.2.0 | The API catalog was replaced with props from the integration layer. The requisition list selector disabled state was fixed. See [RequisitionListView](/dropins-b2b/requisition-list/containers/requisition-list-view/) for setup. Includes the boilerplate integration ([#120](https://github.com/adobe-commerce/storefront-requisition-list/pull/120), [#1156](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156)). |
+| [**Quick Order**](/dropins-b2b/quick-order/) v1.0.0 | The new Quick Order drop-in is integrated for B2B bulk ordering by SKU or product name. Feature parity with Luma Quick Order and Grid Ordering for configurable products ([#1125](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1125), [#1156](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156)). |
 </TableWrapper>
 
 ### Known issues

--- a/src/content/docs/releases/index.mdx
+++ b/src/content/docs/releases/index.mdx
@@ -32,7 +32,7 @@ The Wishlist drop-in now supports multi-store deployments. Pass an optional `sto
 
 #### Checkout shipping customization and GraphQL extensibility
 
-The [ShippingMethods](/dropins/checkout/containers/shipping-methods/) container adds a **`ShippingMethodItem`** slot for full custom row UI (icons, descriptions, badges, layout) while preserving selection behavior, including a **`busy`** flag in slot context when checkout updates or a shipping estimate are pending ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)). The **`estimateShippingMethods`** mutation supports GraphQL extension via **`ESTIMATE_SHIPPING_METHOD_FRAGMENT`** and **`EstimateShippingModel`** ([#307](https://github.com/adobe-commerce/storefront-checkout/pull/307)).
+The [ShippingMethods](/dropins/checkout/containers/shipping-methods/) container adds a `ShippingMethodItem` slot for full custom row UI (icons, descriptions, badges, layout) while preserving selection behavior ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)).
 
 #### Quick Order for B2B bulk ordering
 
@@ -87,7 +87,7 @@ The Drop-in SDK (`@dropins/tools`) was upgraded to ~1.8.0 in this release. The u
 | Component | Improvements |
 |-----------|--------------|
 | [**Cart**](/dropins/cart/) v3.2.0 | Optional `includeOutOfStockItems` prop on [CartSummaryList](/dropins/cart/containers/cart-summary-list/) so out-of-stock and insufficient-quantity items can appear in the main list. Multi-store wishlist integration ([#102](https://github.com/adobe-commerce/storefront-cart/pull/102), [#1139](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1139)). |
-| [**Checkout**](/dropins/checkout/) v3.2.0 | [ShippingMethods](/dropins/checkout/containers/shipping-methods/) **`ShippingMethodItem`** slot (custom row UI; **`busy`** when updates or estimate pending) ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)). **`estimateShippingMethods`** extensibility via **`ESTIMATE_SHIPPING_METHOD_FRAGMENT`** and **`EstimateShippingModel`** ([#307](https://github.com/adobe-commerce/storefront-checkout/pull/307)). |
+| [**Checkout**](/dropins/checkout/) v3.2.0 | [ShippingMethods](/dropins/checkout/containers/shipping-methods/) `ShippingMethodItem` slot for custom shipping method rows ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)). `estimateShippingMethods` extensibility via `ESTIMATE_SHIPPING_METHOD_FRAGMENT` and `EstimateShippingModel` ([#307](https://github.com/adobe-commerce/storefront-checkout/pull/307)). |
 | [**Order**](/dropins/order/) v3.2.0 | No user-facing changes in this release |
 | [**Product Details Page**](/dropins/product-details/) v3.0.2 | Out-of-the-box video support in [ProductGallery](/dropins/product-details/containers/product-gallery/) ([#1100](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1100)) |
 | [**User Account**](/dropins/user-account/) v3.2.0 | No user-facing changes in this release |

--- a/src/content/docs/releases/index.mdx
+++ b/src/content/docs/releases/index.mdx
@@ -14,7 +14,7 @@ The following sections provide high-level summaries of each release suite and de
 
 ## March 2026 suite
 
-This suite brings Product Details Page video support, multi-store wishlist, configurable product listing page size, Quick Order for B2B, checkout shipping UI customization and GraphQL extensibility for shipping estimates, and boilerplate improvements that improve navigation, layout, and multi-website cart behavior. For per-component version details, see the [changelog](/releases/changelog/).
+This suite includes product details page video support, multi-store wishlist, configurable PLP page size, custom product attributes on the PLP, Quick Order for B2B, checkout updates (custom shipping method rows and extensible shipping estimates), and boilerplate improvements for navigation, layout, and multi-website cart behavior. For per-component version details, see the [changelog](/releases/changelog/).
 
 <Aside type="caution" title="Breaking changes">
 There are no breaking changes in this release suite.
@@ -22,7 +22,7 @@ There are no breaking changes in this release suite.
 
 ### Highlights
 
-#### Product Details Page video support
+#### Product details page video support
 
 The [ProductGallery](/dropins/product-details/containers/product-gallery/) container now supports product videos out of the box. Merchants can display video alongside product images in the gallery carousel, improving product presentation and shopper engagement. Videos can be positioned before or after images. See the [ProductGallery configuration](/dropins/product-details/containers/product-gallery/#videos) for setup ([#1100](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1100)).
 
@@ -32,7 +32,7 @@ The Wishlist drop-in now supports multi-store deployments. Pass an optional `sto
 
 #### Checkout shipping customization and GraphQL extensibility
 
-The [ShippingMethods](/dropins/checkout/containers/shipping-methods/) container adds a `ShippingMethodItem` slot for full custom row UI (icons, descriptions, badges, layout) while preserving selection behavior ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)).
+The [ShippingMethods](/dropins/checkout/containers/shipping-methods/) container adds a `ShippingMethodItem` slot so you can replace the default per-method UI while keeping the selection wired to the API ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)). You can also extend the `estimateShippingMethods` payload at build time with `ESTIMATE_SHIPPING_METHOD_FRAGMENT` and `EstimateShippingModel` ([#307](https://github.com/adobe-commerce/storefront-checkout/pull/307)). See [Extending the checkout drop-in](/dropins/checkout/extending/).
 
 #### Quick Order for B2B bulk ordering
 
@@ -40,7 +40,7 @@ B2B customers can add products to cart by SKU or product name in bulk. The new [
 
 #### Configurable product listing page size
 
-Product listing pages now allow merchants to control how many products appear per page. Page size is configurable via block configuration and defaults to 9, giving store owners flexibility without code changes ([#1143](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1143)).
+Product listing pages now allow merchants to control how many products appear per page. Page size is configurable via block configuration and defaults to 9, giving store owners flexibility without code changes ([#1143](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1143)). Custom product attributes can be added to the product listing ([#89](https://github.com/adobe-commerce/storefront-search-dropin/pull/89)).
 
 #### Correct 404 responses for non-existent pages
 
@@ -56,25 +56,24 @@ Non-existent pages now return a proper server-rendered 404 response. Crawlers an
 #### Infrastructure
 
 - **Build tools**: `@dropins/build-tools` upgraded to ~1.1.0 ([#1152](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1152)).
-- **Default assets**: Assets enabled by default in demo config ([#1114](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1114)).
-- **Site config**: Removed folder mapping from default-site.json ([#1148](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1148)).
+- **Default assets**: Assets enabled flag now defaults to true ([#1114](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1114)).
+- **Site config**: Removed folders ref from default-site.json ([#1148](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1148)).
 
-#### Document Authoring
+#### Document authoring
 
-No Document Authoring changes in this release suite.
+No document authoring changes in this release suite.
 
 #### Fixes and improvements
 
 - **PDP block**: Merchants can display video alongside product images without custom code ([#1100](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1100)).
-- **PLP block**: Merchants can control how many products appear per page via block configuration. Defaults to 9 ([#1143](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1143)).
+- **PLP block**: Merchants can control how many products appear per page via block configuration. Defaults to 9 ([#1143](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1143)). Custom product attributes can be added to the product listing ([#89](https://github.com/adobe-commerce/storefront-search-dropin/pull/89)).
 - **404 handling**: Crawlers and tools receive the correct HTTP status for non-existent pages ([#1134](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1134)).
 - **Layout**: Full-width sections and padding-based gutters in columns ([#1133](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1133)).
 - **URL manipulation**: URL handling moved to boilerplate. Filter state resets to page 1 when filters change. Pathname handling works correctly with store code in the URL ([#1119](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1119)).
 - **Wishlist**: Guest and authenticated wishlists stay isolated between store views in multi-website deployments ([#1139](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1139)).
-- **Demo config**: Adobe Commerce Optimizer is enabled by default in the demo config ([#1124](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1124)).
+- **Demo config**: Adobe Commerce Optimizer flag added to demo-config-aco.json ([#1124](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1124)).
 - **B2B (Cart)**: B2B shoppers in multi-store setups navigate to the correct wishlist page. Cart state clears when switching websites to prevent errors ([#1130](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1130), [#1137](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1137)).
-- **B2B (Quick Order)**: B2B users can add products to cart by SKU or product name in bulk. Quick Order drop-in integrated with feature parity to Luma Quick Order and Grid Ordering for configurable products ([#1125](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1125), [#1156](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156)).
-
+- **B2B (Quick Order)**: B2B users can add products to cart by SKU or product name in bulk. The Quick Order drop-in has feature parity with Luma Quick Order and Grid Ordering for configurable products ([#1125](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1125), [#1156](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156)).
 
 ### Updated Drop-in SDK
 
@@ -87,14 +86,14 @@ The Drop-in SDK (`@dropins/tools`) was upgraded to ~1.8.0 in this release. The u
 | Component | Improvements |
 |-----------|--------------|
 | [**Cart**](/dropins/cart/) v3.2.0 | Optional `includeOutOfStockItems` prop on [CartSummaryList](/dropins/cart/containers/cart-summary-list/) so out-of-stock and insufficient-quantity items can appear in the main list. Multi-store wishlist integration ([#102](https://github.com/adobe-commerce/storefront-cart/pull/102), [#1139](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1139)). |
-| [**Checkout**](/dropins/checkout/) v3.2.0 | [ShippingMethods](/dropins/checkout/containers/shipping-methods/) `ShippingMethodItem` slot for custom shipping method rows ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)). `estimateShippingMethods` extensibility via `ESTIMATE_SHIPPING_METHOD_FRAGMENT` and `EstimateShippingModel` ([#307](https://github.com/adobe-commerce/storefront-checkout/pull/307)). |
+| [**Checkout**](/dropins/checkout/) v3.2.0 | `ShippingMethodItem` slot on [ShippingMethods](/dropins/checkout/containers/shipping-methods/) ([#300](https://github.com/adobe-commerce/storefront-checkout/pull/300)). `estimateShippingMethods` extensibility: `ESTIMATE_SHIPPING_METHOD_FRAGMENT`, `EstimateShippingModel` ([#307](https://github.com/adobe-commerce/storefront-checkout/pull/307)). |
 | [**Order**](/dropins/order/) v3.2.0 | No user-facing changes in this release |
 | [**Product Details Page**](/dropins/product-details/) v3.0.2 | Out-of-the-box video support in [ProductGallery](/dropins/product-details/containers/product-gallery/) ([#1100](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1100)) |
 | [**User Account**](/dropins/user-account/) v3.2.0 | No user-facing changes in this release |
 | [**User Auth**](/dropins/user-auth/) v3.2.0 | No user-facing changes in this release |
 | [**Wishlist**](/dropins/wishlist/) v3.2.0 | Multi-store support: optional `storeCode` config prop in [initialization](/dropins/wishlist/initialization/). Storage and cookies scoped per store. Backward compatible for single-store and `default` ([#73](https://github.com/adobe-commerce/storefront-wishlist/pull/73), [#1139](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1139)) |
 | [**Personalization**](/dropins/personalization/) v3.1.1 | User-provided `langDefinitions` passed to the initializer are now correctly merged with the drop-in's defaults, so label and placeholder overrides take effect as expected ([#27](https://github.com/adobe-commerce/storefront-personalization/pull/27)). |
-| [**Product Discovery**](/dropins/product-discovery/) v3.1.0 | Pathname handling is fixed when the store code appears in the URL. Filter state resets to page 1 when filters change. URL manipulation moved to boilerplate ([#86](https://github.com/adobe-commerce/storefront-search-dropin/pull/86), [#88](https://github.com/adobe-commerce/storefront-search-dropin/pull/88)). PLP page size configurable via block config, defaults to 9 ([#1143](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1143)). Add custom product attributes to PLP ([#89](https://github.com/adobe-commerce/storefront-search-dropin/pull/89)). |
+| [**Product Discovery**](/dropins/product-discovery/) v3.1.0 | Pathname handling is fixed when the store code appears in the URL ([#88](https://github.com/adobe-commerce/storefront-search-dropin/pull/88), [#91](https://github.com/adobe-commerce/storefront-search-dropin/pull/91)). Filter state resets to page 1 when filters change ([#86](https://github.com/adobe-commerce/storefront-search-dropin/pull/86)). URL manipulation is handled in the boilerplate ([#1119](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1119)). PLP page size is configurable via block configuration and defaults to 9 ([#1143](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1143)). Custom product attributes can be added to the PLP ([#89](https://github.com/adobe-commerce/storefront-search-dropin/pull/89)). |
 | [**Product Recommendations**](/dropins/recommendations/) v3.0.0 | No user-facing changes in this release |
 | [**Payment Services**](/dropins/payment-services/) v3.0.0 | No user-facing changes in this release |
 
@@ -111,7 +110,7 @@ The Drop-in SDK (`@dropins/tools`) was upgraded to ~1.8.0 in this release. The u
 | [**Purchase Order**](/dropins-b2b/purchase-order/) v1.1.1 | User-provided `langDefinitions` passed to the initializer are now correctly merged with the drop-in's defaults, so label and placeholder overrides take effect as expected ([#52](https://github.com/adobe-commerce/storefront-purchase-order/pull/52)). |
 | [**Quote Management**](/dropins-b2b/quote-management/) v1.1.1 | User-provided `langDefinitions` passed to the initializer are now correctly merged with the drop-in's defaults, so label and placeholder overrides take effect as expected ([#89](https://github.com/adobe-commerce/storefront-quote-management/pull/89)). |
 | [**Requisition List**](/dropins-b2b/requisition-list/) v1.2.0 | API catalog replaced with props from the integration layer. Requisition list selector disabled state fixed. See [RequisitionListView](/dropins-b2b/requisition-list/containers/requisition-list-view/) for setup. Boilerplate integration ([#120](https://github.com/adobe-commerce/storefront-requisition-list/pull/120), [#1156](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156)). |
-| [**Quick Order**](/dropins-b2b/quick-order/) v1.0.0 | New Quick Order drop-in integrated for B2B bulk ordering by SKU or product name. Feature parity with Luma Quick Order and Grid Ordering for configurable products ([#1125](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1125), [#1156](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156)) |
+| [**Quick Order**](/dropins-b2b/quick-order/) v1.0.0 | New Quick Order drop-in integrated for B2B bulk ordering by SKU or product name. Feature parity with Luma Quick Order and Grid Ordering for configurable products ([#1125](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1125), [#1156](https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156)). |
 </TableWrapper>
 
 ### Known issues


### PR DESCRIPTION
## Purpose of this pull request

This pull request refines **ShippingMethods** documentation so the **`ShippingMethodItem`** slot’s **`busy`** flag matches the checkout drop-in’s real behavior: the UI is treated as busy when **pending checkout updates** or a **pending shipping estimate** would block interaction, not only during a vague “loading/sync” state. The consistent wording and writing edits are also included.

### Associated JIRA ticket

COMDOX-1557

## Affected pages

- [ShippingMethods container](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/checkout/containers/shipping-methods/)
- [Checkout slots (ShippingMethods slots)](https://experienceleague.adobe.com/developer/commerce/storefront/dropins/checkout/slots/)
- [Changelog](https://experienceleague.adobe.com/developer/commerce/storefront/releases/changelog/)
- [Release information](https://experienceleague.adobe.com/developer/commerce/storefront/releases/)

## Links to source code

- [storefront-checkout PR #300](https://github.com/adobe-commerce/storefront-checkout/pull/300) (ShippingMethodItem slot)

### What's New highlights

Updated the `ShippingMethods` container documentation to include a fully custom row per method (icons, descriptions, badges, layout) to the Checkout drop-in. 