### PR TITLE
Split oversized llms-txt bundles and fix coverage gap

### DIFF
--- a/scripts/generate-llms-full.js
+++ b/scripts/generate-llms-full.js
@@ -147,13 +147,13 @@ const LLMS_TXT_BUNDLES = [
   {
     slug: 'get-started',
     label: 'Get started',
-    blurb: 'Onboarding, architecture, performance, and Lighthouse for Commerce storefront projects',
+    blurb: 'Onboarding, architecture, backend options, performance, Lighthouse, browser compatibility, and AI documentation bundles',
     filter: p => p.startsWith('get-started/')
   },
   {
     slug: 'boilerplate',
     label: 'Boilerplate',
-    blurb: 'Boilerplate template, blocks reference, configuration, and Universal Editor',
+    blurb: 'Boilerplate setup, configuration, blocks reference, customization, Universal Editor, AI agent skills, and updates',
     filter: p => p.startsWith('boilerplate/')
   },
   {
@@ -177,7 +177,7 @@ const LLMS_TXT_BUNDLES = [
   {
     slug: 'setup-go-live',
     label: 'Setup — go live',
-    blurb: 'Discovery, analytics, AEP, SEO, launch checklist, and data export validation',
+    blurb: 'Discovery, Luma Bridge, analytics, AEP, SEO, launch checklist, and data export validation',
     filter: p => p.startsWith('setup/') && !p.startsWith('setup/configuration/')
   },
   {
@@ -203,7 +203,7 @@ const LLMS_TXT_BUNDLES = [
   {
     slug: 'dropins-order',
     label: 'Order drop-in',
-    blurb: 'Order confirmation and order management drop-in reference',
+    blurb: 'Order management, order confirmation, and returns drop-in reference',
     filter: p => p.startsWith('dropins/order/') && !p.includes('/tutorials/')
   },
   {
@@ -272,7 +272,7 @@ const LLMS_TXT_BUNDLES = [
   {
     slug: 'blocks-reference',
     label: 'Commerce blocks reference',
-    blurb: 'Edge Delivery blocks for commerce (placeholders, slots, and block-level documentation)',
+    blurb: 'EDS block configurations for B2C and B2B commerce (cart, checkout, account, order, quotes, and purchasing)',
     filter: p => p.startsWith('merchants/blocks/')
   },
   {
@@ -284,7 +284,7 @@ const LLMS_TXT_BUNDLES = [
   {
     slug: 'sdk-reference',
     label: 'Storefront SDK',
-    blurb: 'SDK components, patterns, and integration',
+    blurb: 'UI components, design system, reference APIs (Event Bus, GraphQL, slots), CLI, and utilities',
     filter: p => p.startsWith('sdk/')
   },
   {
@@ -308,7 +308,7 @@ const LLMS_TXT_BUNDLES = [
   {
     slug: 'resources',
     label: 'Resources',
-    blurb: 'Placeholders, building with AI (context files), and supplementary resources',
+    blurb: 'Placeholder files (storefront labels for drop-in components) and supplementary resources',
     filter: p => p.startsWith('resources/')
   },
   {

--- a/scripts/generate-llms-full.js
+++ b/scripts/generate-llms-full.js
@@ -141,8 +141,8 @@ const LLMS_TXT_BUNDLES = [
   {
     slug: 'documentation-home',
     label: 'Documentation home',
-    blurb: 'Top-level documentation landing content',
-    filter: p => p === 'index'
+    blurb: 'Top-level documentation landing content and reference hub',
+    filter: p => p === 'index' || p.startsWith('reference/')
   },
   {
     slug: 'get-started',
@@ -169,17 +169,99 @@ const LLMS_TXT_BUNDLES = [
     filter: p => p.startsWith('licensing/')
   },
   {
-    slug: 'setup-reference',
-    label: 'Setup and configuration',
-    blurb: 'Discovery, configuration, SEO, launch, analytics, and compatibility',
-    filter: p => p.startsWith('setup/')
+    slug: 'setup-configuration',
+    label: 'Setup — configuration',
+    blurb: 'Configuration: endpoints, headers, CORS, gated content, multistore, prerender, CDN, AEM Assets, Storefront Compatibility Package',
+    filter: p => p.startsWith('setup/configuration/')
   },
   {
-    slug: 'dropins-reference',
-    label: 'Drop-ins reference',
-    blurb: 'Drop-in components, containers, APIs, and guides (excludes step-by-step tutorials)',
+    slug: 'setup-go-live',
+    label: 'Setup — go live',
+    blurb: 'Discovery, analytics, AEP, SEO, launch checklist, and data export validation',
+    filter: p => p.startsWith('setup/') && !p.startsWith('setup/configuration/')
+  },
+  {
+    slug: 'dropins-intro',
+    label: 'Drop-ins overview',
+    blurb: 'Cross-drop-in concepts, shared APIs, and indexes for B2C and B2B drop-ins',
     filter: p =>
-      (p.startsWith('dropins/') || p.startsWith('dropins-b2b/')) && !p.includes('/tutorials/')
+      (p.startsWith('dropins/all/') || p === 'dropins/index' || p === 'dropins-b2b/index') &&
+      !p.includes('/tutorials/')
+  },
+  {
+    slug: 'dropins-cart',
+    label: 'Cart drop-in',
+    blurb: 'Cart drop-in containers, slots, events, and customization APIs',
+    filter: p => p.startsWith('dropins/cart/') && !p.includes('/tutorials/')
+  },
+  {
+    slug: 'dropins-checkout',
+    label: 'Checkout drop-in',
+    blurb: 'Checkout drop-in containers, slots, events, and customization APIs',
+    filter: p => p.startsWith('dropins/checkout/') && !p.includes('/tutorials/')
+  },
+  {
+    slug: 'dropins-order',
+    label: 'Order drop-in',
+    blurb: 'Order confirmation and order management drop-in reference',
+    filter: p => p.startsWith('dropins/order/') && !p.includes('/tutorials/')
+  },
+  {
+    slug: 'dropins-pdp',
+    label: 'Product details drop-in',
+    blurb: 'Product details page drop-in containers, slots, and APIs',
+    filter: p => p.startsWith('dropins/product-details/') && !p.includes('/tutorials/')
+  },
+  {
+    slug: 'dropins-account-auth',
+    label: 'Account and auth drop-ins',
+    blurb: 'User account and user authentication drop-in reference',
+    filter: p =>
+      (p.startsWith('dropins/user-account/') || p.startsWith('dropins/user-auth/')) &&
+      !p.includes('/tutorials/')
+  },
+  {
+    slug: 'dropins-catalog',
+    label: 'Catalog drop-ins',
+    blurb: 'Product discovery (Live Search), recommendations, and personalization drop-in reference',
+    filter: p =>
+      (p.startsWith('dropins/product-discovery/') ||
+        p.startsWith('dropins/recommendations/') ||
+        p.startsWith('dropins/personalization/')) &&
+      !p.includes('/tutorials/')
+  },
+  {
+    slug: 'dropins-wishlist-payments',
+    label: 'Wishlist and payments drop-ins',
+    blurb: 'Wishlist and payment services drop-in reference',
+    filter: p =>
+      (p.startsWith('dropins/wishlist/') || p.startsWith('dropins/payment-services/')) &&
+      !p.includes('/tutorials/')
+  },
+  {
+    slug: 'dropins-b2b-quote',
+    label: 'B2B quote management drop-in',
+    blurb: 'Quote management drop-in containers, slots, events, and APIs for B2B',
+    filter: p => p.startsWith('dropins-b2b/quote-management/') && !p.includes('/tutorials/')
+  },
+  {
+    slug: 'dropins-b2b-company',
+    label: 'B2B company management drop-ins',
+    blurb: 'Company management and company switcher drop-in reference for B2B',
+    filter: p =>
+      (p.startsWith('dropins-b2b/company-management/') ||
+        p.startsWith('dropins-b2b/company-switcher/')) &&
+      !p.includes('/tutorials/')
+  },
+  {
+    slug: 'dropins-b2b-purchasing',
+    label: 'B2B purchasing drop-ins',
+    blurb: 'Purchase order, quick order, and requisition list drop-in reference for B2B',
+    filter: p =>
+      (p.startsWith('dropins-b2b/purchase-order/') ||
+        p.startsWith('dropins-b2b/quick-order/') ||
+        p.startsWith('dropins-b2b/requisition-list/')) &&
+      !p.includes('/tutorials/')
   },
   {
     slug: 'tutorials-reference',
@@ -912,6 +994,11 @@ function validateCoverage(allFiles) {
       uncovered.slice(0, 20),
       uncovered.length > 20 ? `... (+${uncovered.length - 20} more)` : ''
     );
+  }
+  for (const bundle of LLMS_TXT_BUNDLES) {
+    if (!paths.some(p => bundle.filter(p))) {
+      console.warn(`Warning: bundle "${bundle.slug}" matches zero documentation files`);
+    }
   }
 }
 

--- a/scripts/generate-llms-full.js
+++ b/scripts/generate-llms-full.js
@@ -287,12 +287,14 @@ const LLMS_TXT_BUNDLES = [
     blurb: 'UI components, design system, reference APIs (Event Bus, GraphQL, slots), CLI, and utilities',
     filter: p => p.startsWith('sdk/')
   },
-  {
-    slug: 'videos',
-    label: 'Videos',
-    blurb: 'Training videos and related notes',
-    filter: p => p.startsWith('videos/')
-  },
+  // Excluded: videos/ pages are descriptions of video content with no actionable text for AI tools;
+  // the corresponding step-by-step content lives in tutorials-reference.
+  // {
+  //   slug: 'videos',
+  //   label: 'Videos',
+  //   blurb: 'Training videos and related notes',
+  //   filter: p => p.startsWith('videos/')
+  // },
   {
     slug: 'releases',
     label: 'Releases',
@@ -305,18 +307,20 @@ const LLMS_TXT_BUNDLES = [
     blurb: 'FAQ and operational troubleshooting',
     filter: p => p.startsWith('troubleshooting/')
   },
-  {
-    slug: 'resources',
-    label: 'Resources',
-    blurb: 'Placeholder files (storefront labels for drop-in components) and supplementary resources',
-    filter: p => p.startsWith('resources/')
-  },
-  {
-    slug: 'playgrounds',
-    label: 'Playgrounds',
-    blurb: 'Interactive playground documentation',
-    filter: p => p.startsWith('playgrounds/')
-  }
+  // Excluded: resources/ contains only a list of external JSON URLs; no actionable content for AI tools.
+  // {
+  //   slug: 'resources',
+  //   label: 'Resources',
+  //   blurb: 'Placeholder files (storefront labels for drop-in components) and supplementary resources',
+  //   filter: p => p.startsWith('resources/')
+  // },
+  // Excluded: playgrounds/ pages wrap an interactive GraphiQL UI that renders nothing meaningful as text.
+  // {
+  //   slug: 'playgrounds',
+  //   label: 'Playgrounds',
+  //   blurb: 'Interactive playground documentation',
+  //   filter: p => p.startsWith('playgrounds/')
+  // }
 ];
 
 function shouldAddTrailingSlash(urlPath) {
@@ -985,9 +989,14 @@ ${thematic}
   writeFileSync(OUTPUT_LLMSTXT, body, 'utf-8');
 }
 
+// Paths intentionally excluded from all bundles (content not useful for AI tools).
+const COVERAGE_EXCLUSIONS = ['videos/', 'resources/', 'playgrounds/'];
+
 function validateCoverage(allFiles) {
   const paths = allFiles.map(f => f.relativePath);
-  const uncovered = paths.filter(p => !LLMS_TXT_BUNDLES.some(b => b.filter(p)));
+  const uncovered = paths.filter(
+    p => !LLMS_TXT_BUNDLES.some(b => b.filter(p)) && !COVERAGE_EXCLUSIONS.some(e => p.startsWith(e))
+  );
   if (uncovered.length > 0) {
     console.warn(
       'Warning: some docs are not covered by any _llms-txt bundle filter:',


### PR DESCRIPTION
## Purpose of this pull request

Resolves three related issues with `scripts/generate-llms-full.js` bundle definitions, then fixes inaccurate blurbs and removes bundles with no actionable AI content.

### Bundle splits (#897, #898, #899)

**#897** — Replace `dropins-reference` (1.4 MB) with 11 per-drop-in bundles, all under ~210 KB:
`dropins-intro`, `dropins-cart`, `dropins-checkout`, `dropins-order`, `dropins-pdp`, `dropins-account-auth`, `dropins-catalog`, `dropins-wishlist-payments`, `dropins-b2b-quote`, `dropins-b2b-company`, `dropins-b2b-purchasing`

**#899** — Replace `setup-reference` (227 KB) with `setup-configuration` (~160 KB) and `setup-go-live` (~66 KB)

**#898** — Extend `documentation-home` filter to include `reference/` so `reference/index.mdx` is covered and `validateCoverage` no longer warns on every build

Also adds a per-bundle zero-file check to `validateCoverage` so misconfigured filters are caught at build time.

### Blurb and label accuracy

Corrected 7 bundles where the blurb described content not in the bundle or omitted significant content:

- `resources` — removed false "building with AI" claim (that page is in `get-started`)
- `blocks-reference` — removed misleading "placeholders"; rewrote to describe EDS block configs for merchants
- `dropins-order` — added "returns" (CreateReturn, OrderReturns, ReturnsList containers are in this bundle)
- `setup-go-live` — added Luma Bridge
- `sdk-reference` — replaced vague "components, patterns, integration" with specific coverage (design system, reference APIs, CLI, utilities)
- `get-started` — added browser compatibility and AI documentation bundles
- `boilerplate` — added AI agent skills and updates

### Remove low-value bundles

Commented out three bundles whose generated text provides no actionable content for AI tools:

- `videos` — video description pages with no code or steps; the actual implementations are in `tutorials-reference`
- `resources` — only a list of external JSON URLs; the placeholder keys/values live in those files, not here
- `playgrounds` — wraps an interactive GraphiQL UI that renders as empty text

Entries are commented out (not deleted) so the reasoning is preserved. Added `COVERAGE_EXCLUSIONS` so `validateCoverage` does not warn about these intentionally excluded paths.

## Affected pages

Generated output files (`public/llms.txt`, `public/_llms-txt/*.txt`) are gitignored and rebuilt on deploy; no source pages are affected.

## Links to source code

Closes #897
Closes #898
Closes #899