### PR TITLE
Update readme for creating release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,8 +60,6 @@ Documentation source files live in `src/content/docs/`.
 - Use `dropins/` for **business-to-consumer (B2C)** topics (cart, checkout, wishlist).
 - Use `dropins-b2b/` for **business-to-business (B2B)** topics (requisition list, quote management).
 
-The folder layout controls the left sidebar navigation for most pages.
-
 ## How to add a page
 
 Doc pages are **MDX** files (Markdown plus optional components). Put each page in `src/content/docs/<section>/`. Examples: `dropins/cart`, `dropins-b2b/requisition-list`.
@@ -145,7 +143,7 @@ If you don't have write access to the repo, [fork the repository](https://docs.g
    pnpm build:prod-fast
    ```
 
-   If the command finishes without errors, your changes are ready to share.
+   If the command finishes without errors, your changes are ready for review.
 
 1. Commit your changes on your branch.
 
@@ -167,18 +165,17 @@ Use this when you are starting a coordinated release branch for the team.
 
 ## How to add release notes
 
-Follow the steps below to create a new release section to the docs and matching changelog entries. The release notes skill defines the release notes generation.
+Follow the steps below to create a new release section with matching changelog entries.
 
 The skill reads **GitHub** (the code hosting service) using the [GitHub CLI](https://cli.github.com/) tool, called `gh` in the terminal. Install `gh` if you don't have it. As needed, use the `gh auth login` command once on your machine so Cursor can reach private repositories when it generates notes.
 
 1. Create a local branch for release notes (for example `april-release-notes`).
 
 1. **Jira (optional):** GitHub pull requests sometimes link to **Jira** tickets. The skill can pull ticket text to improve release wording. To use that feature, you need network access to Adobe corporate Jira and a token stored on your Mac. If you skip this block, you can still write release notes from GitHub only.
-
    - Stay on the **Adobe corporate VPN**.
    - Confirm your Jira account can **read** the projects those tickets belong to.
    - Create a **Personal Access Token** on your Jira profile.
-   - Store the token in **macOS Keychain** using the command in the [release-notes skill README](.cursor/skills/release-notes/README.md). The skill reads the token from Keychain. Tokens expire; renew the token and update Keychain when needed.
+   - Store the token in **macOS Keychain** using the command in the [release-notes skill README](.cursor/skills/release-notes/README.md). The skill reads the token from Keychain.
 
 1. In Cursor, ask the agent to draft the release. Include the month and the **merge PR** links for the B2C and B2B boilerplate suites. Example:
 
@@ -190,4 +187,4 @@ The skill reads **GitHub** (the code hosting service) using the [GitHub CLI](htt
 
 1. Push your release-notes branch to GitHub.
 
-1. Open a pull request for the release notes. Set the base branch to your release integration branch (for example `april-release`).
+1. Open a pull request for the release notes. Set the base branch to your release integration branch (for example, `april-release`).

--- a/README.md
+++ b/README.md
@@ -157,12 +157,6 @@ If you don't have write access to the repo, [fork the repository](https://docs.g
 
 1. After your PR merges into `release`, the nightly build publishes updates to the [Commerce Storefront](https://experienceleague.adobe.com/developer/commerce/storefront/) site.
 
-<<<<<<< Updated upstream
-## How to add release notes
-
-1. Run `gh auth login` (required for Cursor to access private repos).
-2. In Cursor, prompt the agent with the release month and PR merge links. Example:
-=======
 ## How to prepare for a new release
 
 Use this when you are starting a coordinated release branch for the team.
@@ -189,18 +183,13 @@ The skill reads **GitHub** (the code hosting service) using the [GitHub CLI](htt
    - Store the token in **macOS Keychain** using the command in the [release-notes skill README](.cursor/skills/release-notes/README.md). The skill reads the token from Keychain. Tokens expire; renew the token and update Keychain when needed.
 
 1. In Cursor, ask the agent to draft the release. Include the month and the **merge PR** links for the B2C and B2B boilerplate suites. Example:
->>>>>>> Stashed changes
 
    > Add the [Month] 2026 release. Use the release merge PRs to generate the release notes and all the code changes:
    > B2C: https://github.com/hlxsites/aem-boilerplate-commerce/pull/1152
    > B2B: https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156
 
-<<<<<<< Updated upstream
-See the [release-notes skill](.cursor/skills/release-notes/SKILL.md) for full details.
-=======
 1. Commit the updated docs on your release-notes branch.
 
 1. Push your release-notes branch to GitHub.
 
 1. Open a pull request for the release notes. Set the base branch to your release integration branch (for example `april-release`).
->>>>>>> Stashed changes

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Welcome to the storefront documentation site! This site is built with [Astro](ht
 - [How to add a diagram](#how-to-add-a-diagram)
 - [How to link between docs](#how-to-link-between-docs)
 - [How to add a PR](#how-to-add-a-pr)
+- [How to prepare for a new release](#how-to-prepare-for-a-new-release)
 - [How to add release notes](#how-to-add-release-notes)
 
 ## Prerequisites
@@ -156,6 +157,8 @@ If you don't have write access to the repo, [fork the repository](https://docs.g
 ## How to prepare for a new release
 
 Use this when you are starting a coordinated release branch for the team.
+
+**Non-release updates:** Not every change belongs in the coordinated release. You might fix a typo or make a small edit that can merge whenever it is ready. For that work, use a **regular feature branch** from `release` with a normal branch name. A **release integration branch** is the branch the team shares for one release (for example `april-release`). Use it only for work that ships with that release. Reviewers can then tell which pull requests are for the release and which are not.
 
 1. Create a new branch from `release`.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Adobe Commerce Storefront documentation
 
-Welcome to the storefront documentation site! This site is built with [Astro](https://astro.build) (a web framework for content sites) and [Starlight](https://starlight.astro.build) (a documentation theme for Astro). This readme helps you install tools, run the site on your computer, add doc pages, and open pull requests. Reading and following the setup section takes about **10 minutes**. When you finish **Set up your local environment**, you'll have the docs running in your browser at [http://localhost:4321/](http://localhost:4321/).
+Welcome to the storefront documentation site! This site is built with [Astro](https://astro.build) (a web framework for content sites) and [Starlight](https://starlight.astro.build) (a documentation theme for Astro). This readme helps you install tools, run the site on your computer, add doc pages, and open pull requests. Reading and following the setup section takes about **5 minutes**. When you finish **Set up your local environment**, you'll have the docs running in your browser at [http://localhost:4321/](http://localhost:4321/).
 
 - [Prerequisites](#prerequisites)
 - [Set up your local environment](#set-up-your-local-environment)
@@ -127,8 +127,6 @@ See the <Link href="https://example.com/docs" text="external documentation" /> f
 
 ## How to add a PR
 
-A **pull request (PR)** is how you propose changes for review. The team publishes from the `release` branch.
-
 If you don't have write access to the repo, [fork the repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) first. Clone your fork, push to your fork, then open a PR from your fork to `release`.
 
 1. Create a new branch from `release`:
@@ -169,13 +167,13 @@ Use this when you are starting a coordinated release branch for the team.
 
 ## How to add release notes
 
-You'll add a new release section to the docs and matching changelog entries. The steps below get you started; the [release-notes skill](.cursor/skills/release-notes/SKILL.md) covers the full workflow (boilerplate drill-down, benefit-first copy, and how Jira text is checked against pull request diffs).
+Follow the steps below to create a new release section to the docs and matching changelog entries. The release notes skill defines the release notes generation.
 
-The skill reads **GitHub** (the code hosting service) using the [GitHub CLI](https://cli.github.com/) tool, called `gh` in the terminal. Install `gh` if you don't have it. Run `gh auth login` once on your machine so Cursor can reach private repositories when it generates notes.
+The skill reads **GitHub** (the code hosting service) using the [GitHub CLI](https://cli.github.com/) tool, called `gh` in the terminal. Install `gh` if you don't have it. As needed, use the `gh auth login` command once on your machine so Cursor can reach private repositories when it generates notes.
 
 1. Create a local branch for release notes (for example `april-release-notes`).
 
-1. **Jira (optional):** GitHub pull requests sometimes link **Jira** tickets (Adobe's issue tracker). The skill can pull ticket text to improve release wording. To use that feature, you need network access to Adobe corporate Jira and a token stored on your Mac. If you skip this block, you can still write release notes from GitHub only.
+1. **Jira (optional):** GitHub pull requests sometimes link to **Jira** tickets. The skill can pull ticket text to improve release wording. To use that feature, you need network access to Adobe corporate Jira and a token stored on your Mac. If you skip this block, you can still write release notes from GitHub only.
 
    - Stay on the **Adobe corporate VPN**.
    - Confirm your Jira account can **read** the projects those tickets belong to.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Adobe Commerce Storefront documentation
 
-Welcome to the storefront documentation site! This site is built with [Astro](https://astro.build) and [Starlight](https://starlight.astro.build). To contribute documentation, follow the instructions below to install the prerequisites, configure your local environment, create new pages, and submit PRs.
+Welcome to the storefront documentation site! This site is built with [Astro](https://astro.build) (a web framework for content sites) and [Starlight](https://starlight.astro.build) (a documentation theme for Astro). This readme helps you install tools, run the site on your computer, add doc pages, and open pull requests. Reading and following the setup section takes about **10 minutes**. When you finish **Set up your local environment**, you'll have the docs running in your browser at [http://localhost:4321/](http://localhost:4321/).
 
 - [Prerequisites](#prerequisites)
 - [Set up your local environment](#set-up-your-local-environment)
@@ -15,46 +15,60 @@ Welcome to the storefront documentation site! This site is built with [Astro](ht
 
 ## Prerequisites
 
-Install Node.js and pnpm:
+You'll use **Node.js** (the JavaScript runtime) and **pnpm** (a package manager for Node projects). Install these before you clone the repo:
 
 - `Node.js 20.13.1` or later.
 - `pnpm 9.x` or later. See the [pnpm installation instructions](https://pnpm.io/installation).
 
 ## Set up your local environment
 
-1. Clone the repository and install dependencies:
+The following steps copy the project to your machine and start the local preview.
+
+1. Clone the repository:
 
    ```bash
    git clone git@github.com:commerce-docs/microsite-commerce-storefront.git
    cd microsite-commerce-storefront
+   ```
+
+1. Install dependencies:
+
+   ```bash
    pnpm install
    ```
 
-2. Run the docs site locally:
+1. Start the local docs site:
 
    ```bash
    pnpm dev
    ```
 
-   This starts the development server, builds the site, and opens a browser at [http://localhost:4321/](http://localhost:4321/). The site auto-reloads when you save changes.
+   You should see the dev server start. Your browser should open [http://localhost:4321/](http://localhost:4321/). When you save a file, the page reloads.
 
 ## Development commands
 
-- `pnpm dev` — Start the local dev server and open a browser. The site auto-reloads when you save.
-- `pnpm build`, `pnpm build:prod`, and `pnpm build:prod-fast` — Run the Astro build. `build:prod-fast` skips compression for a faster production check (handy before opening a PR).
-- `pnpm build:stage` — Build for a staging environment. Requires a `STAGE_URL` environment variable to set the site URL (e.g. `STAGE_URL=https://my-stage.example.com pnpm build:stage`).
+- `pnpm dev` — Start the local dev server and open a browser. The site reloads when you save.
+- `pnpm build`, `pnpm build:prod`, and `pnpm build:prod-fast` — Run the Astro build. `build:prod-fast` skips compression for a faster production check (useful before you open a pull request).
+- `pnpm build:stage` — Build for a staging environment. Set the site URL in an environment variable named `STAGE_URL`. For example: `STAGE_URL=https://my-stage.example.com pnpm build:stage`.
 - `pnpm clean` — Reinstall dependencies (removes `node_modules`, `dist`, `.astro`).
-- `pnpm scrub` — Nuclear option: same as clean but also removes `pnpm-lock.yaml`.
+- `pnpm scrub` — Same as `pnpm clean`, but also deletes `pnpm-lock.yaml`. Use only if you intend to regenerate the lockfile.
 
 ## Content structure
 
-Docs live in `src/content/docs/`. Use `dropins/` for B2C (cart, checkout, wishlist), `dropins-b2b/` for B2B (requisition list, quote management). Folder structure maps to the sidebar, mostly.
+Documentation source files live in `src/content/docs/`.
+
+- Use `dropins/` for **business-to-consumer (B2C)** topics (cart, checkout, wishlist).
+- Use `dropins-b2b/` for **business-to-business (B2B)** topics (requisition list, quote management).
+
+The folder layout controls the left sidebar navigation for most pages.
 
 ## How to add a page
 
-- Docs pages are `.mdx` files in `src/content/docs/<section>/` (e.g. `dropins/cart`, `dropins-b2b/requisition-list`).
-- Add frontmatter: `title`, `description`, and a `sidebar` entry so the page appears in the nav.
-- Use `sidebar.label` and `sidebar.order` to control placement within the navigation sidebar on the left of a page.
+Doc pages are **MDX** files (Markdown plus optional components). Put each page in `src/content/docs/<section>/`. Examples: `dropins/cart`, `dropins-b2b/requisition-list`.
+
+Add **frontmatter** at the top of the file: `title`, `description`, and a `sidebar` entry so the page appears in the nav. Use `sidebar.label` and `sidebar.order` to control the label and order in the sidebar.
+
+Add this to your new `.mdx` file (adjust the values):
 
 ```mdx
 ---
@@ -76,13 +90,13 @@ Your content here. Use components like:
 
 ## How to add images
 
-- **Shared images:** Put files in `public/images/` (optionally in subfolders like `dropins/cart/`). Reference with `![Alt text](@images/path/to/image.png)`.
-- **Colocated images:** Put an `images/` folder next to your docs (e.g. `src/content/docs/how-tos/images/`). Reference with `![Alt text](images/filename.png)` from pages in that section.
-- For images inside a diagram with a caption, wrap in the Diagram component, below.
+- **Shared images:** Put files in `public/images/` (you can use subfolders like `dropins/cart/`). Reference them with `![Alt text](@images/path/to/image.png)`.
+- **Colocated images:** Put an `images/` folder next to your docs (for example `src/content/docs/how-tos/images/`). Reference with `![Alt text](images/filename.png)` from pages in that section.
+- For an image with a caption inside a diagram, use the Diagram component in [How to add a diagram](#how-to-add-a-diagram).
 
 ## How to add a diagram
 
-Import the Diagram component and wrap images or Mermaid code:
+Add this pattern to your `.mdx` file: import the Diagram component, then wrap an image or Mermaid chart.
 
 ```mdx
 import Diagram from '@components/Diagram.astro';
@@ -92,17 +106,18 @@ import Diagram from '@components/Diagram.astro';
 <Diagram type="mermaid" code={`graph LR; A --> B`} />
 ```
 
-Use `caption` for images; use `type="mermaid"` and `code` for flowcharts and sequence diagrams. Example pages of each:
+Use `caption` for still images. Use `type="mermaid"` and `code` for flowcharts and sequence diagrams.
 
-- Images `src/content/docs/dropins/all/slots.mdx`
-- Mermaid `src/content/docs/setup/configuration/aem-prerender.mdx`
+Example pages:
+
+- Images: `src/content/docs/dropins/all/slots.mdx`
+- Mermaid: `src/content/docs/setup/configuration/aem-prerender.mdx`
 
 ## How to link between docs
 
-Links outside the storefront site must use the Link component. Internal links use standard markdown.
+**Internal links** (to another page in this docs site) use normal Markdown with a path that starts with `/`. Example: `[SEO metadata](/setup/seo/metadata/)`.
 
-- **Internal links** (within the storefront docs): Use standard markdown with a path starting with `/`. For example, `[SEO metadata](/setup/seo/metadata/)`.
-- **External links** (outside the storefront site): Use the Link component so they open in a new tab with proper styling:
+**External links** (to any other site) use the Link component so they open in a new tab with the right styling. Add this to your `.mdx` file:
 
 ```mdx
 import Link from '@components/Link.astro';
@@ -112,9 +127,11 @@ See the <Link href="https://example.com/docs" text="external documentation" /> f
 
 ## How to add a PR
 
-If you don't have write access to the repo, [fork the repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) first. Clone your fork instead of the repo, push to your fork, then open a PR from your fork to `release`.
+A **pull request (PR)** is how you propose changes for review. The team publishes from the `release` branch.
 
-1. Create a new branch for your changes, based on `release`:
+If you don't have write access to the repo, [fork the repository](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo) first. Clone your fork, push to your fork, then open a PR from your fork to `release`.
+
+1. Create a new branch from `release`:
 
    ```bash
    git checkout release
@@ -122,19 +139,68 @@ If you don't have write access to the repo, [fork the repository](https://docs.g
    git checkout -b your-branch-name
    ```
 
-2. Make your changes to the docs (edit or add `.mdx` files in `src/content/docs/`).
+1. Edit or add `.mdx` files under `src/content/docs/`.
 
-3. Run `pnpm build:prod-fast` to verify your changes build, then commit, push, and open a PR against `release`. The `release` branch is the main branch used for publishing the site.
+1. Check that the site builds:
 
-4. After your PR is merged into `release`, content is published to the [Commerce Storefront](https://experienceleague.adobe.com/developer/commerce/storefront/) site by the nightly build.
+   ```bash
+   pnpm build:prod-fast
+   ```
 
+   If the command finishes without errors, your changes are ready to share.
+
+1. Commit your changes on your branch.
+
+1. Push your branch to GitHub.
+
+1. Open a pull request against the `release` branch. That branch is what the site uses for publishing.
+
+1. After your PR merges into `release`, the nightly build publishes updates to the [Commerce Storefront](https://experienceleague.adobe.com/developer/commerce/storefront/) site.
+
+<<<<<<< Updated upstream
 ## How to add release notes
 
 1. Run `gh auth login` (required for Cursor to access private repos).
 2. In Cursor, prompt the agent with the release month and PR merge links. Example:
+=======
+## How to prepare for a new release
+
+Use this when you are starting a coordinated release branch for the team.
+
+1. Create a new branch from `release`.
+
+1. Name the branch for the release (for example, `april-release`).
+
+1. Push that branch to GitHub so other contributors can use it.
+
+## How to add release notes
+
+You'll add a new release section to the docs and matching changelog entries. The steps below get you started; the [release-notes skill](.cursor/skills/release-notes/SKILL.md) covers the full workflow (boilerplate drill-down, benefit-first copy, and how Jira text is checked against pull request diffs).
+
+The skill reads **GitHub** (the code hosting service) using the [GitHub CLI](https://cli.github.com/) tool, called `gh` in the terminal. Install `gh` if you don't have it. Run `gh auth login` once on your machine so Cursor can reach private repositories when it generates notes.
+
+1. Create a local branch for release notes (for example `april-release-notes`).
+
+1. **Jira (optional):** GitHub pull requests sometimes link **Jira** tickets (Adobe's issue tracker). The skill can pull ticket text to improve release wording. To use that feature, you need network access to Adobe corporate Jira and a token stored on your Mac. If you skip this block, you can still write release notes from GitHub only.
+
+   - Stay on the **Adobe corporate VPN**.
+   - Confirm your Jira account can **read** the projects those tickets belong to.
+   - Create a **Personal Access Token** on your Jira profile.
+   - Store the token in **macOS Keychain** using the command in the [release-notes skill README](.cursor/skills/release-notes/README.md). The skill reads the token from Keychain. Tokens expire; renew the token and update Keychain when needed.
+
+1. In Cursor, ask the agent to draft the release. Include the month and the **merge PR** links for the B2C and B2B boilerplate suites. Example:
+>>>>>>> Stashed changes
 
    > Add the [Month] 2026 release. Use the release merge PRs to generate the release notes and all the code changes:
    > B2C: https://github.com/hlxsites/aem-boilerplate-commerce/pull/1152
    > B2B: https://github.com/hlxsites/aem-boilerplate-commerce/pull/1156
 
+<<<<<<< Updated upstream
 See the [release-notes skill](.cursor/skills/release-notes/SKILL.md) for full details.
+=======
+1. Commit the updated docs on your release-notes branch.
+
+1. Push your release-notes branch to GitHub.
+
+1. Open a pull request for the release notes. Set the base branch to your release integration branch (for example `april-release`).
+>>>>>>> Stashed changes


### PR DESCRIPTION
## Purpose of this pull request

This pull request improves the repository **README** for new contributors: clearer onboarding (time estimate, split clone/install/dev steps), plain-language definitions (Astro, Starlight, MDX, B2C/B2B), tightened development and content sections, an expanded **How to add a PR** flow (including `pnpm build:prod-fast`), a new **How to prepare for a new release** section, and expanded **How to add release notes** guidance (GitHub CLI, optional Jira/VPN/PAT/Keychain, PR target branch). No published Experience League doc pages are changed.

## Affected pages

No pages on experienceleague.adobe.com are modified. Updates apply only to the GitHub repository readme: [README.md](https://github.com/commerce-docs/microsite-commerce-storefront/blob/release/README.md).

## Associated Jira Ticket

COMDOX-1657