### PR TITLE
ACCS-533: Documentation for Card Vaulting - Save Card Checkbox

### DIFF
--- a/src/content/docs/dropins/payment-services/containers/credit-card.mdx
+++ b/src/content/docs/dropins/payment-services/containers/credit-card.mdx
@@ -29,6 +29,15 @@ The `CreditCard` container provides the following configuration options:
 
 </TableWrapper>
 
+## Card vaulting
+
+The CreditCard container shows a Save this card for future purchases checkbox when both of the following are true:
+
+- The shopper is **logged in** as indicated by the `getCustomerToken` function you provide at [initialization](/dropins/payment-services/initialization/)
+- Card vaulting is **enabled** in the Adobe Commerce Admin at **Stores > Configuration > Sales > Payment Methods > Adobe Payment Services > Credit Card Fields > Vault Enabled**
+
+If the shopper selects the checkbox and submits, the card is saved for future purchases. The checkbox is automatically hidden when either the shopper is a guest or vaulting is disabled.
+
 ## Slots
 
 This container exposes no customizable slots.

--- a/src/content/docs/dropins/payment-services/dictionary.mdx
+++ b/src/content/docs/dropins/payment-services/dictionary.mdx
@@ -69,6 +69,9 @@ Below are the default English (`en_US`) strings provided by the **Payment Servic
           "message": "An unexpected error occurred. Please try again or contact support."
         }
       },
+      "saveCard": {
+        "label": "Save this card for future purchases"
+      },
       "formFields": {
         "cvv": {
           "invalidError": "Enter valid cvv.",

--- a/src/content/docs/dropins/payment-services/styles.mdx
+++ b/src/content/docs/dropins/payment-services/styles.mdx
@@ -52,6 +52,7 @@ The Payment Services drop-in uses BEM-style class naming. Use the browser DevToo
 .payment-services-credit-card-form__eligible-cards-selected {}
 .payment-services-credit-card-form__eligible-cards-unselected {}
 .payment-services-credit-card-form__loading {}
+.payment-services-credit-card-form__save-card {}
 ```
 
 


### PR DESCRIPTION
## Purpose of this pull request

- Documentation the new ability for Card Vaulting - Save Card Checkbox

### Associated JIRA ticket

- https://jira.corp.adobe.com/browse/ACCS-533

### Staging preview

<!--OPTIONAL Link to staging preview if available-->


## Affected pages

- http://localhost:4321/dropins/payment-services/initialization/
- http://localhost:4321/dropins/payment-services/containers/credit-card/ 

## Links to source code

- https://github.com/adobe-commerce/storefront-payment-services/pull/43
- https://git.corp.adobe.com/magento-payments/payments-js-sdk/pull/177

### What's New highlights

<!--  _OPTIONAL - REMOVE THIS SECTION IF NOT USED._

If this pull request introduces changes that should be highlighted in What's New documentation reports.
-->

