### PR TITLE
USF-4017 add inStock to Item interface and fix Footer slot example in recommendations product-list docs

### DIFF
--- a/src/content/docs/dropins/recommendations/containers/product-list.mdx
+++ b/src/content/docs/dropins/recommendations/containers/product-list.mdx
@@ -101,6 +101,7 @@ export interface Item {
   visibility: string;
   queryType: string;
   itemType: string;
+  inStock?: boolean;
 }
 
 interface ItemImage {
@@ -197,15 +198,18 @@ provider.render(ProductList, {
         addToCart.className = 'footer__button--add-to-cart';
         wrapper.appendChild(addToCart);
 
-        if (ctx.product.itemType === 'SimpleProductView') {
+        if (ctx.item.itemType === 'SimpleProductView') {
           // Add to Cart Button
           UI.render(Button, {
             children: 'Add to Cart',
-            onClick: () => {
-              // Call add to cart function from cart/api
-              console.log('Add to Cart');
-            },
+            onClick: ctx.item.inStock
+              ? () => {
+                // Call add to cart function from cart/api
+                console.log('Add to Cart');
+              }
+              : undefined,
             variant: 'primary',
+            disabled: !ctx.item.inStock,
           })(addToCart);
         } else {
           // View Product Button
@@ -213,7 +217,7 @@ provider.render(ProductList, {
             children: 'Select Options',
             onClick: () => {
               console.log('Select Options');
-              window.location.href = ctx.product.urlKey;
+              window.location.href = ctx.item.urlKey;
             },
             variant: 'tertiary',
           })(addToCart);

--- a/src/content/docs/releases/changelog.mdx
+++ b/src/content/docs/releases/changelog.mdx
@@ -1594,6 +1594,16 @@ import Link from '@components/Link.astro';
 ***************************/}
 
     <ChangelogEntry
+      date="2026-05-13"
+      title="Product Recommendations v4.1.0"
+      components={['Product Recommendations']}
+    >
+      The Product Recommendations drop-in now exposes stock availability so integrators can disable the add-to-cart button for out-of-stock items without workarounds.
+
+      - **Out-of-stock add-to-cart gating**: The `inStock` field is now included in `PRODUCTS_VIEW_FRAGMENT` and mapped onto each `Item` in the data transform layer. Integrators reading `ctx.item.inStock` from the `Footer` slot context can conditionally disable the add-to-cart button when `inStock` is `false`, satisfying the requirement that shoppers cannot attempt to purchase unavailable recommended products ([#38](https://github.com/adobe-commerce/storefront-recommendations/pull/38)).
+    </ChangelogEntry>
+
+    <ChangelogEntry
       date="2026-04-30"
       title="Product Recommendations v4.0.1"
       components={['Product Recommendations']}

--- a/src/content/docs/releases/changelog.mdx
+++ b/src/content/docs/releases/changelog.mdx
@@ -1594,16 +1594,6 @@ import Link from '@components/Link.astro';
 ***************************/}
 
     <ChangelogEntry
-      date="2026-05-13"
-      title="Product Recommendations v4.1.0"
-      components={['Product Recommendations']}
-    >
-      The Product Recommendations drop-in now exposes stock availability so integrators can disable the add-to-cart button for out-of-stock items without workarounds.
-
-      - **Out-of-stock add-to-cart gating**: The `inStock` field is now included in `PRODUCTS_VIEW_FRAGMENT` and mapped onto each `Item` in the data transform layer. Integrators reading `ctx.item.inStock` from the `Footer` slot context can conditionally disable the add-to-cart button when `inStock` is `false`, satisfying the requirement that shoppers cannot attempt to purchase unavailable recommended products ([#38](https://github.com/adobe-commerce/storefront-recommendations/pull/38)).
-    </ChangelogEntry>
-
-    <ChangelogEntry
       date="2026-04-30"
       title="Product Recommendations v4.0.1"
       components={['Product Recommendations']}


### PR DESCRIPTION
## Purpose of this pull request

Adds inStock to the Item interface reference and corrects the Footer slot example to use ctx.item (the actual context key) with stock-based add-to-cart gating.

### Associated JIRA ticket

USF-4017

