### PR TITLE
docs: redirect folder mapping and config.json to config service

### DIFF
--- a/src/content/docs/boilerplate/configuration.mdx
+++ b/src/content/docs/boilerplate/configuration.mdx
@@ -102,7 +102,7 @@ For local development, you can use the demo configuration for the boilerplate as
 
    1. Copy all values from the `public` section of your repository `config.json`. That object is what you publish as `public.json` in the Configuration Service.
 
-   1. POST that JSON to `https://admin.hlx.page/config/{ORG}/sites/{SITE}/public.json` using the Configuration Service API. Send the `x-auth-token` header and body format described in the <Link href="https://www.aem.live/docs/config-service-setup" text="Config Service setup guide" /> and the <Link href="https://www.aem.live/docs/admin.html" text="Admin API reference" />.
+   1. POST that JSON to `https://admin.hlx.page/config/{ORG}/sites/{SITE}/public.json` using the Configuration Service API. Authenticate the request and set the body as described in the <Link href="https://www.aem.live/docs/config-service-setup" text="Config Service setup guide" /> and the <Link href="https://www.aem.live/docs/admin.html" text="Admin API reference" />.
 
    1. Delete `config.json` from the repository and merge that change into `main`. After the file no longer exists on `main`, the CDN can resolve configuration from the Configuration Service instead of the repository copy.
 

--- a/src/content/docs/boilerplate/configuration.mdx
+++ b/src/content/docs/boilerplate/configuration.mdx
@@ -96,15 +96,17 @@ For local development, you can use the demo configuration for the boilerplate as
 
    #### If `config.json` is already on `main`
 
-   If you previously committed `config.json` to your `main` branch, Edge Delivery keeps serving that file until you remove it from the branch. To move your settings into the Configuration Service so production uses those values, complete the following steps.
+   If you previously committed `config.json` to your `main` branch, you must complete these steps before the Configuration Service takes effect. Edge Delivery serves a `config.json` file from the repository before it falls back to the Configuration Service, so copying settings into the service alone is not enough until the repository file is gone.
 
    <Steps>
 
-   1. Copy the `public` object from your repository `config.json`. That JSON matches what the Configuration Service stores at `public.json`.
+   1. Copy all values from the `public` section of your repository `config.json`. That object is what you publish as `public.json` in the Configuration Service.
 
-   1. Publish it to `https://admin.hlx.page/config/{ORG}/sites/{SITE}/public.json` with the Configuration Service API (for example, POST with your admin token). See the <Link href="https://www.aem.live/docs/config-service-setup" text="Config Service setup guide" /> and the <Link href="https://www.aem.live/docs/admin.html" text="Admin API reference" /> for authentication and request format.
+   1. POST that JSON to `https://admin.hlx.page/config/{ORG}/sites/{SITE}/public.json` using the Configuration Service API. Send the `x-auth-token` header and body format described in the <Link href="https://www.aem.live/docs/config-service-setup" text="Config Service setup guide" /> and the <Link href="https://www.aem.live/docs/admin.html" text="Admin API reference" />.
 
-   1. Delete `config.json` from the repository and merge that change into `main`. After the file no longer exists on `main`, the CDN can use the Configuration Service instead of the repository copy.
+   1. Delete `config.json` from the repository and merge that change into `main`. After the file no longer exists on `main`, the CDN can resolve configuration from the Configuration Service instead of the repository copy.
+
+   1. When you verify in a browser, clear session storage for your site in Developer Tools (Application → Session storage), then reload. The storefront caches configuration in session storage, so clearing it avoids stale values after you switch sources. For caching behavior and timing, see [Storefront configuration](/setup/configuration/commerce-configuration/).
 
    </Steps>
 

--- a/src/content/docs/boilerplate/configuration.mdx
+++ b/src/content/docs/boilerplate/configuration.mdx
@@ -6,8 +6,10 @@ sidebar:
   order: 4
 ---
 
-import { Aside, Code } from '@astrojs/starlight/components';
+import { Aside, Code, Steps } from '@astrojs/starlight/components';
 import Link from '@components/Link.astro';
+import Tasks from '@components/Tasks.astro';
+import Task from '@components/Task.astro';
 
 The AEM Commerce boilerplate requires configuration to connect to your Adobe Commerce instance and customize the storefront behavior.
 
@@ -78,21 +80,35 @@ For local development, you can use the demo configuration for the boilerplate as
 
 ### Local vs Production Configuration
 
-**For local development:**
+#### For local development
 - Save a copy of the demo configuration (from <Link href="https://main--aem-boilerplate-commerce--hlxsites.aem.live/config.json" text="https://main--aem-boilerplate-commerce--hlxsites.aem.live/config.json" />) as `config.json` in your project root.
 - The AEM CLI will automatically serve `config.json` at runtime.
 - Alternatively, use the <Link href="https://da.live/app/adobe-commerce/storefront-tools/tools/config-generator/config-generator" text="config generator tool" /> to generate a configuration with your backend values (may contain placeholders to fill in).
 - Update the values to connect to your own Commerce backend as needed.
 
-**For production deployment:**
+#### For production deployment
 
-1. **Configuration Service (Recommended)** - Use the Configuration Service, which stores configuration at `https://admin.hlx.page/config/{ORG}/sites/{SITE}/public.json`. This approach allows configuration updates without code deployments and is the preferred method for all production sites. See the <Link href="https://www.aem.live/docs/config-service-setup" text="Config Service setup guide" /> for details.
+- **Configuration Service (Recommended)** - Use the Configuration Service, which stores configuration at `https://admin.hlx.page/config/{ORG}/sites/{SITE}/public.json`. This approach allows configuration updates without code deployments and is the preferred method for all production sites. See the <Link href="https://www.aem.live/docs/config-service-setup" text="Config Service setup guide" /> for details.
 
    :::caution
    Do **not** commit `config.json` to the `main` branch if you are using the Configuration Service. A `config.json` present on a code branch takes precedence over the Configuration Service, which means your production config service values will be silently ignored. Reserve `config.json` for local development and branch-based testing only.
    :::
 
-2. **Repository-based config (local dev and branch testing only)** - A `config.json` file in your repository root is useful for local development and testing on feature branches. Edge Delivery Services will serve this file at `/config.json` and it will override the Configuration Service. Do not use this approach for production — remove or exclude `config.json` from your `main` branch.
+   #### If `config.json` is already on `main`
+
+   If you previously committed `config.json` to your `main` branch, Edge Delivery keeps serving that file until you remove it from the branch. To move your settings into the Configuration Service so production uses those values, complete the following steps.
+
+   <Steps>
+
+   1. Copy the `public` object from your repository `config.json`. That JSON matches what the Configuration Service stores at `public.json`.
+
+   1. Publish it to `https://admin.hlx.page/config/{ORG}/sites/{SITE}/public.json` with the Configuration Service API (for example, POST with your admin token). See the <Link href="https://www.aem.live/docs/config-service-setup" text="Config Service setup guide" /> and the <Link href="https://www.aem.live/docs/admin.html" text="Admin API reference" /> for authentication and request format.
+
+   1. Delete `config.json` from the repository and merge that change into `main`. After the file no longer exists on `main`, the CDN can use the Configuration Service instead of the repository copy.
+
+   </Steps>
+
+- **Repository-based config (local dev and branch testing only)** - A `config.json` file in your repository root is useful for local development and testing on feature branches. Edge Delivery Services will serve this file at `/config.json` and it will override the Configuration Service. Do not use this approach for production — remove or exclude `config.json` from your `main` branch.
 
 ## Production Configuration Templates
 

--- a/src/content/docs/boilerplate/configuration.mdx
+++ b/src/content/docs/boilerplate/configuration.mdx
@@ -84,11 +84,15 @@ For local development, you can use the demo configuration for the boilerplate as
 - Alternatively, use the <Link href="https://da.live/app/adobe-commerce/storefront-tools/tools/config-generator/config-generator" text="config generator tool" /> to generate a configuration with your backend values (may contain placeholders to fill in).
 - Update the values to connect to your own Commerce backend as needed.
 
-**For production deployment, choose one of these options:**
+**For production deployment:**
 
-1. **Configuration Service (Recommended)** - Use the Configuration Service, which stores configuration at `https://admin.hlx.page/config/{ORG}/sites/{SITE}/public.json`. This approach stores configuration in the same format as the `public` section in `default-site.json` and allows configuration updates without code deployments. Note that a local `config.json` in your repository will override the Configuration Service.
+1. **Configuration Service (Recommended)** - Use the Configuration Service, which stores configuration at `https://admin.hlx.page/config/{ORG}/sites/{SITE}/public.json`. This approach allows configuration updates without code deployments and is the preferred method for all production sites. See the <Link href="https://www.aem.live/docs/config-service-setup" text="Config Service setup guide" /> for details.
 
-2. **Repository-based config (Simple)** - Create a `config.json` file in your repository root with your production Commerce backend details and commit the file. Edge Delivery Services will serve this file at `/config.json` in production. Start with either the demo config or use the config generator tool, then update all values to match your backend.
+   :::caution
+   Do **not** commit `config.json` to the `main` branch if you are using the Configuration Service. A `config.json` present on a code branch takes precedence over the Configuration Service, which means your production config service values will be silently ignored. Reserve `config.json` for local development and branch-based testing only.
+   :::
+
+2. **Repository-based config (local dev and branch testing only)** - A `config.json` file in your repository root is useful for local development and testing on feature branches. Edge Delivery Services will serve this file at `/config.json` and it will override the Configuration Service. Do not use this approach for production — remove or exclude `config.json` from your `main` branch.
 
 ## Production Configuration Templates
 

--- a/src/content/docs/setup/configuration/commerce-configuration.mdx
+++ b/src/content/docs/setup/configuration/commerce-configuration.mdx
@@ -541,19 +541,25 @@ When your storefront loads in the browser, the following sequence occurs:
 1. **Browser requests** `https://[site]/config.json`
 2. **EDS CDN checks** if a `config.json` file exists in the code repository root
 3. **If found** - The `config.json` file from the repository is served
-4. **If not found** - The CDN falls back to the `public` config from the EDS site config
+4. **If not found** - The CDN falls back to the `public` config from the EDS site config (Config Service)
 
-**Important:** A committed `config.json` file in your repository will always take precedence over the public config from EDS site config.
+:::caution[Do not commit config.json to main]
+A `config.json` file in your repository **always** takes precedence over the Config Service. This means if `config.json` is committed to your `main` branch, your Config Service values will be silently ignored in production.
+
+`config.json` is intended for **local development and branch-based testing only**. For production, use the Config Service and ensure `config.json` is absent from the `main` branch.
+:::
 
 ### Getting a starter configuration
 
-To get a configuration for your Commerce storefront, you have two options:
+To get a configuration for your Commerce storefront, use one of these approaches:
 
-1. **Copy the demo configuration**: Download and customize the live configuration for the boilerplate from <Link href="https://main--aem-boilerplate-commerce--hlxsites.aem.live/config.json" text="https://main--aem-boilerplate-commerce--hlxsites.aem.live/config.json" />. This provides a working example with all required fields.
+1. **Config Service (recommended for production)**: Use the Config Service to store and manage your production configuration. See the <Link href="https://www.aem.live/docs/config-service-setup" text="Config Service setup guide" /> to get started. Your configuration is stored at `https://admin.hlx.page/config/{ORG}/sites/{SITE}/public.json` and served automatically — no `config.json` in the repository is needed.
 
-2. **Generate with your values**: Use the <Link href="https://da.live/app/adobe-commerce/storefront-tools/tools/config-generator/config-generator" text="config generator tool" /> to automatically generate a configuration for your Commerce backend. Note that the generated config may contain placeholders that you'll need to replace with actual values.
+2. **Generate a local starter config**: Use the <Link href="https://da.live/app/adobe-commerce/storefront-tools/tools/config-generator/config-generator" text="config generator tool" /> to automatically generate a configuration for your Commerce backend. Use this as the basis for your Config Service upload or for local development. Note that the generated config may contain placeholders that you'll need to replace with actual values.
 
-**Important**: Always update the configuration values to match your specific Commerce backend before deploying to production.
+3. **Copy the demo configuration**: Download and customize the live configuration for the boilerplate from <Link href="https://main--aem-boilerplate-commerce--hlxsites.aem.live/config.json" text="https://main--aem-boilerplate-commerce--hlxsites.aem.live/config.json" />. This provides a working example with all required fields — useful as a reference for local development.
+
+**Important**: Always update the configuration values to match your specific Commerce backend. For production, push your configuration to the Config Service rather than committing `config.json` to your `main` branch.
 
 ### Local Development Configuration
 

--- a/src/content/docs/setup/configuration/multistore-setup.mdx
+++ b/src/content/docs/setup/configuration/multistore-setup.mdx
@@ -174,13 +174,13 @@ Product Detail Pages (PDP) are mapped to a single document at `products/default`
 
 #### Step 1: Authenticate
 
-Go to `https://admin.hlx.page/login`, then go to your selected IDP login URL, and sign in. Retrieve the auth token from your browser's cookie storage (available in Developer Tools → Application → Cookies). Send that value in the `x-auth-token` header on Admin API requests, following the same header pattern as in the curl examples in the <Link href="https://www.aem.live/docs/config-service-setup" text="Config Service setup guide" />.
+Go to `https://admin.hlx.page/login`, then go to your selected IDP login URL, and sign in. Retrieve the auth token from your browser's cookie storage (available in Developer Tools → Application → Cookies). Use that token to authenticate Admin API requests, with the headers and request format described in the <Link href="https://www.aem.live/docs/config-service-setup" text="Config Service setup guide" /> and the <Link href="https://www.aem.live/docs/admin.html" text="Admin API reference" />.
 
 #### Step 2: Get the current folder configuration
 
 ```http
 GET https://admin.hlx.page/config/{ORG}/sites/{SITE}/folders.json
-x-auth-token: {YOUR_AUTH_TOKEN}
+Authorization: token {YOUR_AUTH_TOKEN}
 ```
 
 The response is a JSON object mapping URL path prefixes to template document paths, for example:
@@ -199,7 +199,7 @@ Add your new store view mappings and POST the complete object back to the same e
 
 ```http
 POST https://admin.hlx.page/config/{ORG}/sites/{SITE}/folders.json
-x-auth-token: {YOUR_AUTH_TOKEN}
+Authorization: token {YOUR_AUTH_TOKEN}
 Content-Type: application/json
 ```
 

--- a/src/content/docs/setup/configuration/multistore-setup.mdx
+++ b/src/content/docs/setup/configuration/multistore-setup.mdx
@@ -166,21 +166,54 @@ The store view codes in Adobe Commerce Admin must exactly match the folder names
 <Task>
 ### Update folder mapping
 
-Product Detail Pages (PDP) are mapped to a single document at `products/default`. When adding a new store view, you'll need to add a corresponding folder mapping for the new URLs.
+Product Detail Pages (PDP) are mapped to a single document at `products/default`. When adding a new store view, you must add a corresponding folder mapping for the new URLs using the **Config Service API**.
 
-Update your site configuration (using the Configuration Service or `default-site.json`) to add the new store view mapping under the `folders:` section:
+:::note
+**fstab.yaml is bootstrap-only.** After the AEM Code Sync bot initially provisions your site, changes to `fstab.yaml` in the code repository have no effect. Folder mapping must be managed through the Config Service API described below.
+:::
+
+#### Step 1: Authenticate
+
+Go to `https://admin.hlx.page/auth/adobe` and sign in with your Adobe ID. Retrieve the auth token from your browser's cookie storage (available in DevTools → Application → Cookies).
+
+#### Step 2: Get the current folder configuration
+
+```http
+GET https://admin.hlx.page/config/{ORG}/sites/{SITE}/folders.json
+Authorization: token {YOUR_AUTH_TOKEN}
+```
+
+The response is a JSON object mapping URL path prefixes to template document paths, for example:
 
 ```json
 {
-  "folders": {
-    "/en/products/": "/en/products/default",
-    "/en-ca/products/": "/en-ca/products/default",
-    "/fr-ca/products/": "/fr-ca/products/default"
-  }
+  "/products/": "/products/default"
 }
 ```
 
-To learn more about the Config Service, see <Link href={"https://www.aem.live/docs/config-service-setup"} text={"aem.live's documentation"} /> or read the <Link href={"https://www.aem.live/docs/admin.html#tag/siteConfig/operation/updateConfigSite"} text={"API documentation"} /> to learn how to publish your updates.
+#### Step 3: Modify and POST the updated configuration
+
+Add your new store view mappings and POST the complete object back to the same endpoint:
+
+```http
+POST https://admin.hlx.page/config/{ORG}/sites/{SITE}/folders.json
+Authorization: token {YOUR_AUTH_TOKEN}
+Content-Type: application/json
+```
+
+```json
+{
+  "/en/products/": "/en/products/default",
+  "/en-ca/products/": "/en-ca/products/default",
+  "/fr-ca/products/": "/fr-ca/products/default"
+}
+```
+
+:::caution
+The POST **replaces** the entire `folders.json` object. Always start from the current GET response and include all existing mappings alongside your new ones.
+:::
+
+For full details, see the <Link href={"https://www.aem.live/docs/config-service-setup"} text={"Config Service setup guide"} /> and the <Link href={"https://www.aem.live/docs/admin.html"} text={"Admin API reference"} />.
 
 </Task>
 
@@ -384,7 +417,7 @@ Your multistore infrastructure is now ready to support multiple locales with pro
 ### Common Issues
 
 #### Store View Not Loading
-- **Check the folder mapping**: Verify that the folder mapping in your site configuration (Configuration Service or `default-site.json`) matches your folder structure
+- **Check the folder mapping**: Verify that the folder mapping is correct by querying the Config Service: `GET https://admin.hlx.page/config/{ORG}/sites/{SITE}/folders.json`. Note that editing `fstab.yaml` has no effect after initial site setup — all folder mapping changes must go through the Config Service API.
 - **Verify the headers**: Ensure that the headers in `config.json` or Configuration Service match the store view codes in Adobe Commerce Admin
 - **Check the session storage**: Use browser developer tools to verify that the correct headers are being sent
 

--- a/src/content/docs/setup/configuration/multistore-setup.mdx
+++ b/src/content/docs/setup/configuration/multistore-setup.mdx
@@ -174,7 +174,7 @@ Product Detail Pages (PDP) are mapped to a single document at `products/default`
 
 #### Step 1: Authenticate
 
-Go to `https://admin.hlx.page/login`, then go to your selected IDP login url, and sign in. Retrieve the auth token from your browser's cookie storage (available in DevTools → Application → Cookies).
+Go to `https://admin.hlx.page/login`, then go to your selected IDP login URL, and sign in. Retrieve the auth token from your browser's cookie storage (available in Developer Tools → Application → Cookies).
 
 #### Step 2: Get the current folder configuration
 
@@ -191,7 +191,7 @@ The response is a JSON object mapping URL path prefixes to template document pat
 }
 ```
 
-If you don't receive a response, you may not have folder mapping yet. In that case, move on to step 3 and creeate the JSON object manually.
+If you don't receive a response, you may not have folder mapping yet. In that case, move on to step 3 and create the JSON object manually.
 
 #### Step 3: Modify and POST the updated configuration
 

--- a/src/content/docs/setup/configuration/multistore-setup.mdx
+++ b/src/content/docs/setup/configuration/multistore-setup.mdx
@@ -174,7 +174,7 @@ Product Detail Pages (PDP) are mapped to a single document at `products/default`
 
 #### Step 1: Authenticate
 
-Go to `https://admin.hlx.page/auth/adobe` and sign in with your Adobe ID. Retrieve the auth token from your browser's cookie storage (available in DevTools → Application → Cookies).
+Go to `https://admin.hlx.page/login`, then go to your selected IDP login url, and sign in. Retrieve the auth token from your browser's cookie storage (available in DevTools → Application → Cookies).
 
 #### Step 2: Get the current folder configuration
 
@@ -190,6 +190,8 @@ The response is a JSON object mapping URL path prefixes to template document pat
   "/products/": "/products/default"
 }
 ```
+
+If you don't receive a response, you may not have folder mapping yet. In that case, move on to step 3 and creeate the JSON object manually.
 
 #### Step 3: Modify and POST the updated configuration
 

--- a/src/content/docs/setup/configuration/multistore-setup.mdx
+++ b/src/content/docs/setup/configuration/multistore-setup.mdx
@@ -174,13 +174,13 @@ Product Detail Pages (PDP) are mapped to a single document at `products/default`
 
 #### Step 1: Authenticate
 
-Go to `https://admin.hlx.page/login`, then go to your selected IDP login URL, and sign in. Retrieve the auth token from your browser's cookie storage (available in Developer Tools → Application → Cookies).
+Go to `https://admin.hlx.page/login`, then go to your selected IDP login URL, and sign in. Retrieve the auth token from your browser's cookie storage (available in Developer Tools → Application → Cookies). Send that value in the `x-auth-token` header on Admin API requests, following the same header pattern as in the curl examples in the <Link href="https://www.aem.live/docs/config-service-setup" text="Config Service setup guide" />.
 
 #### Step 2: Get the current folder configuration
 
 ```http
 GET https://admin.hlx.page/config/{ORG}/sites/{SITE}/folders.json
-Authorization: token {YOUR_AUTH_TOKEN}
+x-auth-token: {YOUR_AUTH_TOKEN}
 ```
 
 The response is a JSON object mapping URL path prefixes to template document paths, for example:
@@ -199,7 +199,7 @@ Add your new store view mappings and POST the complete object back to the same e
 
 ```http
 POST https://admin.hlx.page/config/{ORG}/sites/{SITE}/folders.json
-Authorization: token {YOUR_AUTH_TOKEN}
+x-auth-token: {YOUR_AUTH_TOKEN}
 Content-Type: application/json
 ```
 

--- a/src/content/docs/troubleshooting/faq.mdx
+++ b/src/content/docs/troubleshooting/faq.mdx
@@ -186,10 +186,11 @@ If the `x-error` header shows a failure when loading an `.md` file from content-
 Product detail pages (PDPs) may return a 404 when the requested URL cannot be resolved to a document in the Edge Delivery content pipeline. In most cases, this indicates that no corresponding content resource exists or is accessible for that path. Verify the following:
 
 **Overlay / BYOM not set up:** If your project depends on prerendering or BYOM (bring your own markup) to serve PDPs, make sure it is fully configured. See [AEM Commerce prerender](/setup/configuration/aem-prerender/).
-- **Folder mapping (deprecated) and uppercase SKUs:** Folder mapping via `fstab.yaml` is deprecated and is no longer the recommended approach. In addition, `fstab.yaml` is only read once during initial site creation — changes to it after the AEM Code Sync bot provisions your site have no effect. If you need to add or update folder mappings, use the Config Service API instead:
+- **Folder mapping (deprecated) and uppercase SKUs:** Folder mapping is deprecated and is no longer the recommended approach. In addition, `fstab.yaml` is only read once during initial site creation — changes to it after the AEM Code Sync bot provisions your site have no effect. If you need to add or update folder mappings, use the Config Service API instead:
 
   ```http
   GET  https://admin.hlx.page/config/{ORG}/sites/{SITE}/folders.json
+  {/* Modify the JSON object and POST it back to the same endpoint */}
   POST https://admin.hlx.page/config/{ORG}/sites/{SITE}/folders.json
   ```
 

--- a/src/content/docs/troubleshooting/faq.mdx
+++ b/src/content/docs/troubleshooting/faq.mdx
@@ -194,11 +194,14 @@ Product detail pages (PDPs) may return a 404 when the requested URL cannot be re
   POST https://admin.hlx.page/config/{ORG}/sites/{SITE}/folders.json
   ```
 
+  Use GET to read the current mapping, edit the JSON object, then POST it back to the same URL.
+
   See the <Link href={"https://www.aem.live/docs/admin.html"} text={"Admin API reference"} /> and the <Link href={"https://www.aem.live/developer/folder-mapping"} text={"folder mapping deprecation notice"} /> for details.
 
   If you are still using folder mapping, note that URLs must be lowercase. If your SKUs contain uppercase letters, you need to provide metadata (for example, using bulk metadata) so the correct content is matched to each URL. See:
-- <Link href={"https://www.aem.live/docs/bulk-metadata"} text={"Bulk metadata"} />
-- [SEO metadata](/setup/seo/metadata/#generate-metadata)
+
+  - <Link href={"https://www.aem.live/docs/bulk-metadata"} text={"Bulk metadata"} />
+  - [SEO metadata](/setup/seo/metadata/#generate-metadata)
 
 ![Example storefront URL path for a product detail page](@images/troubleshoot/eds-pdp-url-path.png)
 

--- a/src/content/docs/troubleshooting/faq.mdx
+++ b/src/content/docs/troubleshooting/faq.mdx
@@ -186,8 +186,16 @@ If the `x-error` header shows a failure when loading an `.md` file from content-
 Product detail pages (PDPs) may return a 404 when the requested URL cannot be resolved to a document in the Edge Delivery content pipeline. In most cases, this indicates that no corresponding content resource exists or is accessible for that path. Verify the following:
 
 **Overlay / BYOM not set up:** If your project depends on prerendering or BYOM (bring your own markup) to serve PDPs, make sure it is fully configured. See [AEM Commerce prerender](/setup/configuration/aem-prerender/).
-- **Folder mapping and uppercase SKUs:** If you are using the **deprecated** folder mapping method for PDPs, URLs must be lowercase. If your SKUs contain uppercase letters, you need to provide metadata (for example, using bulk metadata) so the correct content is matched to each URL. See:
-- <Link href={"https://www.aem.live/developer/folder-mapping"} text={"Folder mapping"} />
+- **Folder mapping (deprecated) and uppercase SKUs:** Folder mapping via `fstab.yaml` is deprecated and is no longer the recommended approach. In addition, `fstab.yaml` is only read once during initial site creation — changes to it after the AEM Code Sync bot provisions your site have no effect. If you need to add or update folder mappings, use the Config Service API instead:
+
+  ```http
+  GET  https://admin.hlx.page/config/{ORG}/sites/{SITE}/folders.json
+  POST https://admin.hlx.page/config/{ORG}/sites/{SITE}/folders.json
+  ```
+
+  See the <Link href={"https://www.aem.live/docs/admin.html"} text={"Admin API reference"} /> and the <Link href={"https://www.aem.live/developer/folder-mapping"} text={"folder mapping deprecation notice"} /> for details.
+
+  If you are still using folder mapping, note that URLs must be lowercase. If your SKUs contain uppercase letters, you need to provide metadata (for example, using bulk metadata) so the correct content is matched to each URL. See:
 - <Link href={"https://www.aem.live/docs/bulk-metadata"} text={"Bulk metadata"} />
 - [SEO metadata](/setup/seo/metadata/#generate-metadata)
 


### PR DESCRIPTION
**WIP: Needs human review.**

## What was confusing

Three related issues were sending users in the wrong direction:

1. **fstab.yaml changes silently have no effect** after the AEM Code Sync bot initially provisions a site. Docs didn't say this anywhere, leaving users confused when their fstab edits didn't apply.
2. **Folder mapping had no documented update path.** The deprecated fstab.yaml approach was still described as an option alongside the Config Service, but no steps existed for actually using the API to manage `folders.json`.
3. **config.json in the code repo was framed as a valid production option**, when in reality it silently overrides the Config Service — which is the opposite of what production sites should do.

## What changed

- **`multistore-setup.mdx`**: Replaced the vague "use Config Service or default-site.json" note with concrete GET/POST steps for `folders.json`. Added an explicit callout that `fstab.yaml` is bootstrap-only and changes to it after setup are ignored. Updated the troubleshooting tip to query the config service directly.
- **`configuration.mdx` (boilerplate)**: Made Config Service the unambiguous primary recommendation. Added a caution that `config.json` on `main` silently overrides the Config Service. Relabeled repo-based config as "local dev and branch testing only."
- **`faq.mdx`**: Expanded the deprecated folder mapping entry to explain that `fstab.yaml` is bootstrap-only, and linked to the Admin API as the correct replacement.
- **`commerce-configuration.mdx`**: Added a caution callout warning against committing `config.json` to `main`. Reordered the starter config options to lead with the Config Service approach.

## Reference docs

- Config Service setup: https://www.aem.live/docs/config-service-setup
- Admin API reference: https://www.aem.live/docs/admin.html
- Folder mapping deprecation: https://www.aem.live/developer/folder-mapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)