### PR TITLE
remove ref to helix config sheet

### DIFF
--- a/src/content/docs/setup/launch/index.mdx
+++ b/src/content/docs/setup/launch/index.mdx
@@ -72,7 +72,7 @@ As you develop, carefully track all changes made in development or staging envir
 ### CDN and caching
 
 * [ ] Update your CDN configuration with your production GraphQL endpoint (`yourproject.com/graphql`). Use that endpoint for all Sidekick extensions and scripts (for example, sitemap generation and the image importer).
-* [ ] Request a new CDN purge token for the Adobe Commerce production environment when you use Adobe Commerce Fastly. Update the `.helix/config.xlsx` file in SharePoint with the `authToken` and `serviceId` values.
+* [ ] Request a new CDN purge token for the Adobe Commerce production environment when you use Adobe Commerce Fastly. Update your [site configuration](https://tools.aem.live/tools/cdn-setup/index.html) with the `authToken` and `serviceId` values.
 * [ ] Validate your [CDN configuration](/setup/configuration/content-delivery-network/) and ensure that caching
       and cache invalidation work as expected.
 * [ ] Add a store-specific cache buster to the Catalog Service and Live Search requests for [multi-store setups](/setup/seo/indexing/#multi-store-setups) (for example, a query parameter or proxy through your CDN configuration).

--- a/src/content/docs/setup/launch/index.mdx
+++ b/src/content/docs/setup/launch/index.mdx
@@ -72,7 +72,7 @@ As you develop, carefully track all changes made in development or staging envir
 ### CDN and caching
 
 * [ ] Update your CDN configuration with your production GraphQL endpoint (`yourproject.com/graphql`). Use that endpoint for all Sidekick extensions and scripts (for example, sitemap generation and the image importer).
-* [ ] Request a new CDN purge token for the Adobe Commerce production environment when you use Adobe Commerce Fastly. Update your [site configuration](https://tools.aem.live/tools/cdn-setup/index.html) with the `authToken` and `serviceId` values.
+* [ ] Request a new CDN purge token for your Adobe Commerce production environment when using Adobe Commerce Fastly. Then update your [site configuration](https://tools.aem.live/tools/cdn-setup/index.html) by adding the authToken and serviceId values.
 * [ ] Validate your [CDN configuration](/setup/configuration/content-delivery-network/) and ensure that caching
       and cache invalidation work as expected.
 * [ ] Add a store-specific cache buster to the Catalog Service and Live Search requests for [multi-store setups](/setup/seo/indexing/#multi-store-setups) (for example, a query parameter or proxy through your CDN configuration).


### PR DESCRIPTION
Old ref to `.helix/config.xlsx`. CDN purge token managed now via the tool linked.