### PR TITLE
ACCS-603 - Add showVariant variables

### DIFF
--- a/src/content/docs/dropins/cart/functions.mdx
+++ b/src/content/docs/dropins/cart/functions.mdx
@@ -45,7 +45,7 @@ The Cart drop-in provides API functions that enable you to programmatically cont
 
 ## addProductsToCart
 
-The `addProductsToCart` function adds products to a cart. You must supply a `sku` and `quantity`for each product. The other parameters are specified for complex product types. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/mutations/add-products`/" text="addProductsToCart" /> mutation.
+The `addProductsToCart` function adds products to a cart. You must supply a `sku` and `quantity` for each product. The other parameters are specified for complex product types. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/add-products/" text="addProductsToCart" /> mutation.
 
 ```ts
 const addProductsToCart = async (
@@ -76,7 +76,7 @@ Returns [`CartModel`](#cartmodel) or `null`.
 
 ## applyCouponsToCart
 
-A function that applies or replaces one or more coupons to the cart. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/mutations/apply-coupons-to-cart`/" text="applyCouponsToCart" /> mutation.
+A function that applies or replaces one or more coupons to the cart. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/apply-coupons-to-cart/" text="applyCouponsToCart" /> mutation.
 
 ```ts
 const applyCouponsToCart = async (
@@ -104,7 +104,7 @@ Returns [`CartModel`](#cartmodel) or `null`.
 
 ## applyGiftCardToCart
 
-The `applyGiftCardToCart` function is used to apply a gift card to the current shopping cart. It takes the gift card code as an argument and updates the cart with the applied gift card. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/mutations/apply-gift-card-to-cart`/" text="applyGiftCardToCart" /> mutation.
+The `applyGiftCardToCart` function is used to apply a gift card to the current shopping cart. It takes the gift card code as an argument and updates the cart with the applied gift card. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/apply-gift-card-to-cart/" text="applyGiftCardToCart" /> mutation.
 
 ```ts
 const applyGiftCardToCart = async (
@@ -176,7 +176,7 @@ Returns `[CountryData]`.
 
 ## getEstimatedTotals
 
-A function that returns estimated totals for cart based on an address. It takes an `address` parameter. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/mutations/estimate-totals`/" text="estimateTotals" /> mutation.
+A function that returns estimated totals for cart based on an address. It takes an `address` parameter. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/estimate-totals/" text="estimateTotals" /> mutation.
 
 ```ts
 const getEstimatedTotals = async (
@@ -202,7 +202,7 @@ Returns [`CartModel`](#cartmodel) or `null`.
 
 ## getEstimateShipping
 
-The `getEstimateShipping` function returns the first available shipping method and its estimated cost, based on the provided address. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/mutations/estimate-shipping-methods`/" text="estimateShippingMethods" /> mutation. Note: This function returns raw `GraphQL` data. For a transformed `ShippingMethod` object, listen to the `s`hipping/estimat`e` event instead.
+The `getEstimateShipping` function returns the first available shipping method and its estimated cost, based on the provided address. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/estimate-shipping-methods/" text="estimateShippingMethods" /> mutation. Note: This function returns raw `GraphQL` data. For a transformed `ShippingMethod` object, listen to the [`shipping/estimate`](/dropins/cart/events/#shippingestimate-emits-and-listens) event instead.
 
 ```ts
 const getEstimateShipping = async (
@@ -252,7 +252,7 @@ Returns `Array<{ code: string; name: string }>`.
 
 ## getStoreConfig
 
-The `getStoreConfig` function returns information about a store's configuration. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/store/queries/store-config`/" text="storeConfig" /> query.
+The `getStoreConfig` function returns information about a store's configuration. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/store/queries/store-config/" text="storeConfig" /> query.
 
 ```ts
 const getStoreConfig = async (): Promise<StoreConfigModel | null>
@@ -268,7 +268,7 @@ Returns [`StoreConfigModel`](#storeconfigmodel) or `null`.
 
 ## initializeCart
 
-The `initializeCart` function initializes a guest or customer cart. This function is automatically called during the initialize phase of a dropin's lifecycle. You do not need to call this manually. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/mutations/merge-carts`/" text="mergeCarts" /> mutation.
+The `initializeCart` function initializes a guest or customer cart. This function is automatically called during the initialize phase of a dropin's lifecycle. You do not need to call this manually. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/merge-carts/" text="mergeCarts" /> mutation.
 
 ```ts
 const initializeCart = async (): Promise<CartModel | null>
@@ -318,7 +318,7 @@ Returns [`CartModel`](#cartmodel) or `null`.
 
 ## removeGiftCardFromCart
 
-This function removes a single gift card from the cart. It function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/mutations/remove-giftcard`/" text="removeGiftCardFromCart" /> mutation.
+This function removes a single gift card from the cart. It function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/remove-giftcard/" text="removeGiftCardFromCart" /> mutation.
 
 ```ts
 const removeGiftCardFromCart = async (
@@ -360,7 +360,7 @@ Returns [`CartModel`](#cartmodel) or `null`.
 
 ## setGiftOptionsOnCart
 
-<Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/mutations/set-gift-options`/" text="setGiftOptionsOnCart" /> is a function that sets gift options on the cart. It takes a `giftOptions` parameter.
+<Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/set-gift-options/" text="setGiftOptionsOnCart" /> is a function that sets gift options on the cart. It takes a `giftOptions` parameter.
 
 ```ts
 const setGiftOptionsOnCart = async (
@@ -386,9 +386,9 @@ Returns [`CartModel`](#cartmodel) or `null`.
 
 ## updateProductsFromCart
 
-The `updateProductsFromCart` function updates cart items by either changing the quantity or removing and adding an item in one step. When passing a specified quantity, the function replaces the current quantity. Setting the quantity to 0 removes an item from the cart. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/mutations/update-items`/" text="updateCartItems" /> mutation.
+The `updateProductsFromCart` function updates cart items by either changing the quantity or removing and adding an item in one step. When passing a specified quantity, the function replaces the current quantity. Setting the quantity to 0 removes an item from the cart. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/update-items/" text="updateCartItems" /> mutation.
 
-When an `optionsUIDs` array is sent along with the cart item’s UID and quantity, the function adds the item with the specified options. It removes any pre-existing item with the same UID that lacks the newly provided `optionsUIDs`. In this process, the function invokes first the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/mutations/add-products`/" text="addProductsToCart" />, and later the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/mutations/update-items`/" text="updateCartItems" /> mutations.
+When an `optionsUIDs` array is sent along with the cart item’s UID and quantity, the function adds the item with the specified options. It removes any pre-existing item with the same UID that lacks the newly provided `optionsUIDs`. In this process, the function invokes first the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/add-products/" text="addProductsToCart" />, and later the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/update-items/" text="updateCartItems" /> mutations.
 
 ```ts
 const updateProductsFromCart = async (

--- a/src/content/docs/dropins/checkout/functions.mdx
+++ b/src/content/docs/dropins/checkout/functions.mdx
@@ -65,7 +65,7 @@ function authenticateCustomer(authenticated = false): Promise<any>
 
 ## estimateShippingMethods
 
-The `estimateShippingMethods` function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/mutations/estimate-shipping-methods`/" text="estimateShippingMethods" /> mutation.
+The `estimateShippingMethods` function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/estimate-shipping-methods/" text="estimateShippingMethods" /> mutation.
 
 ```ts
 const estimateShippingMethods = async (
@@ -151,7 +151,7 @@ Returns [`Customer`](#customer) or `null`.
 
 ## getNegotiableQuote
 
-The `getNegotiableQuote` function retrieves a negotiable quote for B2B customers. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/queries/negotiable-quote`/" text="negotiableQuote" /> query.
+The `getNegotiableQuote` function retrieves a negotiable quote for B2B customers. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/queries/negotiable-quote/" text="negotiableQuote" /> query.
 
 ```ts
 const getNegotiableQuote = async (
@@ -227,7 +227,7 @@ function initializeCheckout(input: InitializeInput): Promise<any>
 
 ## isEmailAvailable
 
-The `isEmailAvailable` function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/queries/is-email-available`/" text="isEmailAvailable" /> query.
+The `isEmailAvailable` function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/queries/is-email-available/" text="isEmailAvailable" /> query.
 
 ```ts
 const isEmailAvailable = async (
@@ -267,7 +267,7 @@ Returns `void`.
 
 ## setBillingAddress
 
-The `setBillingAddress` function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/mutations/set-billing-address-on-cart`/" text="setBillingAddressOnCart" /> mutation.
+The `setBillingAddress` function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/set-billing-address-on-cart/" text="setBillingAddressOnCart" /> mutation.
 
 ```ts
 const setBillingAddress = async (
@@ -293,7 +293,7 @@ Returns `void`.
 
 ## setGuestEmailOnCart
 
-The `setGuestEmailOnCart` function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/mutations/set-guest-email-on-cart`/" text="setGuestEmailOnCart" /> mutation.
+The `setGuestEmailOnCart` function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/set-guest-email-on-cart/" text="setGuestEmailOnCart" /> mutation.
 
 ```ts
 const setGuestEmailOnCart = async (
@@ -319,7 +319,7 @@ Returns `void`.
 
 ## setPaymentMethod
 
-The `setPaymentMethod` function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/mutations/set-payment-method-on-cart`/" text="setPaymentMethodOnCart" /> mutation.
+The `setPaymentMethod` function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/set-payment-method-on-cart/" text="setPaymentMethodOnCart" /> mutation.
 
 ```ts
 const setPaymentMethod = async (
@@ -345,7 +345,7 @@ Returns `void`.
 
 ## setShippingAddress
 
-The `setShippingAddress` function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/mutations/set-shipping-addresses-on-cart`/" text="setShippingAddressesOnCart" /> mutation.
+The `setShippingAddress` function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/set-shipping-addresses-on-cart/" text="setShippingAddressesOnCart" /> mutation.
 
 ```ts
 const setShippingAddress = async (
@@ -371,7 +371,7 @@ Returns `void`.
 
 ## setShippingMethods
 
-The `setShippingMethods` function sets one or more shipping methods on the cart. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/mutations/set-shipping-methods-on-cart`/" text="setShippingMethodsOnCart" /> mutation.
+The `setShippingMethods` function sets one or more shipping methods on the cart. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/set-shipping-methods-on-cart/" text="setShippingMethodsOnCart" /> mutation.
 
 ```ts
 const setShippingMethods = async (

--- a/src/content/docs/dropins/order/functions.mdx
+++ b/src/content/docs/dropins/order/functions.mdx
@@ -45,7 +45,7 @@ The Order drop-in provides API functions that enable you to programmatically con
 
 ## cancelOrder
 
-The `cancelOrder` function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/orders/mutations/cancel-order`/" text="cancelOrder" /> mutation. You must pass an order ID and reason.
+The `cancelOrder` function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/orders/mutations/cancel-order/" text="cancelOrder" /> mutation. You must pass an order ID and reason.
 
 ```ts
 const cancelOrder = async (
@@ -77,7 +77,7 @@ Returns `void | null | undefined`.
 
 ## confirmCancelOrder
 
-The `confirmCancelOrder` function confirms the cancellation of an order using the provided order ID and confirmation key. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/orders/mutations/confirm-cancel-order`/" text="confirmCancelOrder" /> mutation.
+The `confirmCancelOrder` function confirms the cancellation of an order using the provided order ID and confirmation key. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/orders/mutations/confirm-cancel-order/" text="confirmCancelOrder" /> mutation.
 
 ```ts
 const confirmCancelOrder = async (
@@ -105,7 +105,7 @@ Returns `void`.
 
 ## confirmGuestReturn
 
-The `confirmGuestReturn` function confirms a return request for a guest order using an order ID and confirmation key. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/orders/mutations/confirm-return`/" text="confirmReturn" /> mutation.
+The `confirmGuestReturn` function confirms a return request for a guest order using an order ID and confirmation key. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/orders/mutations/confirm-return/" text="confirmReturn" /> mutation.
 
 ```ts
 const confirmGuestReturn = async (
@@ -133,7 +133,7 @@ Returns [`OrderDataModel`](#orderdatamodel) or `null`.
 
 ## getAttributesForm
 
-The `getAttributesForm` function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/attributes/queries/attributes-form`/" text="attributesForm" /> query.
+The `getAttributesForm` function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/attributes/queries/attributes-form/" text="attributesForm" /> query.
 
 ```ts
 const getAttributesForm = async (
@@ -159,7 +159,7 @@ Returns `AttributesFormModel[]`.
 
 ## getAttributesList
 
-The `getAttributesList` function is a wrapper for the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/attributes/queries/attributes-list`/" text="attributesList" /> query. You must pass an attribute code to retrieve the list. The system default values are `CUSTOMER`, `CUSTOMER_ADDRESS`, `CATALOG_PRODUCT` and `RMA_ITEM`.
+The `getAttributesList` function is a wrapper for the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/attributes/queries/attributes-list/" text="attributesList" /> query. You must pass an attribute code to retrieve the list. The system default values are `CUSTOMER`, `CUSTOMER_ADDRESS`, `CATALOG_PRODUCT` and `RMA_ITEM`.
 
 ```ts
 const getAttributesList = async (
@@ -185,7 +185,7 @@ Returns `AttributesFormModel[] | []`.
 
 ## getCustomer
 
-The `getCustomer` function is a wrapper for the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/customer/queries/customer`/" text="customer" /> query. You must pass a customer ID to retrieve the customer data.
+The `getCustomer` function is a wrapper for the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/queries/customer/" text="customer" /> query. You must pass a customer ID to retrieve the customer data.
 
 ```ts
 const getCustomer = async (): Promise<CustomerDataModelShort>
@@ -201,7 +201,7 @@ Returns [`CustomerDataModelShort`](#customerdatamodelshort).
 
 ## getCustomerOrdersReturn
 
-The `getCustomerOrdersReturn` function returns details about the returns a customer has requested. It is a wrapper for the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/customer/queries/customer`/" text="customer" /> query.
+The `getCustomerOrdersReturn` function returns details about the returns a customer has requested. It is a wrapper for the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/queries/customer/" text="customer" /> query.
 
 ```ts
 const getCustomerOrdersReturn = async (
@@ -229,7 +229,7 @@ Returns [`CustomerOrdersReturnModel`](#customerordersreturnmodel) or `null`.
 
 ## getGuestOrder
 
-The `getGuestOrder` function is a wrapper for the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/orders/queries/guest-order`/" text="guestOrder" /> query.
+The `getGuestOrder` function is a wrapper for the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/orders/queries/guest-order/" text="guestOrder" /> query.
 
 ```ts
 const getGuestOrder = async (
@@ -257,7 +257,7 @@ Returns [`OrderDataModel`](#orderdatamodel) or `null`.
 
 ## getStoreConfig
 
-The `getStoreConfig` function returns information about the storefront configuration. It is a wrapper for the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/store/queries/store-config`/" text="storeConfig" /> query.
+The `getStoreConfig` function returns information about the storefront configuration. It is a wrapper for the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/store/queries/store-config/" text="storeConfig" /> query.
 
 ```ts
 const getStoreConfig = async (): Promise<StoreConfigModel | null>
@@ -273,7 +273,7 @@ Returns [`StoreConfigModel`](#storeconfigmodel) or `null`.
 
 ## guestOrderByToken
 
-The `guestOrderByToken` function retrieves a guest order using a token generated by Adobe Commerce. It is a wrapper for the `guestOrderByToken` query. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/orders/queries/guest-order-by-token`/" text="guestOrderByToken" /> query.
+The `guestOrderByToken` function retrieves a guest order using a token generated by Adobe Commerce. It is a wrapper for the `guestOrderByToken` query. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/orders/queries/guest-order-by-token/" text="guestOrderByToken" /> query.
 
 ```ts
 const guestOrderByToken = async (
@@ -301,7 +301,7 @@ Returns [`OrderDataModel`](#orderdatamodel) or `null`.
 
 ## placeNegotiableQuoteOrder
 
-The `placeNegotiableQuoteOrder` function places an order for a negotiable quote. It is a wrapper for the `placeNegotiableQuoteOrder` mutation. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/orders/mutations/place-negotiable-quote-order`/" text="placeNegotiableQuoteOrder" /> mutation.
+The `placeNegotiableQuoteOrder` function places an order for a negotiable quote. It is a wrapper for the `placeNegotiableQuoteOrder` mutation. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/orders/mutations/place-negotiable-quote-order/" text="placeNegotiableQuoteOrder" /> mutation.
 
 ```ts
 const placeNegotiableQuoteOrder = async (
@@ -351,7 +351,7 @@ Returns `OrderDataModel | null | undefined`. See [`OrderDataModel`](#orderdatamo
 
 ## reorderItems
 
-The `reorderItems` function allows a logged-in customer to add all the products from a previous order into their cart. It is a wrapper for the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/orders/mutations/reorder-items`/" text="reorderItems" /> mutation.
+The `reorderItems` function allows a logged-in customer to add all the products from a previous order into their cart. It is a wrapper for the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/orders/mutations/reorder-items/" text="reorderItems" /> mutation.
 
 ```ts
 const reorderItems = async (
@@ -378,7 +378,7 @@ Returns [`ReorderItemsProps`](#reorderitemsprops).
 ## requestGuestOrderCancel
 
 The `requestGuestOrderCancel` function is similar to the `cancelOrder` function, but it is used for guest orders.
-The token is a unique value generated using guest's email, order number and postcode The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/orders/mutations/request-guest-order-cancel`/" text="requestGuestOrderCancel" /> mutation.
+The token is a unique value generated using guest's email, order number and postcode The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/orders/mutations/request-guest-order-cancel/" text="requestGuestOrderCancel" /> mutation.
 
 ```ts
 const requestGuestOrderCancel = async (
@@ -410,7 +410,7 @@ Returns `void`.
 
 ## requestGuestReturn
 
-The `requestGuestReturn` function initiates a return request for a guest order. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/orders/mutations/request-guest-return`/" text="requestGuestReturn" /> mutation.
+The `requestGuestReturn` function initiates a return request for a guest order. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/orders/mutations/request-guest-return/" text="requestGuestReturn" /> mutation.
 
 ```ts
 const requestGuestReturn = async (
@@ -448,7 +448,7 @@ Promise<{
 
 ## requestReturn
 
-The `requestReturn` function takes the `RequestReturnProps` form as an argument and initiates the process of returning items from an order. It is a wrapper for the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/orders/mutations/request-return`/" text="requestReturn" /> mutation.
+The `requestReturn` function takes the `RequestReturnProps` form as an argument and initiates the process of returning items from an order. It is a wrapper for the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/orders/mutations/request-return/" text="requestReturn" /> mutation.
 
 ```ts
 const requestReturn = async (
@@ -474,7 +474,7 @@ Returns `RequestReturnModel | {}`. See [`RequestReturnModel`](#requestreturnmode
 
 ## setPaymentMethodAndPlaceOrder
 
-The `setPaymentMethodAndPlaceOrder` function sets the payment method on a cart and immediately places the order. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/cart/mutations/set-payment-method-on-cart`/" text="setPaymentMethodOnCart" /> mutation.
+The `setPaymentMethodAndPlaceOrder` function sets the payment method on a cart and immediately places the order. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/cart/mutations/set-payment-method-on-cart/" text="setPaymentMethodOnCart" /> mutation.
 
 ```ts
 const setPaymentMethodAndPlaceOrder = async (

--- a/src/content/docs/dropins/product-details/containers/product-header.mdx
+++ b/src/content/docs/dropins/product-details/containers/product-header.mdx
@@ -9,6 +9,8 @@ The `ProductHeader` container is designed to display the header information of a
 
 The header displays the product name with the SKU below it. Set `hideSku` to `true` to hide the SKU.
 
+For **configurable** products, when the shopper has selected a full variant, product data on `pdp/data` can include `variantSku` and `variantName` (see [`getRefinedProduct`](/dropins/product-details/functions/#getrefinedproduct)). Set `showVariantSku` and/or `showVariantName` to `true` to show those values in the header in addition to the parent product name and SKU.
+
 The container receives initial product data during [initialization](/dropins/product-details/initialization/) to preload the component and, being event-driven, updates with data emitted to `pdp/data` within the event scope.
 
 ## ProductHeader configurations
@@ -21,6 +23,8 @@ The `ProductHeader` container provides the following configuration options:
     ['Option', 'Type', 'Req?', 'Description'],
     ['hideSku', 'boolean', 'No', 'Determines whether the SKU should be hidden in the header. Defaults to false.'],
     ['scope', 'string', 'No', 'Unique identifier for the PDP context. Only containers rendered with this scope will respond to product events.'],
+    ['showVariantSku', 'boolean', 'No', 'When true, displays the variant SKU when present on product data (configurable product with a resolved simple variant). Defaults to false.'],
+    ['showVariantName', 'boolean', 'No', 'When true, displays the variant name when present on product data (configurable product with a resolved simple variant). Defaults to false.'],
   ]}
 />
 
@@ -31,6 +35,8 @@ The following example demonstrates how to configure the `ProductHeader` containe
 ```js
 render(ProductHeader, {
   hideSku: false,
+  showVariantSku: true,
+  showVariantName: true,
 });
 ```
 

--- a/src/content/docs/dropins/product-details/functions.mdx
+++ b/src/content/docs/dropins/product-details/functions.mdx
@@ -116,7 +116,7 @@ Returns [`ValuesModel`](#valuesmodel) or `null`.
 
 ## getProductData
 
-The `getProductData` function returns the product data for a given product SKU. It fetches data from Adobe Commerce and optionally preselects the first available option. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/products/queries/products`/" text="products" /> query.
+The `getProductData` function returns the product data for a given product SKU. It fetches data from Adobe Commerce and optionally preselects the first available option. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/products/queries/products/" text="products" /> query.
 
 ```ts
 const getProductData = async (
@@ -147,7 +147,9 @@ Returns [`ProductModel`](#productmodel) or `null`.
 
 ## getRefinedProduct
 
-The `getRefinedProduct` function returns refined product data with specific options selected. This is used for configurable products where options have been chosen. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/products/queries/refine-product`/" text="refineProduct" /> query.
+The `getRefinedProduct` function returns refined product data with specific options selected. This is used for configurable products where options have been chosen. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/products/queries/refine-product/" text="refineProduct" /> query.
+
+For configurable products, the returned [`ProductModel`](#productmodel) always keeps the parent product’s `name` and `sku`. When refinement resolves to a simple variant (`SimpleProductView`), the model also includes `variantSku` and `variantName` for that variant so you can display or forward the child SKU and title (for example from the [`ProductHeader`](/dropins/product-details/containers/product-header/) container).
 
 ```ts
 const getRefinedProduct = async (
@@ -288,6 +290,7 @@ interface ProductModel {
   externalId?: string;
   externalParentId?: string;
   variantSku?: string;
+  variantName?: string;
   productType?: ProductType | undefined;
 }
 ```

--- a/src/content/docs/dropins/recommendations/functions.mdx
+++ b/src/content/docs/dropins/recommendations/functions.mdx
@@ -30,7 +30,7 @@ The Recommendations drop-in provides API functions that enable you to programmat
 
 ## getRecommendations
 
-The `getRecommendations` function retrieves product recommendations based on various parameters such as page type, current SKU, cart items, and user history. The function calls the `GraphQL` recommendations query and transforms the response into a standardized format. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/products/queries/recommendations`/" text="recommendations" /> query.
+The `getRecommendations` function retrieves product recommendations based on various parameters such as page type, current SKU, cart items, and user history. The function calls the `GraphQL` recommendations query and transforms the response into a standardized format. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/products/queries/recommendations/" text="recommendations" /> query.
 
 ```ts
 const getRecommendations = async (

--- a/src/content/docs/dropins/user-account/functions.mdx
+++ b/src/content/docs/dropins/user-account/functions.mdx
@@ -41,7 +41,7 @@ The User Account drop-in provides API functions that enable you to programmatica
 
 ## createCustomerAddress
 
-The `createCustomerAddress` function creates an address for an existing customer using the `CustomerAddressesModel` object as an argument. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/customer/mutations/create-address`/" text="createCustomerAddress" /> mutation.
+The `createCustomerAddress` function creates an address for an existing customer using the `CustomerAddressesModel` object as an argument. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/create-address/" text="createCustomerAddress" /> mutation.
 
 ```ts
 const createCustomerAddress = async (
@@ -67,7 +67,7 @@ Returns `string`.
 
 ## getAttributesForm
 
-The `getAttributesForm` function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/attributes/queries/attributes-form`/" text="attributesForm" /> query to retrieve EAV attributes associated with customer and customer address frontend forms. The `formCode` parameter must be one of the following values: `customer_account_create`, `customer_account_edit`, `customer_address_create`, or `customer_address_edit`.
+The `getAttributesForm` function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/attributes/queries/attributes-form/" text="attributesForm" /> query to retrieve EAV attributes associated with customer and customer address frontend forms. The `formCode` parameter must be one of the following values: `customer_account_create`, `customer_account_edit`, `customer_address_create`, or `customer_address_edit`.
 
 ```ts
 const getAttributesForm = async (
@@ -93,7 +93,7 @@ Returns `AttributesFormModel[]`.
 
 ## getCountries
 
-The `getCountries` function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/store/queries/countries`/" text="countries" /> query to retrieve a list of countries.
+The `getCountries` function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/store/queries/countries/" text="countries" /> query to retrieve a list of countries.
 
 ```ts
 const getCountries = async (): Promise<{
@@ -121,7 +121,7 @@ See [`Country`](#country).
 
 ## getCustomer
 
-The `getCustomer` function retrieves the customer information for the logged-in customer. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/customer/queries/customer`/" text="customer" /> query.
+The `getCustomer` function retrieves the customer information for the logged-in customer. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/queries/customer/" text="customer" /> query.
 
 ```ts
 const getCustomer = async (): Promise<CustomerDataModelShort>
@@ -137,7 +137,7 @@ Returns [`CustomerDataModelShort`](#customerdatamodelshort).
 
 ## getCustomerAddress
 
-The `getCustomerAddress` function returns an array of addresses associated with the current customer. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/customer/queries/customer`/" text="customer" /> query.
+The `getCustomerAddress` function returns an array of addresses associated with the current customer. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/queries/customer/" text="customer" /> query.
 
 ```ts
 const getCustomerAddress = async (): Promise<
@@ -161,7 +161,7 @@ See [`CustomerAddressesModel`](#customeraddressesmodel).
 
 ## getOrderHistoryList
 
-The `getOrderHistoryList` function is an asynchronous function that retrieves a list of customer orders using the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/customer/queries/customer`/" text="customer" /> query. It optionally takes parameters for pagination and filtering.
+The `getOrderHistoryList` function is an asynchronous function that retrieves a list of customer orders using the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/queries/customer/" text="customer" /> query. It optionally takes parameters for pagination and filtering.
 
 ```ts
 const getOrderHistoryList = async (
@@ -191,7 +191,7 @@ Returns [`OrderHistoryModel`](#orderhistorymodel) or `null`.
 
 ## getRegions
 
-The `getRegions` function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/store/queries/country`/" text="country" /> query to retrieve a list of states or provinces for a specific country.
+The `getRegions` function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/store/queries/country/" text="country" /> query to retrieve a list of states or provinces for a specific country.
 
 ```ts
 const getRegions = async (
@@ -217,7 +217,7 @@ Returns `RegionTransform[] | []`. See [`RegionTransform`](#regiontransform).
 
 ## getStoreConfig
 
-The `getStoreConfig` function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/store/queries/store-config`/" text="storeConfig" /> query to retrieve details about password requirements.
+The `getStoreConfig` function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/store/queries/store-config/" text="storeConfig" /> query to retrieve details about password requirements.
 
 ```ts
 const getStoreConfig = async (): Promise<StoreConfigModel>
@@ -233,7 +233,7 @@ Returns [`StoreConfigModel`](#storeconfigmodel).
 
 ## removeCustomerAddress
 
-The `removeCustomerAddress` function removes an address associated with the current customer. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/customer/mutations/delete-address`/" text="deleteCustomerAddress" /> mutation.
+The `removeCustomerAddress` function removes an address associated with the current customer. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/delete-address/" text="deleteCustomerAddress" /> mutation.
 
 ```ts
 const removeCustomerAddress = async (
@@ -259,7 +259,7 @@ Returns `boolean`.
 
 ## updateCustomer
 
-The `updateCustomer` function updates the logged-in customer. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/customer/mutations/update-v2`/" text="updateCustomerV2" /> mutation.
+The `updateCustomer` function updates the logged-in customer. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/update-v2/" text="updateCustomerV2" /> mutation.
 
 The `form` object keys are converted to snake_case using the `convertKeysCase` utility with specific mappings for `firstName`, `lastName`, `middleName`, and `custom_attributesV2`.
 
@@ -288,7 +288,7 @@ Returns `string`.
 
 ## updateCustomerAddress
 
-The `updateCustomerAddress` function updates an address associated with the current customer. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/customer/mutations/update-address`/" text="updateCustomerAddress" /> mutation.
+The `updateCustomerAddress` function updates an address associated with the current customer. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/update-address/" text="updateCustomerAddress" /> mutation.
 
 The `forms` object includes an `addressId`, which is a number representing the ID of the address to be updated and other address details as defined in `CustomerAddressesModel`.
 
@@ -316,7 +316,7 @@ Returns `string`.
 
 ## updateCustomerEmail
 
-The `updateCustomerEmail` function updates the email address of the logged-in customer. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/customer/mutations/update-email`/" text="updateCustomerEmail" /> mutation.
+The `updateCustomerEmail` function updates the email address of the logged-in customer. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/update-email/" text="updateCustomerEmail" /> mutation.
 
 ```ts
 const updateCustomerEmail = async (
@@ -342,7 +342,7 @@ Returns `string`.
 
 ## updateCustomerPassword
 
-The `updateCustomerPassword` function updates the password of the logged-in customer. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/customer/mutations/change-password`/" text="changeCustomerPassword" /> mutation.
+The `updateCustomerPassword` function updates the password of the logged-in customer. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/change-password/" text="changeCustomerPassword" /> mutation.
 
 ```ts
 const updateCustomerPassword = async (

--- a/src/content/docs/dropins/user-auth/functions.mdx
+++ b/src/content/docs/dropins/user-auth/functions.mdx
@@ -42,7 +42,7 @@ The User Auth drop-in provides API functions that enable you to programmatically
 
 ## confirmEmail
 
-The `confirmEmail` function completes the customer activation process using the supplied `customerEmail` and `customerConfirmationKey` parameters. Adobe Commerce sends the confirmation key to the customer when they request to create an account. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/customer/mutations/confirm-email`/" text="confirmEmail mutation" />.
+The `confirmEmail` function completes the customer activation process using the supplied `customerEmail` and `customerConfirmationKey` parameters. Adobe Commerce sends the confirmation key to the customer when they request to create an account. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/confirm-email/" text="confirmEmail mutation" />.
 
 ```ts
 const confirmEmail = async (
@@ -68,7 +68,7 @@ Returns `confirmEmailResponse | undefined`.
 
 ## createCustomer
 
-The `createCustomer` function creates a customer account based on the data supplied in the `forms` parameter. By default, the function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/customer/mutations/create`/" text="createCustomer mutation" />. If the `apiVersion2` parameter is set to `true`, the function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/customer/mutations/create-v2`/" text="createCustomerV2 mutation" />.
+The `createCustomer` function creates a customer account based on the data supplied in the `forms` parameter. By default, the function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/create/" text="createCustomer mutation" />. If the `apiVersion2` parameter is set to `true`, the function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/create-v2/" text="createCustomerV2 mutation" />.
 
 ```ts
 const createCustomer = async (
@@ -96,7 +96,7 @@ Returns [`CustomerModel`](#customermodel).
 
 ## createCustomerAddress
 
-The `createCustomerAddress` function defines a new customer address. The customer can subsequently designate the address for billing or shipping orders. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/customer/mutations/create-address`/" text="createCustomerAddress mutation" />.
+The `createCustomerAddress` function defines a new customer address. The customer can subsequently designate the address for billing or shipping orders. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/create-address/" text="createCustomerAddress mutation" />.
 
 ```ts
 const createCustomerAddress = async (
@@ -138,7 +138,7 @@ Returns [`AdobeCommerceOptimizerModel`](#adobecommerceoptimizermodel).
 
 ## getAttributesForm
 
-The `getAttributesForm` function retrieves EAV attributes associated with customer and customer address frontend forms. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/attributes/queries/attributes-form`/" text="attributesForm query" />.
+The `getAttributesForm` function retrieves EAV attributes associated with customer and customer address frontend forms. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/attributes/queries/attributes-form/" text="attributesForm query" />.
 
 ```ts
 const getAttributesForm = async (
@@ -164,7 +164,7 @@ Returns `AttributesFormModel[]`.
 
 ## getCustomerData
 
-The `getCustomerData` function retrieves data about the customer represented by the value of the `auth_dropin_user_token` parameter. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/customer/queries/customer`/" text="customer query" />.
+The `getCustomerData` function retrieves data about the customer represented by the value of the `auth_dropin_user_token` parameter. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/queries/customer/" text="customer query" />.
 
 ```ts
 const getCustomerData = async (
@@ -211,10 +211,10 @@ The `getCustomerToken` function handles the sign-in operation. It requires `user
 1. Retrieves the customer token.
 2. Fetches customer data using the token.
 3. Sets the `auth_dropin_firstname` and `auth_dropin_user_token` cookies.
-4. Publishes an <Link href="https://github.`com/adobe/adobe-client-data-layer`" text="Adobe Client Data Layer (ACDL)" /> event.
+4. Publishes an <Link href="https://github.com/adobe/adobe-client-data-layer" text="Adobe Client Data Layer (ACDL)" /> event.
 5. Emits an "authenticated" event.
 
-You can use the `getCustomerToken` function to build a custom authentication flow that remains fully integrated with other drop-in components. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/customer/mutations/generate-token`/" text="generateCustomerToken mutation" />.
+You can use the `getCustomerToken` function to build a custom authentication flow that remains fully integrated with other drop-in components. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/generate-token/" text="generateCustomerToken mutation" />.
 
 ```ts
 const getCustomerToken = async (
@@ -250,7 +250,7 @@ Promise<{
 
 ## getStoreConfig
 
-The `getStoreConfig` function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/store/queries/store-config`/" text="storeConfig query" /> to retrieve store configuration data.
+The `getStoreConfig` function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/store/queries/store-config/" text="storeConfig query" /> to retrieve store configuration data.
 
 ```ts
 const getStoreConfig = async (): Promise<StoreConfigModel>
@@ -266,7 +266,7 @@ Returns [`StoreConfigModel`](#storeconfigmodel).
 
 ## requestPasswordResetEmail
 
-The `requestPasswordResetEmail` function initiates the process of resetting a customer's password. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/customer/mutations/request-password-reset-email`/" text="requestPasswordResetEmail mutation" />.
+The `requestPasswordResetEmail` function initiates the process of resetting a customer's password. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/request-password-reset-email/" text="requestPasswordResetEmail mutation" />.
 
 ```ts
 const requestPasswordResetEmail = async (
@@ -292,7 +292,7 @@ Returns [`PasswordResetEmailModel`](#passwordresetemailmodel).
 
 ## resendConfirmationEmail
 
-The `resendConfirmationEmail` function resends the email confirmation to the customer using the supplied `customerEmail` parameter. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/customer/mutations/resend-confirmation-email`/" text="resendConfirmationEmail mutation" />, which is included in the Storefront Compatibility Package.
+The `resendConfirmationEmail` function resends the email confirmation to the customer using the supplied `customerEmail` parameter. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/resend-confirmation-email/" text="resendConfirmationEmail mutation" />, which is included in the Storefront Compatibility Package.
 
 ```ts
 const resendConfirmationEmail = async (
@@ -318,7 +318,7 @@ Returns `resendConfirmationEmailResponse`.
 
 ## resetPassword
 
-The `resetPassword` function resets a customer's password using the supplied `email`, `resetPasswordToken`, and `newPassword` parameters. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/customer/mutations/reset-password`/" text="resetPassword mutation" />.
+The `resetPassword` function resets a customer's password using the supplied `email`, `resetPasswordToken`, and `newPassword` parameters. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/reset-password/" text="resetPassword mutation" />.
 
 ```ts
 const resetPassword = async (
@@ -348,7 +348,7 @@ Returns [`ResetPasswordModel`](#resetpasswordmodel).
 
 ## revokeCustomerToken
 
-The `revokeCustomerToken` function revokes the customer's token and clears cookie. It then publishes an ACDL event and emits an "authenticated" event. This API can also be used to build a custom sign-out flow that stays fully integrated with other drop-in components. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/customer/mutations/revoke-token`/" text="revokeCustomerToken mutation" />.
+The `revokeCustomerToken` function revokes the customer's token and clears cookie. It then publishes an ACDL event and emits an "authenticated" event. This API can also be used to build a custom sign-out flow that stays fully integrated with other drop-in components. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/revoke-token/" text="revokeCustomerToken mutation" />.
 
 ```ts
 const revokeCustomerToken = async (): Promise<RevokeCustomerTokenModel>

--- a/src/content/docs/dropins/wishlist/functions.mdx
+++ b/src/content/docs/dropins/wishlist/functions.mdx
@@ -37,7 +37,7 @@ The Wishlist drop-in provides API functions that enable you to programmatically 
 
 ## addProductsToWishlist
 
-The `addProductsToWishlist` function allows you to add products to a user's wishlist. This function is typically used when a user wants to save a product for later purchase. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/wishlist/mutations/add-products-to-wishlist`/" text="addProductsToWishlist" /> mutation.
+The `addProductsToWishlist` function allows you to add products to a user's wishlist. This function is typically used when a user wants to save a product for later purchase. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/wishlist/mutations/add-products-to-wishlist/" text="addProductsToWishlist" /> mutation.
 
 ```ts
 const addProductsToWishlist = async (
@@ -81,7 +81,7 @@ Returns [`StoreConfigModel`](#storeconfigmodel) or `null`.
 
 ## getWishlistById
 
-The `getWishlistById` function retrieves a wishlist by its ID. This is useful for accessing a specific user's wishlist. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/wishlist/queries/wishlist`/" text="wishlist_v2" /> query.
+The `getWishlistById` function retrieves a wishlist by its ID. This is useful for accessing a specific user's wishlist. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/wishlist/queries/wishlist/" text="wishlist_v2" /> query.
 
 ```ts
 const getWishlistById = async (
@@ -149,7 +149,7 @@ function mergeWishlists(wishlist: Wishlist): Promise<Wishlist | null>
 
 ## removeProductsFromWishlist
 
-The `removeProductsFromWishlist` function allows you to remove products from a user's wishlist. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/wishlist/mutations/remove-products-from-wishlist`/" text="removeProductsFromWishlist" /> mutation.
+The `removeProductsFromWishlist` function allows you to remove products from a user's wishlist. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/wishlist/mutations/remove-products-from-wishlist/" text="removeProductsFromWishlist" /> mutation.
 
 ```ts
 const removeProductsFromWishlist = async (
@@ -191,7 +191,7 @@ Returns [`Wishlist`](#wishlist) or `null`.
 
 ## updateProductsInWishlist
 
-The `updateProductsInWishlist` function allows you to update the quantity of products in a user's wishlist. The function calls the <Link href="https://developer.adobe.`com/commerce/webapi/graphql/schema/wishlist/mutations/update-products-in-wishlist`/" text="updateProductsInWishlist" /> mutation.
+The `updateProductsInWishlist` function allows you to update the quantity of products in a user's wishlist. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/wishlist/mutations/update-products-in-wishlist/" text="updateProductsInWishlist" /> mutation.
 
 ```ts
 const updateProductsInWishlist = async (


### PR DESCRIPTION
## Purpose of this pull request

Add showVariantSku and showVariantName to decide whether the variant name or variant sku for a configurable product must be shown or not.

Also, I've encountered errors in some links within the drop-in function sections, where a lot of links had backticks, linking to a wrong URL.

e.g. 

within https://experienceleague.adobe.com/developer/commerce/storefront/dropins/product-details/functions/#getproductdata

the text says:

The function calls the [products](https://developer.adobe.`com/commerce/webapi/graphql/schema/products/queries/products%60/) query.

while the link should be:

https://developer.adobe.com/commerce/webapi/graphql/schema/products/queries/products/

### Associated JIRA ticket

https://jira.corp.adobe.com/browse/ACCS-603

### Staging preview

<img width="1613" height="832" alt="Screenshot 2026-03-25 at 15 00 31" src="https://github.com/user-attachments/assets/447085a9-7922-4ce7-a5df-b61e0f2593f7" />

<img width="1220" height="854" alt="Screenshot 2026-03-25 at 15 12 03" src="https://github.com/user-attachments/assets/7089118e-a11b-4677-a0d2-7f8973621dea" />

<img width="1182" height="294" alt="Screenshot 2026-03-25 at 15 22 03" src="https://github.com/user-attachments/assets/d3c3abd5-fad1-4e04-8e8c-db18291a4605" />

## Affected pages

<!-- REQUIRED List the affected pages on experienceleague.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://experienceleague.adobe.com/developer/commerce/storefront/dropins/product-details/containers/product-header/
- https://experienceleague.adobe.com/developer/commerce/storefront/dropins/product-details/functions/#productmodel
- https://experienceleague.adobe.com/developer/commerce/storefront/dropins/cart/functions/#getestimateshipping

## Links to source code

- https://github.com/adobe-commerce/storefront-pdp/pull/63
- https://github.com/adobe-commerce/storefront-pdp/pull/64

### What's New highlights

<!--  _OPTIONAL - REMOVE THIS SECTION IF NOT USED._

If this pull request introduces changes that should be highlighted in What's New documentation reports.
-->

