### PR TITLE
Removing locale from analytics for ACO

### DIFF
--- a/src/content/docs/setup/configuration/commerce-configuration.mdx
+++ b/src/content/docs/setup/configuration/commerce-configuration.mdx
@@ -280,7 +280,6 @@ For Adobe Commerce Optimizer environments, use a simplified analytics configurat
     "base-currency-code": "{{CURRENCY_CODE}}",
     "environment": "{{ENVIRONMENT_TYPE}}",
     "environment-id": "{{YOUR_TENANT_ID}}",
-    "locale": "{{LOCALE}}",
     "store-url": "{{STORE_URL}}",
     "store-view-currency-code": "{{CURRENCY_CODE}}",
     "storefront-template": "{{TEMPLATE_TYPE}}",
@@ -296,7 +295,6 @@ For Adobe Commerce Optimizer environments, use a simplified analytics configurat
 - **`base-currency-code`** - The base currency code for the store (for example, "USD", "EUR")
 - **`environment`** - Environment type ("Production", "Testing")
 - **`environment-id`** - The tenant ID for the Adobe Commerce Optimizer instance
-- **`locale`** - Catalog source locale (language or geography) for the store view, for example `en-US`
 - **`store-url`** - Base URL for the store
 - **`store-view-currency-code`** - Currency code for the store view (for example, "USD", "EUR")
 - **`storefront-template`** - (Optional) Storefront template type (for example, "Other")


### PR DESCRIPTION


## Purpose of this pull request

This pull request (PR) removes the reference to the locale for the analytics section of ACO.



## Affected pages

<!-- REQUIRED List the affected pages on experienceleague.adobe.com (URLs). Not necessary for large numbers of files. -->

- https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/commerce-configuration/#analytics
