### PR TITLE
Remove locale from ACO analytics example

### DIFF
--- a/src/content/docs/setup/configuration/commerce-configuration.mdx
+++ b/src/content/docs/setup/configuration/commerce-configuration.mdx
@@ -536,7 +536,6 @@ This example shows the configuration for Adobe Commerce Optimizer (ACO), which u
         "base-currency-code": "USD",
         "environment": "Testing",
         "environment-id": "8idEEDDiVwjCEJAyB5kjfi",
-        "locale": "en-US",
         "store-url": "https://main--boilerplate-aco--adobe-commerce.aem.live/",
         "store-view-currency-code": "USD",
         "storefront-template": "Other",


### PR DESCRIPTION
Follow-up to #840: removes the `locale` field from the Adobe Commerce Optimizer (ACO) analytics configuration example in `commerce-configuration.mdx`.

**Change**
- Delete `"locale": "en-US",` from the ACO `analytics` object example.

Made with [Cursor](https://cursor.com)

## Associated Jira Ticket

COMDOX-1653