### PR TITLE
Add build:stage script to package.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ scripts/verify-*.js
 # AI editor config
 .claude/
 .cursor/
+.intent/

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Install Node.js and pnpm:
 
 - `pnpm dev` — Start the local dev server and open a browser. The site auto-reloads when you save.
 - `pnpm build`, `pnpm build:prod`, and `pnpm build:prod-fast` — Run the Astro build. `build:prod-fast` skips compression for a faster production check (handy before opening a PR).
+- `pnpm build:stage` — Build for a staging environment. Requires a `STAGE_URL` environment variable to set the site URL (e.g. `STAGE_URL=https://my-stage.example.com pnpm build:stage`).
 - `pnpm clean` — Reinstall dependencies (removes `node_modules`, `dist`, `.astro`).
 - `pnpm scrub` — Nuclear option: same as clean but also removes `pnpm-lock.yaml`.
 

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "preview": "NODE_ENV=development astro preview --open",
     "build:prod": "NODE_ENV=production VITE_PROD_BASE_PATH=/developer/commerce/storefront astro build",
     "build:prod-fast": "NODE_ENV=production VITE_PROD_BASE_PATH=/developer/commerce/storefront SKIP_COMPRESSION=true astro build",
+    "build:stage": "NODE_ENV=github VITE_GITHUB_BASE_PATH='' pnpm astro build --site ${STAGE_URL}",
     "preview:prod": "NODE_ENV=production VITE_PROD_BASE_PATH=/developer/commerce/storefront astro preview",
     "preview:prod-fast": "NODE_ENV=production VITE_PROD_BASE_PATH=/developer/commerce/storefront SKIP_COMPRESSION=true astro preview",
     "lint": "prettier --write  \"**/*.{js,jsx,ts,tsx,md,mdx,astro}\" && eslint --fix \"src/**/*.{js,ts,jsx,tsx,astro}\"",


### PR DESCRIPTION
## Purpose of this pull request

This pull request improves the local and CI workflow for **staging builds** and keeps repo ignores in line with optional tooling directories.

**Summary**

- Adds a `build:stage` npm script that runs an Astro build with `NODE_ENV=github`, empty GitHub base path, and `STAGE_URL` passed as the build site (for staging/preview hosts).
- Documents `pnpm build:stage` and the required `STAGE_URL` variable in the README.
- Adds `.intent/` to `.gitignore` so local intent/tooling files are not tracked.

**Type of content:** Configuration and contributor documentation (no storefront user-guide content changes).

### Associated JIRA ticket

COMDOX-1348
