### PR TITLE
ACCS-726: Add a numeric attribute format sample

### DIFF
--- a/src/content/docs/dropins/product-details/containers/product-attributes.mdx
+++ b/src/content/docs/dropins/product-details/containers/product-attributes.mdx
@@ -18,7 +18,7 @@ The `ProductAttributes` container provides the following configuration options:
   options={[
     ['Option', 'Type', 'Req?', 'Description'],
     ['scope', 'string', 'No', 'Unique identifier for the PDP context. Only containers rendered with this scope will respond to product events.'],
-    ['formatValue', '(value, id, label) => string', 'No', 'Custom formatter for attribute display values.'],
+    ['formatValue', '(value, id, label) => string', 'No', ''A function that formats an attribute value for display. Receives the raw value, attribute ID, and label; returns the string to display.''],
   ]}
 />
 
@@ -34,7 +34,7 @@ return productRenderer.render(ProductAttributes, {
 
 ### Formatting numeric attributes
 
-Numeric attributes from the catalog (e.g., `10.000000`) are displayed as-is by default. To format them, use the `formatValue` prop with your own formatter:
+Numeric attributes from the catalog (for example, `10.000000`) appear exactly as stored. To change how a number displays, pass a formatting function to the `formatValue` prop:
 
 ```js
 const formatNumericAttribute = (value) => {

--- a/src/content/docs/dropins/product-details/containers/product-attributes.mdx
+++ b/src/content/docs/dropins/product-details/containers/product-attributes.mdx
@@ -34,14 +34,23 @@ return productRenderer.render(ProductAttributes, {
 
 ### Formatting numeric attributes
 
-Numeric attributes from the catalog (e.g., `10.000000`) are displayed as-is by default. To format them, use the `formatValue` prop with the built-in `formatNumeric` utility:
+Numeric attributes from the catalog (e.g., `10.000000`) are displayed as-is by default. To format them, use the `formatValue` prop with your own formatter:
 
 ```js
-import { isNumericValue, formatNumeric } from '@dropins/storefront-pdp/lib/number';
+const formatNumericAttribute = (value) => {
+  const trimmed = value.trim();
+
+  if (!/^[+-]?\d+(\.\d+)?$/.test(trimmed)) {
+    return value;
+  }
+
+  return new Intl.NumberFormat(document.documentElement.lang).format(
+    Number(trimmed),
+  );
+};
 
 return productRenderer.render(ProductAttributes, {
-  formatValue: (value) =>
-    isNumericValue(value) ? formatNumeric(value) : value,
+  formatValue: formatNumericAttribute,
 });
 ```
 
@@ -50,11 +59,21 @@ This strips trailing zeros: `10.000000` becomes `10`, `0.010000` becomes `0.01`.
 To format only specific attributes, use the `id` parameter:
 
 ```js
-import { formatNumeric } from '@dropins/storefront-pdp/lib/number';
+const formatNumericAttribute = (value) => {
+  const trimmed = value.trim();
+
+  if (!/^[+-]?\d+(\.\d+)?$/.test(trimmed)) {
+    return value;
+  }
+
+  return new Intl.NumberFormat(document.documentElement.lang).format(
+    Number(trimmed),
+  );
+};
 
 return productRenderer.render(ProductAttributes, {
   formatValue: (value, id) => {
-    if (id === 'weight') return formatNumeric(value);
+    if (id === 'weight') return formatNumericAttribute(value);
     return value;
   },
 });

--- a/src/content/docs/dropins/product-details/containers/product-attributes.mdx
+++ b/src/content/docs/dropins/product-details/containers/product-attributes.mdx
@@ -18,6 +18,7 @@ The `ProductAttributes` container provides the following configuration options:
   options={[
     ['Option', 'Type', 'Req?', 'Description'],
     ['scope', 'string', 'No', 'Unique identifier for the PDP context. Only containers rendered with this scope will respond to product events.'],
+    ['formatValue', '(value, id, label) => string', 'No', 'Custom formatter for attribute display values.'],
   ]}
 />
 
@@ -28,5 +29,33 @@ The following example demonstrates how to configure the `ProductAttributes` cont
 ```js
 return productRenderer.render(ProductAttributes, {
   scope: 'modal', // optional
+});
+```
+
+### Formatting numeric attributes
+
+Numeric attributes from the catalog (e.g., `10.000000`) are displayed as-is by default. To format them, use the `formatValue` prop with the built-in `formatNumeric` utility:
+
+```js
+import { isNumericValue, formatNumeric } from '@dropins/storefront-pdp/lib/number';
+
+return productRenderer.render(ProductAttributes, {
+  formatValue: (value) =>
+    isNumericValue(value) ? formatNumeric(value) : value,
+});
+```
+
+This strips trailing zeros: `10.000000` becomes `10`, `0.010000` becomes `0.01`.
+
+To format only specific attributes, use the `id` parameter:
+
+```js
+import { formatNumeric } from '@dropins/storefront-pdp/lib/number';
+
+return productRenderer.render(ProductAttributes, {
+  formatValue: (value, id) => {
+    if (id === 'weight') return formatNumeric(value);
+    return value;
+  },
 });
 ```

--- a/src/content/docs/dropins/product-details/containers/product-attributes.mdx
+++ b/src/content/docs/dropins/product-details/containers/product-attributes.mdx
@@ -59,18 +59,6 @@ This strips trailing zeros: `10.000000` becomes `10`, `0.010000` becomes `0.01`.
 To format only specific attributes, use the `id` parameter:
 
 ```js
-const formatNumericAttribute = (value) => {
-  const trimmed = value.trim();
-
-  if (!/^[+-]?\d+(\.\d+)?$/.test(trimmed)) {
-    return value;
-  }
-
-  return new Intl.NumberFormat(document.documentElement.lang).format(
-    Number(trimmed),
-  );
-};
-
 return productRenderer.render(ProductAttributes, {
   formatValue: (value, id) => {
     if (id === 'weight') return formatNumericAttribute(value);


### PR DESCRIPTION
## Purpose of this pull request

Adds documentation for formatting product attributes in the `ProductAttributes` container, with examples focused on numeric attribute values.

### Associated JIRA ticket

https://jira.corp.adobe.com/browse/ACCS-726

## Affected pages

- src/content/docs/dropins/product-details/containers/product-attributes.mdx: http://localhost:4321/dropins/product-details/containers/product-attributes/#productattributes-configurations

## Links to source code

- https://github.com/adobe-commerce/storefront-pdp/pull/65

### What's New highlights

- Documents the formatValue option for the ProductAttributes container
- Adds an example using formatNumeric and isNumericValue to format numeric catalog attribute values
- Shows how to target formatting for specific attributes using the attribute id