### PR TITLE
docs: fix audit gaps in user-account and requisition-list

### DIFF
--- a/src/content/docs/dropins-b2b/requisition-list/functions.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/functions.mdx
@@ -13,10 +13,10 @@ import TableWrapper from '@components/TableWrapper.astro';
 import Link from '@components/Link.astro';
 import { Aside } from '@astrojs/starlight/components';
 
-The Requisition List drop-in provides **10 API functions** for managing requisition lists and their items, including creating lists, adding/removing products, and managing list metadata.
+The Requisition List drop-in provides **12 API functions** for managing requisition lists and their items, including creating lists, adding/removing products, and managing list metadata.
 
 <div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
-<strong>Version: 1.2.0</strong>
+<strong>Version: 1.3.0</strong>
 </div>
 
 <TableWrapper nowrap={[0]}>
@@ -25,12 +25,14 @@ The Requisition List drop-in provides **10 API functions** for managing requisit
 | --- | --- |
 | [`addProductsToRequisitionList`](#addproductstorequisitionlist) | Adds products to a requisition list. |
 | [`addRequisitionListItemsToCart`](#addrequisitionlistitemstocart) | Adds the chosen items from a requisition list to the logged-in user's cart. |
+| [`copyItemsBetweenRequisitionLists`](#copyitemsbetweenrequisitionlists) | Copies items from one requisition list to another. |
 | [`createRequisitionList`](#createrequisitionlist) | Creates a new requisition list with the name and description provided for the logged-in user. |
 | [`deleteRequisitionList`](#deleterequisitionlist) | Deletes a requisition list identified by UID. |
 | [`deleteRequisitionListItems`](#deleterequisitionlistitems) | Deletes items from a requisition list. |
 | [`getRequisitionList`](#getrequisitionlist) | Returns information about the requested requisition list for the logged-in user. |
 | [`getRequisitionLists`](#getrequisitionlists) | Returns the requisition lists for the logged-in user. |
 | [`getStoreConfig`](#getstoreconfig) | Returns details about the store configuration. |
+| [`moveItemsBetweenRequisitionLists`](#moveitemsbetweenrequisitionlists) | Moves items from one requisition list to another. |
 | [`updateRequisitionList`](#updaterequisitionlist) | Updates an existing requisition list with the name and description provided for the logged-in user. |
 | [`updateRequisitionListItems`](#updaterequisitionlistitems) | Updates the items of an existing requisition list with the quantity and options provided for the logged-in user. |
 

--- a/src/content/docs/dropins-b2b/requisition-list/functions.mdx
+++ b/src/content/docs/dropins-b2b/requisition-list/functions.mdx
@@ -25,14 +25,14 @@ The Requisition List drop-in provides **12 API functions** for managing requisit
 | --- | --- |
 | [`addProductsToRequisitionList`](#addproductstorequisitionlist) | Adds products to a requisition list. |
 | [`addRequisitionListItemsToCart`](#addrequisitionlistitemstocart) | Adds the chosen items from a requisition list to the logged-in user's cart. |
-| [`copyItemsBetweenRequisitionLists`](#copyitemsbetweenrequisitionlists) | Copies items from one requisition list to another. |
+| [`copyItemsBetweenRequisitionLists`](#copyitemsbetweenrequisitionlists) | Copies items from one requisition list to another for a logged-in user. |
 | [`createRequisitionList`](#createrequisitionlist) | Creates a new requisition list with the name and description provided for the logged-in user. |
 | [`deleteRequisitionList`](#deleterequisitionlist) | Deletes a requisition list identified by UID. |
 | [`deleteRequisitionListItems`](#deleterequisitionlistitems) | Deletes items from a requisition list. |
 | [`getRequisitionList`](#getrequisitionlist) | Returns information about the requested requisition list for the logged-in user. |
 | [`getRequisitionLists`](#getrequisitionlists) | Returns the requisition lists for the logged-in user. |
 | [`getStoreConfig`](#getstoreconfig) | Returns details about the store configuration. |
-| [`moveItemsBetweenRequisitionLists`](#moveitemsbetweenrequisitionlists) | Moves items from one requisition list to another. |
+| [`moveItemsBetweenRequisitionLists`](#moveitemsbetweenrequisitionlists) | Moves items from one requisition list to another for a logged-in user. |
 | [`updateRequisitionList`](#updaterequisitionlist) | Updates an existing requisition list with the name and description provided for the logged-in user. |
 | [`updateRequisitionListItems`](#updaterequisitionlistitems) | Updates the items of an existing requisition list with the quantity and options provided for the logged-in user. |
 
@@ -342,13 +342,95 @@ Emits the `requisitionList/data` event.
 
 Returns [`RequisitionList`](#requisitionlist) or `null`.
 
+## moveItemsBetweenRequisitionLists
+
+Moves items from one requisition list to another for a logged-in user.
+
+```ts
+const moveItemsBetweenRequisitionLists = async (
+  sourceRequisitionListUid: string,
+  destinationRequisitionListUid: string,
+  requisitionListItemUids: string[],
+  pageSize: number,
+  currentPage: number
+): Promise<MoveItemsResult | null>
+```
+
+<TableWrapper nowrap={[0,1]}>
+
+| Parameter | Type | Req? | Description |
+|---|---|---|---|
+| `sourceRequisitionListUid` | `string` | Yes | The unique identifier for the requisition list from which items will be moved. |
+| `destinationRequisitionListUid` | `string` | Yes | The unique identifier for the requisition list to which items will be moved. |
+| `requisitionListItemUids` | `string[]` | Yes | An array of requisition list item UIDs to move. These are the unique identifiers for specific items within the source list. |
+| `pageSize` | `number` | Yes | The number of items to return per page in the updated requisition list responses. |
+| `currentPage` | `number` | Yes | The page number for pagination (1-indexed) in the updated requisition list responses. |
+
+</TableWrapper>
+
+### Events
+
+Emits the `requisitionList/data` event for the source list after items are moved.
+
+### Returns
+
+Returns an object with the following structure, or `null` if the operation fails:
+
+```ts
+interface MoveItemsResult {
+  sourceList: RequisitionList | null;
+  destinationList: RequisitionList | null;
+}
+```
+
+- `sourceList`: The updated source requisition list after items have been moved, or `null` if not available.
+- `destinationList`: The updated destination requisition list after items have been added, or `null` if not available.
+
+## copyItemsBetweenRequisitionLists
+
+Copies items from one requisition list to another for a logged-in user.
+
+```ts
+const copyItemsBetweenRequisitionLists = async (
+  sourceRequisitionListUid: string,
+  destinationRequisitionListUid: string,
+  requisitionListItemUids: string[]
+): Promise<CopyItemsResult | null>
+```
+
+<TableWrapper nowrap={[0,1]}>
+
+| Parameter | Type | Req? | Description |
+|---|---|---|---|
+| `sourceRequisitionListUid` | `string` | Yes | The unique identifier for the requisition list from which items will be copied. |
+| `destinationRequisitionListUid` | `string` | Yes | The unique identifier for the requisition list to which items will be copied. |
+| `requisitionListItemUids` | `string[]` | Yes | An array of requisition list item UIDs to copy. These are the unique identifiers for specific items within the source list. |
+
+</TableWrapper>
+
+### Events
+
+Does not emit any drop-in events.
+
+### Returns
+
+Returns an object with the following structure, or `null` if the operation fails:
+
+```ts
+interface CopyItemsResult {
+  destinationList: RequisitionList | null;
+}
+```
+
+- `destinationList`: The updated destination requisition list after items have been copied, or `null` if not available.
+
 ## Data Models
 
 The following data models are used by functions in this drop-in.
 
 ### RequisitionList
 
-The `RequisitionList` object is returned by the following functions: [`addProductsToRequisitionList`](#addproductstorequisitionlist), [`createRequisitionList`](#createrequisitionlist), [`deleteRequisitionList`](#deleterequisitionlist), [`deleteRequisitionListItems`](#deleterequisitionlistitems), [`getRequisitionList`](#getrequisitionlist), [`getRequisitionLists`](#getrequisitionlists), [`updateRequisitionList`](#updaterequisitionlist), [`updateRequisitionListItems`](#updaterequisitionlistitems).
+The `RequisitionList` object is returned by the following functions: [`addProductsToRequisitionList`](#addproductstorequisitionlist), [`createRequisitionList`](#createrequisitionlist), [`deleteRequisitionList`](#deleterequisitionlist), [`deleteRequisitionListItems`](#deleterequisitionlistitems), [`getRequisitionList`](#getrequisitionlist), [`getRequisitionLists`](#getrequisitionlists), [`updateRequisitionList`](#updaterequisitionlist), [`updateRequisitionListItems`](#updaterequisitionlistitems), [`moveItemsBetweenRequisitionLists`](#moveitemsbetweenrequisitionlists), [`copyItemsBetweenRequisitionLists`](#copyitemsbetweenrequisitionlists).
 
 ```ts
 interface RequisitionList {

--- a/src/content/docs/dropins/user-account/events.mdx
+++ b/src/content/docs/dropins/user-account/events.mdx
@@ -40,7 +40,7 @@ Emitted when any GraphQL or network request made by the drop-in fails. Aborted r
 Every API function in the drop-in (`getCustomer`, `updateCustomer`, `getOrderHistoryList`, `createCustomerAddress`, `deletePaymentToken`, `getCustomerPaymentTokens`, and others) is wired to emit this event on failure.
 
 <Aside type="note">
-This event uses the bare channel name `error` (not `account/error`). The `source` field in the payload is set to `'auth'` for historical reasons. Both values are a known inconsistency that may be corrected in a future major version.
+This event uses the bare channel name `error` (not `account/error`). The `source` field in the payload is set to `'auth'`.
 </Aside>
 
 #### Event payload

--- a/src/content/docs/dropins/user-account/events.mdx
+++ b/src/content/docs/dropins/user-account/events.mdx
@@ -49,7 +49,7 @@ This event uses the bare channel name `error` (not `account/error`). The `source
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `source` | `string` | Always `'auth'` (historical; may change to `'account'` in a future version). |
+| `source` | `string` | Always `'auth'`. |
 | `type` | `string` | Always `'network'`. |
 | `error` | `Error` | The original caught `Error` object. |
 

--- a/src/content/docs/dropins/user-account/events.mdx
+++ b/src/content/docs/dropins/user-account/events.mdx
@@ -22,6 +22,7 @@ The **User Account** drop-in uses the [event bus](/sdk/reference/events) to emit
 
 | Event | Direction | Description |
 |-------|-----------|-------------|
+| [`error`](#error-emits) | Emits | Emitted when a network request fails (excluding aborted requests). |
 | [account/customerPaymentTokens](#accountcustomerpaymenttokens-listens) | Listens | Optional **display list** of stored payment tokens for the PaymentMethods UI (injection only); consumed eagerly when present. Does not participate in removal. |
 | [companyContext/changed](#companycontextchanged-listens) | Listens | Fired by Company Context (`companyContext`) when a change occurs. |
 
@@ -31,6 +32,40 @@ The **User Account** drop-in uses the [event bus](/sdk/reference/events) to emit
 ## Event details
 
 The following sections provide detailed information about each event, including its direction, event payload, and usage examples.
+
+### `error` (emits)
+
+Emitted when any GraphQL or network request made by the drop-in fails. Aborted requests (`AbortError`) are excluded — they are re-thrown but do not trigger this event. The event fires on the shared event bus before the error is re-thrown, so listeners receive it even when the calling code also handles the rejection.
+
+Every API function in the drop-in (`getCustomer`, `updateCustomer`, `getOrderHistoryList`, `createCustomerAddress`, `deletePaymentToken`, `getCustomerPaymentTokens`, and others) is wired to emit this event on failure.
+
+<Aside type="note">
+This event uses the bare channel name `error` (not `account/error`). The `source` field in the payload is set to `'auth'` for historical reasons. Both values are a known inconsistency that may be corrected in a future major version.
+</Aside>
+
+#### Event payload
+
+<TableWrapper nowrap={[0, 1]}>
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `source` | `string` | Always `'auth'` (historical; may change to `'account'` in a future version). |
+| `type` | `string` | Always `'network'`. |
+| `error` | `Error` | The original caught `Error` object. |
+
+</TableWrapper>
+
+#### Example
+
+```js
+import { events } from '@dropins/tools/event-bus.js';
+
+events.on('error', (payload) => {
+  if (payload.source === 'auth' && payload.type === 'network') {
+    console.error('User Account network error:', payload.error.message);
+  }
+});
+```
 
 ### `account/customerPaymentTokens` (listens)
 

--- a/src/content/docs/dropins/user-account/functions.mdx
+++ b/src/content/docs/dropins/user-account/functions.mdx
@@ -29,7 +29,7 @@ The User Account drop-in provides API functions that enable you to programmatica
 | [`getCustomer`](#getcustomer) | Retrieves the customer information for the logged-in customer. |
 | [`getCustomerAddress`](#getcustomeraddress) | Returns an array of addresses associated with the current customer. |
 | [`getCustomerPaymentTokens`](#getcustomerpaymenttokens) | Retrieves stored payment tokens for the logged-in customer via the `customerPaymentTokens query`. |
-| [deletePaymentToken](#deletepaymenttoken) | Removes a stored payment token using the `deletePaymentToken mutation`. |
+| [`deletePaymentToken`](#deletepaymenttoken) | Removes a stored payment token using the `deletePaymentToken mutation`. |
 | [`getOrderHistoryList`](#getorderhistorylist) | Retrieves a list of customer orders asynchronously using the customer query. |
 | [`getRegions`](#getregions) | Calls the country query to retrieve a list of states or provinces for a specific country. |
 | [`getStoreConfig`](#getstoreconfig) | Calls the `storeConfig` query to retrieve details about password requirements. |


### PR DESCRIPTION
## Purpose of this pull request

- Fix missing backticks on the `deletePaymentToken` row in the User Account functions overview table (the audit script requires them to recognize the function as documented)
- Document the `error` event emitted by the User Account drop-in on all network failures, including the payload shape and which API functions trigger it
- Add `moveItemsBetweenRequisitionLists` and `copyItemsBetweenRequisitionLists` to the Requisition List functions overview table. The detail sections were added in PR #807 but the table rows were omitted, causing the audit to flag them as missing; also bumps the count to 12 and version to 1.3.0
- Restore the `moveItemsBetweenRequisitionLists` and `copyItemsBetweenRequisitionLists` detail sections that were accidentally dropped by commit `ba101685e` after PR #807 was merged