### PR TITLE
adds a performance best practices page, and references it in places.

### DIFF
--- a/astro.sidebar.mjs
+++ b/astro.sidebar.mjs
@@ -28,6 +28,7 @@ export function generateSidebar() {
             { label: 'Create a storefront', link: '/get-started/create-storefront/' },
             { label: 'Browser compatibility', link: '/get-started/browser-compatibility/' },
             { label: 'Lighthouse audits', link: '/get-started/run-lighthouse/' },
+            { label: 'Performance best practices', link: '/get-started/performance/' },
             { label: "Launch checklist", link: "setup/launch/" },
           ],
         },

--- a/src/content/docs/boilerplate/blocks-reference.mdx
+++ b/src/content/docs/boilerplate/blocks-reference.mdx
@@ -171,6 +171,8 @@ Enhance your storefront with:
 
 ## Performance considerations
 
+For storefront-wide guidance see [Performance best practices](/get-started/performance/).
+
 ### Lazy loading
 
 Commerce blocks are lazy-loaded automatically:

--- a/src/content/docs/get-started/index.mdx
+++ b/src/content/docs/get-started/index.mdx
@@ -55,6 +55,14 @@ Quick Start provides everything you need to begin building with Adobe Commerce S
   <LinkCard
     noborder
     icon='document'
+    title="Performance best practices"
+    description='Apply best practices to ensure your site performance is optimized and aligned with <a href="https://www.aem.live/developer/keeping-it-100" target="_blank" rel="noopener noreferrer" style="position: relative; z-index: 2;">Keeping it 100</a>.'
+    link="/get-started/performance/"
+    rightIcon="right-arrow"
+  />
+  <LinkCard
+    noborder
+    icon='document'
     title="Launch Checklist"
     description="Verify that you have completed all recommended steps before launching your storefront project."
     link="/setup/launch/"

--- a/src/content/docs/get-started/performance.mdx
+++ b/src/content/docs/get-started/performance.mdx
@@ -1,0 +1,36 @@
+---
+title: Performance best practices
+description: Align your Commerce storefront with Adobe Edge Delivery performance guidance (Keeping it 100), with boilerplate-specific file locations and links to storefront docs.
+sidebar:
+  label: Performance best practices
+  order: 3
+---
+
+import Link from '@components/Link.astro';
+import { Aside } from '@astrojs/starlight/components';
+
+Adobe Commerce storefronts on Edge Delivery Services follow the same performance model as other AEM boilerplate projects. The authoritative explanation—**Eager, Lazy, and Delayed** loading, **LCP**, what belongs in each phase, fonts, and common anti-patterns (including when **not** to preload or use early hints)—is in <Link href="https://www.aem.live/developer/keeping-it-100" text="Web Performance, Keeping your Lighthouse Score 100" /> on AEM.live. Read that first; this page only maps those ideas to the **Commerce boilerplate** and points to related storefront docs.
+
+## Where it shows up in the Commerce boilerplate
+
+### Delayed phase
+
+<Link href="https://www.aem.live/developer/keeping-it-100" text="Keeping it 100" /> describes a **Delayed** phase for third-party tags, marketing tooling, extended analytics, consent, chat, and similar scripts—usually via `delayed.js`, and timed so they do not compete with **LCP** and the rest of the experience.
+
+In the Commerce boilerplate, put that work in <Link href="https://github.com/hlxsites/aem-boilerplate-commerce/blob/main/scripts/delayed.js" text="`scripts/delayed.js`" />, not on the eager path. For Adobe Experience Platform and related patterns, see [Adobe Experience Platform analytics](/setup/analytics/adobe-experience-platform/).
+
+### Eager vs lazy styles
+
+The "Keeping it 100" guide’s **eager** phase is where everything required for the real **LCP** element must be ready (markup, CSS, and JS for that experience), within the **network and payload constraints** it describes— including why **indiscriminate** `preload`, early hints, and preconnect can **hurt** mobile **LCP** if they pull bandwidth away from what the visitor actually needs first.
+
+In the Commerce boilerplate, global design tokens and site-wide styles typically live in <Link href="https://github.com/hlxsites/aem-boilerplate-commerce/blob/main/styles/styles.css" text="`styles/styles.css`" />; non-critical styles are deferred per [Branding and styles](/dropins/all/branding/) (for example **`lazy-styles.css`** after LCP). Tune **`head.html`** and loading order in line with **Keeping it 100**, not a separate set of rules. The "Keeping it 100" guide also explains why **preloading web fonts** is usually **counterproductive** for performance—prefer the boilerplate’s font fallback behavior unless you have a measured exception.
+
+<Aside type="tip" title="Related storefront docs">
+Catalog-oriented tips (images, APIs, loading order) are in the [FAQ](/troubleshooting/faq#how-can-i-improve-the-performance-of-my-catalog-pages). Validate changes with [Lighthouse audits](/get-started/run-lighthouse/) and the [launch checklist](/setup/launch/#performance-and-monitoring).
+</Aside>
+
+## See also
+
+- <Link href="https://www.aem.live/developer/keeping-it-100" text="Keeping it 100 — Web Performance (AEM.live)" />
+- [Run Lighthouse audits](/get-started/run-lighthouse/)
+- [Launch checklist — Performance and monitoring](/setup/launch/#performance-and-monitoring)

--- a/src/content/docs/get-started/performance.mdx
+++ b/src/content/docs/get-started/performance.mdx
@@ -1,5 +1,5 @@
 ---
-title: Performance best practices
+title: Performance Best Practices
 description: Align your Commerce storefront with Adobe Edge Delivery performance guidance (Keeping it 100), with boilerplate-specific file locations and links to storefront docs.
 sidebar:
   label: Performance best practices
@@ -7,30 +7,57 @@ sidebar:
 ---
 
 import Link from '@components/Link.astro';
+import LinkCard from '@components/LinkCard.astro';
 import { Aside } from '@astrojs/starlight/components';
+import { Steps } from '@astrojs/starlight/components';
 
-Adobe Commerce storefronts on Edge Delivery Services follow the same performance model as other AEM boilerplate projects. The authoritative explanation—**Eager, Lazy, and Delayed** loading, **LCP**, what belongs in each phase, fonts, and common anti-patterns (including when **not** to preload or use early hints)—is in <Link href="https://www.aem.live/developer/keeping-it-100" text="Web Performance, Keeping your Lighthouse Score 100" /> on AEM.live. Read that first; this page only maps those ideas to the **Commerce boilerplate** and points to related storefront docs.
+When you change how scripts and styles load on the Adobe Commerce boilerplate, you follow the same performance model as other Edge Delivery storefronts. The sections below map eager, lazy, and delayed loading—and ideas such as LCP and fonts—to concrete files and load order in your project.
 
-## Where it shows up in the Commerce boilerplate
+<LinkCard
+  noborder
+  icon="rocket"
+  title="Start with Keeping it 100 on AEM.live"
+  description="The canonical guide covers eager, lazy, and delayed loading, Largest Contentful Paint (LCP), fonts, and mistakes such as overusing <code>preload</code> and early hints. Read it before you edit <code>head.html</code> or split CSS."
+  link="https://www.aem.live/developer/keeping-it-100"
+  rightIcon="external"
+  target="_blank"
+  rel="noopener noreferrer"
+  aria-label="Keeping it 100 on AEM.live (opens in a new tab)"
+/>
+
+## How to use this page
+
+<Steps>
+1. Read Keeping it 100 to understand the eager, lazy, and delayed phases and LCP limits.
+1. Use the sections below to map each phase to files in the Commerce boilerplate.
+1. After you change loading behavior, run [Lighthouse audits](/get-started/run-lighthouse/) and review [Performance and monitoring](/setup/launch/#performance-and-monitoring) on the launch checklist.
+</Steps>
+
+## Performance in the Commerce boilerplate
 
 ### Delayed phase
 
-<Link href="https://www.aem.live/developer/keeping-it-100" text="Keeping it 100" /> describes a **Delayed** phase for third-party tags, marketing tooling, extended analytics, consent, chat, and similar scripts—usually via `delayed.js`, and timed so they do not compete with **LCP** and the rest of the experience.
+<Link href="https://www.aem.live/developer/keeping-it-100" text="Keeping it 100" /> describes a delayed phase for third-party tags, marketing tooling, extended analytics, consent, chat, and similar scripts. Load them through `delayed.js` so they do not compete with LCP or the rest of the experience.
 
-In the Commerce boilerplate, put that work in <Link href="https://github.com/hlxsites/aem-boilerplate-commerce/blob/main/scripts/delayed.js" text="`scripts/delayed.js`" />, not on the eager path. For Adobe Experience Platform and related patterns, see [Adobe Experience Platform analytics](/setup/analytics/adobe-experience-platform/).
+In the Commerce boilerplate, implement that path in <Link href="https://github.com/hlxsites/aem-boilerplate-commerce/blob/main/scripts/delayed.js" text="`scripts/delayed.js`" />. Keep it off the eager path. For Adobe Experience Platform and related patterns, see [Adobe Experience Platform analytics](/setup/analytics/adobe-experience-platform/).
 
 ### Eager vs lazy styles
 
-The "Keeping it 100" guide’s **eager** phase is where everything required for the real **LCP** element must be ready (markup, CSS, and JS for that experience), within the **network and payload constraints** it describes— including why **indiscriminate** `preload`, early hints, and preconnect can **hurt** mobile **LCP** if they pull bandwidth away from what the visitor actually needs first.
+Keeping it 100 treats styles in two phases so LCP stays predictable.
 
-In the Commerce boilerplate, global design tokens and site-wide styles typically live in <Link href="https://github.com/hlxsites/aem-boilerplate-commerce/blob/main/styles/styles.css" text="`styles/styles.css`" />; non-critical styles are deferred per [Branding and styles](/dropins/all/branding/) (for example **`lazy-styles.css`** after LCP). Tune **`head.html`** and loading order in line with **Keeping it 100**, not a separate set of rules. The "Keeping it 100" guide also explains why **preloading web fonts** is usually **counterproductive** for performance—prefer the boilerplate’s font fallback behavior unless you have a measured exception.
+The **eager** phase is for everything the real LCP element needs right away: markup, CSS, and JavaScript for that first paint. Stay within the network and payload limits the guide describes.
 
-<Aside type="tip" title="Related storefront docs">
-Catalog-oriented tips (images, APIs, loading order) are in the [FAQ](/troubleshooting/faq#how-can-i-improve-the-performance-of-my-catalog-pages). Validate changes with [Lighthouse audits](/get-started/run-lighthouse/) and the [launch checklist](/setup/launch/#performance-and-monitoring).
+<Aside type="caution" title="Preload and early hints">
+Indiscriminate <code>preload</code>, early hints, and <code>preconnect</code> can steal bandwidth from what the visitor needs first and hurt mobile LCP. Keeping it 100 explains how to stay inside safe limits instead of adding every hint you can think of.
 </Aside>
 
-## See also
+The **lazy** phase is for styles (and related assets) that do not need to block the first paint of the LCP element. You load them after LCP so they do not extend the critical path. For how the storefront splits global versus deferred CSS—including patterns such as `lazy-styles.css`—read [Branding and styles](/dropins/all/branding/).
 
-- <Link href="https://www.aem.live/developer/keeping-it-100" text="Keeping it 100 — Web Performance (AEM.live)" />
-- [Run Lighthouse audits](/get-started/run-lighthouse/)
-- [Launch checklist — Performance and monitoring](/setup/launch/#performance-and-monitoring)
+### File layout for eager and lazy CSS
+
+In the Commerce boilerplate, eager, site-wide tokens and styles usually live in <Link href="https://github.com/hlxsites/aem-boilerplate-commerce/blob/main/styles/styles.css" text="`styles/styles.css`" />. Deferred (lazy) CSS belongs in the patterns described in [Branding and styles](/dropins/all/branding/)—for example `lazy-styles.css`—not bundled into the eager file. Align `head.html` and load order with Keeping it 100 instead of inventing a parallel rule set. Keeping it 100 also explains why preloading web fonts is usually counterproductive. Rely on the Commerce boilerplate's font fallbacks unless you have a measured reason to change that.
+
+<Aside type="tip" title="Related storefront docs">
+For catalog-oriented tips (images, APIs, loading order), see the [FAQ](/troubleshooting/faq#how-can-i-improve-the-performance-of-my-catalog-pages). After you change loading behavior, run [Lighthouse audits](/get-started/run-lighthouse/) and review the [launch checklist](/setup/launch/#performance-and-monitoring).
+</Aside>
+

--- a/src/content/docs/get-started/run-lighthouse.mdx
+++ b/src/content/docs/get-started/run-lighthouse.mdx
@@ -24,6 +24,8 @@ PageSpeed Insights is the most accurate way to audit your storefront's Web Vital
 
 Visit the Adobe Experience Manager docs topic, [Keeping it 100](https://www.aem.live/developer/keeping-it-100) 💯, to learn more about what PageSpeed Insights measure and how to keep your storefront at 100.
 
+For implementation-focused guidance see [Performance best practices](/get-started/performance/).
+
 ## Step-by-step
 
 <Steps>

--- a/src/content/docs/setup/launch/index.mdx
+++ b/src/content/docs/setup/launch/index.mdx
@@ -47,6 +47,7 @@ As you develop, carefully track all changes made in development or staging envir
 <Checklist checklistKey="performance">
 ### Performance and monitoring
 
+* [ ] Ensure you have followed all [Performance best practices](/get-started/performance/).
 * [ ] (Optional) Configure Google Analytics and Google Tag Manager.
 * [ ] Validate your [storefront
       events](https://github.com/adobe/commerce-events/tree/main/examples/events/snowplow-debugger)

--- a/src/content/docs/troubleshooting/faq.mdx
+++ b/src/content/docs/troubleshooting/faq.mdx
@@ -43,6 +43,8 @@ See the <Link href="https://experienceleague.adobe.com/en/docs/commerce/saas-dat
 
 ## How can I improve the performance of my catalog pages?
 
+For storefront-wide guidance see [Performance best practices](/get-started/performance/).
+
 ### Images
 
 - Product images should be delivered in the appropriate size and should not be delivered larger than their rendered size. Use Fastly Image Optimizer where possible to deliver images in modern `.webp` format.


### PR DESCRIPTION
I had a hard time finding clear messaging about our stance on performance, especially for "delayed" loading, and css.

There are certainly other things we can add, but I figured we just need to start with a best practices page, correlate it to AEM's docs (since they already go over a lot of this). We can add commerce specific best practices to our docs (as I do in this PR).