### PR TITLE
fixed file/.html issue

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -63,9 +63,6 @@ async function config() {
     trailingSlash: 'ignore',
     outDir: './dist',
     build: {
-      // Emit /path/page.html instead of /path/page/index.html so deploy pipelines
-      // do not generate hundreds of index.html → trailing-slash 301 rules for every doc page.
-      format: 'file',
       inlineStylesheets: 'always',
     },
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request reverts **`build.format: 'file'`** in `astro.config.mjs`. That setting made Astro emit **`page.html`** files instead of **`page/index.html`**, which led to:

- New topics only being reliably reachable at **`.html` URLs** (for example `/resources/build-with-ai.html`) while **clean URLs** (for example `/resources/build-with-ai/`) did not get a new `index.html` on deploy.
- **Duplicate URL patterns** (directory-style vs `.html`) and inconsistent behavior compared to older deploys that still had `index.html` paths.

Restoring the default **directory** build output aligns with Edge Delivery / Experience League expectations: **trailing-slash paths** and existing public URLs behave consistently. **`inlineStylesheets: 'always'`** is unchanged.

### Staging preview

<!--OPTIONAL Link to staging preview if available-->


## Affected pages

All documentation pages under the Commerce storefront microsite (build output and URL shape). Examples called out in review:

- https://experienceleague.adobe.com/developer/commerce/storefront/resources/build-with-ai/
- https://experienceleague.adobe.com/developer/commerce/storefront/resources/
- https://experienceleague.adobe.com/developer/commerce/storefront/

## Links to source code

Reverts the build-format portion of the change discussed in [microsite-commerce-storefront PR #876](https://github.com/commerce-docs/microsite-commerce-storefront/pull/876) / commit `6743d83e` (restore directory-style static output; address trailing-slash / CDN concerns at the infrastructure layer instead).

### What's New highlights

<!-- _OPTIONAL - REMOVE THIS SECTION IF NOT USED._ -->