### PR TITLE
COMDOX-1681: Authoring Commerce blocks and placeholder docs

### DIFF
--- a/astro.sidebar.mjs
+++ b/astro.sidebar.mjs
@@ -831,6 +831,7 @@ export function generateSidebar() {
             { label: 'How block tables work', link: '/merchants/quick-start/block-tables/' },
             { label: 'Page Metadata', link: '/merchants/quick-start/page-metadata/' },
             { label: 'Section Metadata', link: '/merchants/quick-start/section-metadata/' },
+            { label: 'Labels and Placeholders', link: '/merchants/quick-start/labels-and-placeholders/' },
           ],
         },
         {

--- a/astro.sidebar.mjs
+++ b/astro.sidebar.mjs
@@ -827,6 +827,7 @@ export function generateSidebar() {
             { label: 'Using the Universal Editor', link: '/merchants/quick-start/universal-editor/' },
             // { label: 'Using Digital Assets Management', link: '/merchants/quick-start/digital-assets-management/' },
             { label: 'Using Content and Commerce Blocks', link: '/merchants/quick-start/content-commerce-blocks/' },
+            { label: 'Authoring Commerce blocks', link: '/merchants/quick-start/authoring-commerce-blocks/' },
             { label: 'How block tables work', link: '/merchants/quick-start/block-tables/' },
             { label: 'Page Metadata', link: '/merchants/quick-start/page-metadata/' },
             { label: 'Section Metadata', link: '/merchants/quick-start/section-metadata/' },

--- a/astro.sidebar.mjs
+++ b/astro.sidebar.mjs
@@ -832,6 +832,7 @@ export function generateSidebar() {
             { label: 'Page Metadata', link: '/merchants/quick-start/page-metadata/' },
             { label: 'Section Metadata', link: '/merchants/quick-start/section-metadata/' },
             { label: 'Labels and Placeholders', link: '/merchants/quick-start/labels-and-placeholders/' },
+            { label: 'Placeholder sheets', link: '/merchants/quick-start/placeholder-sheets/' },
           ],
         },
         {

--- a/src/content/docs/merchants/blocks/index.mdx
+++ b/src/content/docs/merchants/blocks/index.mdx
@@ -8,6 +8,8 @@ import LinkCard from '@components/LinkCard.astro';
 
 Commerce blocks are pre-built components that add shopping functionality to your pages. Choose the blocks that match your storefront type—B2C (business-to-consumer) or B2B (business-to-business).
 
+If you are new to authoring Commerce pages, read [Authoring Commerce blocks](/merchants/quick-start/authoring-commerce-blocks/) first. It explains drop-ins, blocks, and pages as three layers; what you can change without code; and when to hand off to a developer.
+
 <CardGrid columns={2}>
   <LinkCard
     noborder

--- a/src/content/docs/merchants/quick-start/authoring-commerce-blocks.mdx
+++ b/src/content/docs/merchants/quick-start/authoring-commerce-blocks.mdx
@@ -1,74 +1,74 @@
 ---
 title: Authoring Commerce blocks
-description: "Orient authors and integrators to Commerce blocks and drop-ins: what each layer is, what you can change without code, what needs a developer, and how to hand work off when it falls outside your tools."
+description: Learn how a Commerce page is built from drop-ins, Commerce blocks, and pages, what you can change without code, and what to hand to a developer when code is required.
 sidebar:
   order: 2
 ---
 
 import { Aside } from '@astrojs/starlight/components';
-import Link from '@components/Link.astro';
 import Term from '@components/Term.astro';
+import { Steps } from '@astrojs/starlight/components';
 
-This page orients you to the layers behind a Commerce storefront page, what an author can change on each layer without writing code, and what to hand off to a developer when a request reaches the edge of your tools. Read this once before you dive into the individual block pages, so the rest of the merchant documentation makes sense as a system rather than a list.
+This page explains how a Commerce storefront page is built from three layers, what an author can change on each layer without writing code, and what to hand to a developer when a request needs code. Read this once before you open the individual Commerce block pages, so you can tell at a glance whether a change is yours to make or your developer's.
 
 The audience is two roles working together:
 
-- Author — edits pages and content in <Term>Document Authoring</Term> (or the Universal Editor).
-- Integrator — configures the storefront's connection to Adobe Commerce, store views, and shared site settings, often by editing configuration files alongside a developer.
+- **Author** — edits pages and content in <Term>Document Authoring</Term> (or the Universal Editor).
+- **Integrator** — configures the storefront's connection to Adobe Commerce, store views, and shared site settings, often by editing configuration files alongside a developer.
 
-Most pages in this section are written for authors. This page also names the integrator and developer roles so a request that does not fit the author tools has a clear next step.
+Most pages in this section are written for authors. This page also names the integrator and developer roles so you know who to ask when a request is outside your author tools.
 
 ## Three things you'll work with
 
-A Commerce page is made of three layers stacked together:
+A Commerce page is built from three layers:
 
-- <Term>Drop-in components</Term> are the code components Adobe ships, such as the Product Details, Cart, Checkout, and Account drop-ins. A drop-in renders most of what shoppers see on a Commerce screen — the gallery, the price, the cart line items, the checkout form — and reads live data from Commerce so it always reflects the current catalog and shopper.
-- A block is how a drop-in appears in your document. You add a block by adding a small table with the block name (for example, `product-details` or `commerce-cart`) and any settings the block needs. See [How block tables work](/merchants/quick-start/block-tables/) for the table shape.
-- A page is the document the block lives on. The page can include more than one block, plus other content blocks for marketing copy, images, breadcrumbs, and recommendations.
+- <Term>**Drop-in components**</Term> are the code components Adobe ships, such as the Product Details, Cart, Checkout, and Account drop-ins. A drop-in displays most of what shoppers see on a Commerce screen — the gallery, the price, the cart line items, the checkout form. It also pulls live data from Commerce, so the price, stock, and cart state stay current.
+- **A Commerce block** is how a drop-in appears in your document. You create a Commerce block by adding a small table with the block name (for example, `product-details` or `commerce-cart`) and any settings the Commerce block needs. See [How block tables work](/merchants/quick-start/block-tables/) for the table shape.
+- **A page** is the document the Commerce block lives on. A page can include more than one Commerce block, plus other content blocks like marketing copy, images, breadcrumbs, and recommendations.
 
-A useful way to picture the layers: the drop-in is the engine, the block is the steering wheel you put in the dashboard, and the page is the car body around them. You build the page and add the steering wheel; Adobe ships the engine.
+A useful way to picture the layers: the drop-in is the engine, the Commerce block is the steering wheel, and the page is the car around them. You build the car and add the steering wheel. Adobe ships the engine.
 
 ## What you can change without code
 
-For every Commerce block, the following changes are author tasks. They use document tables and sheets in Document Authoring, not code:
+For every Commerce block, you can make these changes in Document Authoring using tables and sheets, not code:
 
 | Task | Where to do it | Reference |
 | --- | --- | --- |
-| Choose which block appears on a page | The block table on the page | [How block tables work](/merchants/quick-start/block-tables/) |
-| Set the small handful of settings a block accepts | The block table on the page | The block's reference page in [B2C blocks](/merchants/blocks/b2c/) or [B2B blocks](/merchants/blocks/b2b/) |
+| Choose which Commerce block appears on a page | The block table on the page | [How block tables work](/merchants/quick-start/block-tables/) |
+| Set the few settings a Commerce block accepts | The block table on the page | The Commerce block's reference page in [B2C Commerce blocks](/merchants/blocks/b2c/) or [B2B Commerce blocks](/merchants/blocks/b2b/) |
 | Change the words shoppers see (button labels, headings, messages) | The placeholders sheet for the matching drop-in | [Labels and placeholders](/merchants/quick-start/labels-and-placeholders/) |
 | Set the page title, description, and indexing | The metadata table at the top of the page | [Page metadata](/merchants/quick-start/page-metadata/) |
-| Adjust spacing, background, and column widths around a block | A section-metadata table after the block | [Section metadata](/merchants/quick-start/section-metadata/) |
+| Adjust spacing, background, and column widths around a Commerce block | A section-metadata table after the Commerce block | [Section metadata](/merchants/quick-start/section-metadata/) |
 | Translate labels into other locales | The locale-specific placeholders sheets | [Commerce localization tasks](/merchants/quick-start/content-localization-commerce-tasks/) |
-| Add related blocks on the same page (breadcrumbs, recommendations, content blocks) | Add another block table on the page | [Using Content and Commerce blocks](/merchants/quick-start/content-commerce-blocks/) |
-| Schedule when a page goes live | Snapshot scheduling in the sidekick | [Scheduling options](/merchants/edge-delivery-services/scheduling/) |
+| Add related blocks on the same page (for example, breadcrumbs or product recommendations) | Add another block table on the page | [Using Content and Commerce blocks](/merchants/quick-start/content-commerce-blocks/) |
+| Schedule when a page goes live | Snapshot scheduling in Document Authoring | [Scheduling options](/merchants/edge-delivery-services/scheduling/) |
 
 If the change you want is in the list above, you do not need a developer. Open the right tool, make the edit, preview, publish, and verify.
 
 ## What needs a developer
 
-These changes touch code or configuration outside the author tools. Open a ticket with your developer when you need any of them:
+These changes require code or configuration outside the author tools. Open a ticket with your developer when you need any of them:
 
 | Task | Why it is not an author task |
 | --- | --- |
-| Add or remove a region inside a drop-in (for example, a wishlist button on the PDP) | The region is rendered by the drop-in's container, not by your block table. A developer adds the region through the drop-in slot or container API. |
+| Add or remove an element inside a drop-in (for example, a wishlist button on the product details page) | That element is rendered by the drop-in's container, not by your block table. A developer adds it using a drop-in slot or by customizing a container. |
 | Change the visual design of a drop-in (colors, fonts, button shapes beyond section metadata) | Visual design lives in the project's CSS and design tokens. A developer edits those files. |
-| Wire a new analytics or A/B testing event | The drop-in publishes events on the event bus. A developer subscribes to the event and forwards it to the analytics or testing tool. |
-| Connect or change the Commerce backend (endpoints, store view headers, services) | These settings live in `config.json` and similar files. The integrator owns this work, often paired with a developer. |
-| Add a brand-new drop-in not yet in the boilerplate | A developer installs the package and writes the block that mounts it. |
-| Replace the underlying functionality of a block (for example, change how Add to Cart behaves) | The behavior comes from the drop-in code, not from the block table. A developer customizes the drop-in. |
+| Track a new event in analytics or A/B testing | The drop-in publishes events on a shared event bus. A developer subscribes to the event and forwards it to whichever tool the site uses (for example, Google Analytics or Adobe Target). |
+| Connect or change the Commerce backend (endpoints, store view headers, services) | These settings live in your [storefront configuration](/setup/configuration/commerce-configuration/). The integrator owns this work, often paired with a developer. |
+| Add a new drop-in that isn't in the boilerplate yet | A developer installs the package and writes the Commerce block that mounts it. |
+| Change how a Commerce block behaves, not just how it looks (for example, how Add to Cart works) | The behavior comes from the drop-in code, not from the block table. A developer customizes the drop-in. |
 
-See [Customize beyond authoring](/dropins/all/introduction/) for the developer-facing overview of containers, slots, and events. Sharing the same vocabulary makes the handoff faster.
+See [Introduction to drop-in components](/dropins/all/introduction/) for the developer-facing overview of containers, slots, and events. Sharing the same vocabulary makes the handoff faster.
 
 ## Roles at a glance
 
 A small Commerce team usually splits the work like this:
 
-- Author — owns content and the words shoppers see. Edits pages, sets block settings, edits placeholders sheets, manages section and page metadata, publishes content, schedules releases. Lives in Document Authoring.
-- Integrator — owns the storefront's connection to Adobe Commerce and to shared site settings. Edits `config.json`, store view headers, and similar configuration. Works with the developer when a setting requires a code change.
-- Developer — owns the code in the boilerplate repository. Customizes drop-ins (slots, events, containers), changes design tokens and CSS, adds new drop-ins, and wires analytics and integrations.
+- **Author** — owns content and the words shoppers see. Edits pages, sets block settings, edits placeholders sheets, manages section and page metadata, publishes content, schedules releases. Lives in Document Authoring.
+- **Integrator** — owns the storefront's connection to Adobe Commerce and to shared site settings. Edits the [storefront configuration](/setup/configuration/commerce-configuration/), store view headers, and similar settings. Works with the developer when a setting requires a code change.
+- **Developer** — owns the code in the boilerplate repository. Customizes drop-ins (slots, events, containers), changes design tokens and CSS, adds new drop-ins, and connects analytics and integrations.
 
-On a small team the same person may wear two of these hats. The distinction still helps when you write a ticket: name the role you want help from, and the work routes faster.
+On a small team, one person may do two of these jobs. The split still helps when you write a ticket — name the role you need help from, and your request reaches the right person faster.
 
 <Aside type="tip" title="Tip for tickets">
 When you raise a request that needs a developer, include three things: the page URL, the block name (for example, `product-details`), and a one-sentence description of what you want shoppers to see that you cannot do from the author tools. That is usually enough for the developer to start.
@@ -76,19 +76,24 @@ When you raise a request that needs a developer, include three things: the page 
 
 ## How a typical task flows
 
-A real request usually looks like this:
+A typical request looks like this:
 
-1. Someone asks you to change something on a Commerce page — wording, layout, a new SKU on a marketing page, a different button color, an analytics event.
+<Steps>
+1. You receive a request to change something on a Commerce page — wording, layout, a new SKU on a marketing page, a different button color, an analytics event.
+
 1. Check the [What you can change without code](#what-you-can-change-without-code) table. If the change is there, follow the linked authoring page.
-1. If the change is not there, check [What needs a developer](#what-needs-a-developer). Pick the matching row, then file a ticket using the tip above.
-1. After the developer ships the change, you usually still own the publish step in Document Authoring. Preview the page, publish it, and verify the change on the live site.
 
-This flow keeps small requests fast and keeps developer time focused on real code work.
+1. If the change is not there, check [What needs a developer](#what-needs-a-developer). Pick the matching row, then file a ticket using the tip above.
+
+1. After the developer ships the change, you'll still own the publish step in Document Authoring. Preview the page, publish it, and verify the change on the live site.
+</Steps>
+
+This flow keeps small requests fast and keeps developer time on the changes that need code.
 
 ## Where to go next
 
 - [How block tables work](/merchants/quick-start/block-tables/) — the table shape used in every block on this page.
 - [Your first page](/merchants/quick-start/your-first-page/) — a hands-on walkthrough that ties block tables, page metadata, and section metadata together.
-- [B2C Commerce blocks](/merchants/blocks/b2c/) — the full reference for every B2C block.
-- [B2B Commerce blocks](/merchants/blocks/b2b/) — the full reference for every B2B block.
+- [B2C Commerce blocks](/merchants/blocks/b2c/) — the full reference for every B2C Commerce block.
+- [B2B Commerce blocks](/merchants/blocks/b2b/) — the full reference for every B2B Commerce block.
 - [Labels and placeholders](/merchants/quick-start/labels-and-placeholders/) — change the words shoppers see, end to end.

--- a/src/content/docs/merchants/quick-start/authoring-commerce-blocks.mdx
+++ b/src/content/docs/merchants/quick-start/authoring-commerce-blocks.mdx
@@ -1,0 +1,94 @@
+---
+title: Authoring Commerce blocks
+description: "Orient authors and integrators to Commerce blocks and drop-ins: what each layer is, what you can change without code, what needs a developer, and how to hand work off when it falls outside your tools."
+sidebar:
+  order: 2
+---
+
+import { Aside } from '@astrojs/starlight/components';
+import Link from '@components/Link.astro';
+import Term from '@components/Term.astro';
+
+This page orients you to the layers behind a Commerce storefront page, what an author can change on each layer without writing code, and what to hand off to a developer when a request reaches the edge of your tools. Read this once before you dive into the individual block pages, so the rest of the merchant documentation makes sense as a system rather than a list.
+
+The audience is two roles working together:
+
+- Author — edits pages and content in <Term>Document Authoring</Term> (or the Universal Editor).
+- Integrator — configures the storefront's connection to Adobe Commerce, store views, and shared site settings, often by editing configuration files alongside a developer.
+
+Most pages in this section are written for authors. This page also names the integrator and developer roles so a request that does not fit the author tools has a clear next step.
+
+## Three things you'll work with
+
+A Commerce page is made of three layers stacked together:
+
+- <Term>Drop-in components</Term> are the code components Adobe ships, such as the Product Details, Cart, Checkout, and Account drop-ins. A drop-in renders most of what shoppers see on a Commerce screen — the gallery, the price, the cart line items, the checkout form — and reads live data from Commerce so it always reflects the current catalog and shopper.
+- A block is how a drop-in appears in your document. You add a block by adding a small table with the block name (for example, `product-details` or `commerce-cart`) and any settings the block needs. See [How block tables work](/merchants/quick-start/block-tables/) for the table shape.
+- A page is the document the block lives on. The page can include more than one block, plus other content blocks for marketing copy, images, breadcrumbs, and recommendations.
+
+A useful way to picture the layers: the drop-in is the engine, the block is the steering wheel you put in the dashboard, and the page is the car body around them. You build the page and add the steering wheel; Adobe ships the engine.
+
+## What you can change without code
+
+For every Commerce block, the following changes are author tasks. They use document tables and sheets in Document Authoring, not code:
+
+| Task | Where to do it | Reference |
+| --- | --- | --- |
+| Choose which block appears on a page | The block table on the page | [How block tables work](/merchants/quick-start/block-tables/) |
+| Set the small handful of settings a block accepts | The block table on the page | The block's reference page in [B2C blocks](/merchants/blocks/b2c/) or [B2B blocks](/merchants/blocks/b2b/) |
+| Change the words shoppers see (button labels, headings, messages) | The placeholders sheet for the matching drop-in | [Labels and placeholders](/merchants/quick-start/labels-and-placeholders/) |
+| Set the page title, description, and indexing | The metadata table at the top of the page | [Page metadata](/merchants/quick-start/page-metadata/) |
+| Adjust spacing, background, and column widths around a block | A section-metadata table after the block | [Section metadata](/merchants/quick-start/section-metadata/) |
+| Translate labels into other locales | The locale-specific placeholders sheets | [Commerce localization tasks](/merchants/quick-start/content-localization-commerce-tasks/) |
+| Add related blocks on the same page (breadcrumbs, recommendations, content blocks) | Add another block table on the page | [Using Content and Commerce blocks](/merchants/quick-start/content-commerce-blocks/) |
+| Schedule when a page goes live | Snapshot scheduling in the sidekick | [Scheduling options](/merchants/edge-delivery-services/scheduling/) |
+
+If the change you want is in the list above, you do not need a developer. Open the right tool, make the edit, preview, publish, and verify.
+
+## What needs a developer
+
+These changes touch code or configuration outside the author tools. Open a ticket with your developer when you need any of them:
+
+| Task | Why it is not an author task |
+| --- | --- |
+| Add or remove a region inside a drop-in (for example, a wishlist button on the PDP) | The region is rendered by the drop-in's container, not by your block table. A developer adds the region through the drop-in slot or container API. |
+| Change the visual design of a drop-in (colors, fonts, button shapes beyond section metadata) | Visual design lives in the project's CSS and design tokens. A developer edits those files. |
+| Wire a new analytics or A/B testing event | The drop-in publishes events on the event bus. A developer subscribes to the event and forwards it to the analytics or testing tool. |
+| Connect or change the Commerce backend (endpoints, store view headers, services) | These settings live in `config.json` and similar files. The integrator owns this work, often paired with a developer. |
+| Add a brand-new drop-in not yet in the boilerplate | A developer installs the package and writes the block that mounts it. |
+| Replace the underlying functionality of a block (for example, change how Add to Cart behaves) | The behavior comes from the drop-in code, not from the block table. A developer customizes the drop-in. |
+
+See [Customize beyond authoring](/dropins/all/introduction/) for the developer-facing overview of containers, slots, and events. Sharing the same vocabulary makes the handoff faster.
+
+## Roles at a glance
+
+A small Commerce team usually splits the work like this:
+
+- Author — owns content and the words shoppers see. Edits pages, sets block settings, edits placeholders sheets, manages section and page metadata, publishes content, schedules releases. Lives in Document Authoring.
+- Integrator — owns the storefront's connection to Adobe Commerce and to shared site settings. Edits `config.json`, store view headers, and similar configuration. Works with the developer when a setting requires a code change.
+- Developer — owns the code in the boilerplate repository. Customizes drop-ins (slots, events, containers), changes design tokens and CSS, adds new drop-ins, and wires analytics and integrations.
+
+On a small team the same person may wear two of these hats. The distinction still helps when you write a ticket: name the role you want help from, and the work routes faster.
+
+<Aside type="tip" title="Tip for tickets">
+When you raise a request that needs a developer, include three things: the page URL, the block name (for example, `product-details`), and a one-sentence description of what you want shoppers to see that you cannot do from the author tools. That is usually enough for the developer to start.
+</Aside>
+
+## How a typical task flows
+
+A real request usually looks like this:
+
+1. Someone asks you to change something on a Commerce page — wording, layout, a new SKU on a marketing page, a different button color, an analytics event.
+1. Check the [What you can change without code](#what-you-can-change-without-code) table. If the change is there, follow the linked authoring page.
+1. If the change is not there, check [What needs a developer](#what-needs-a-developer). Pick the matching row, then file a ticket using the tip above.
+1. After the developer ships the change, you usually still own the publish step in Document Authoring. Preview the page, publish it, and verify the change on the live site.
+
+This flow keeps small requests fast and keeps developer time focused on real code work.
+
+## Where to go next
+
+- [How block tables work](/merchants/quick-start/block-tables/) — the table shape used in every block on this page.
+- [Your first page](/merchants/quick-start/your-first-page/) — a hands-on walkthrough that ties block tables, page metadata, and section metadata together.
+- [B2C Commerce blocks](/merchants/blocks/b2c/) — the full reference for every B2C block.
+- [B2B Commerce blocks](/merchants/blocks/b2b/) — the full reference for every B2B block.
+- [Labels and placeholders](/merchants/quick-start/labels-and-placeholders/) — change the words shoppers see, end to end.

--- a/src/content/docs/merchants/quick-start/index.mdx
+++ b/src/content/docs/merchants/quick-start/index.mdx
@@ -13,6 +13,7 @@ Get started by learning what Commerce Storefront is and how block tables work, t
 |-------|-------------|
 | **Get oriented** | |
 | [What is Commerce Storefront?](/merchants/quick-start/create-content/) | Learn about the Commerce Storefront platform and the tools you use to build storefront pages |
+| [Authoring Commerce blocks](/merchants/quick-start/authoring-commerce-blocks/) | Drop-ins, blocks, and pages as three layers; what you can change without code; when to hand off to a developer |
 | [How block tables work](/merchants/quick-start/block-tables/) | How document tables map to blocks (name row, key-value settings, and merged full-width content rows) |
 | **Build a page** | |
 | [Using the Document Authoring tool](/merchants/quick-start/document-authoring/) | Learn the document-based authoring interface for creating and editing page content |

--- a/src/content/docs/merchants/quick-start/labels-and-placeholders.mdx
+++ b/src/content/docs/merchants/quick-start/labels-and-placeholders.mdx
@@ -1,55 +1,54 @@
 ---
-title: Labels and Placeholders
-description: Change the words shoppers see in Commerce blocks (button text, headings, messages) by editing a placeholders sheet in Document Authoring, with the preview-and-publish step that often gets skipped.
+title: Labels and placeholders
+description: Change the words shoppers see in Commerce blocks by editing a placeholders sheet in Document Authoring, including the publish step that is easy to miss.
 sidebar:
   order: 5
+time: 5 minutes
 ---
 
 import Tasks from '@components/Tasks.astro';
 import Task from '@components/Task.astro';
-import { Aside } from '@astrojs/starlight/components';
-import Link from '@components/Link.astro';
 import Term from '@components/Term.astro';
+import { Steps, Aside } from '@astrojs/starlight/components';
 
-This page explains how to change the words shoppers see on Commerce blocks (for example, "Add to Cart", price labels, or empty-cart messages) by editing a placeholders sheet in <Term>Document Authoring</Term>. The hardest part is not the edit itself; it is remembering to publish the sheet so the change actually reaches the page. The procedure below walks through the edit, the publish, and how to verify the result.
+This page explains how to change the words shoppers see on Commerce blocks (for example, "Add to Cart", price labels, or empty-cart messages) by editing a placeholders sheet in <Term>Document Authoring</Term>. The hardest part is not the edit itself. It's remembering to publish the sheet so the change reaches the page.
 
-## What a placeholder is
+Here's what you'll do:
 
-A placeholder is a label key that the storefront looks up at page load and renders as text. The default text for every Commerce block lives in a placeholders sheet stored in your content folder. Each <Term>drop-in</Term> has its own sheet — for example, `pdp` for the product detail page, `cart` for the shopping cart, and `checkout` for checkout.
+<Steps>
 
-Two columns matter: Key and Value. Keys use a dotted path such as `Cart.MiniCart.heading` that the drop-in knows how to look up. Values are the text shoppers see. Authors change values; developers (and the drop-ins themselves) own the keys.
+1. Find the placeholders sheet for your block.
 
-The Adobe Commerce boilerplate ships with placeholders sheets already wired up, so you do not add the sheet or change code to start using it.
+1. Edit the value of the label you want to change.
 
-## Find the right sheet for your block
+1. Preview the sheet to push your change to the preview site.
 
-Each Commerce block reads exactly one placeholders sheet — the sheet that belongs to the drop-in the block uses. Use the table below to pick the sheet:
+1. Publish the sheet to push your change to the live site.
 
-| Block (or area)                                                                  | Sheet to edit               |
-| -------------------------------------------------------------------------------- | --------------------------- |
-| `product-details`                                                                | `placeholders/pdp`          |
-| `commerce-cart`, `commerce-mini-cart`                                            | `placeholders/cart`         |
-| `commerce-checkout`, `commerce-checkout-success`                                 | `placeholders/checkout`     |
-| `commerce-login`, `commerce-create-account`, `commerce-create-password`, `commerce-forgot-password`, `commerce-confirm-account` | `placeholders/auth`         |
-| `commerce-account-*`, `commerce-customer-*`, `commerce-addresses`                | `placeholders/account`      |
-| `commerce-orders-list`, `commerce-order-*`, `commerce-create-return`, `commerce-return-*`, `commerce-returns-list` | `placeholders/order`        |
-| `commerce-wishlist`                                                              | `placeholders/wishlist`     |
-| `product-list-page`, `commerce-search-order`                                     | `placeholders/search`       |
-| Product recommendations                                                          | `placeholders/recommendations` |
-| Labels reused across blocks (header buttons, generic actions)                    | `placeholders/global`       |
+1. Hard-refresh the storefront page (press Cmd+Shift+R or Ctrl+Shift+R) to see the new label.
 
-To see every default key and value the boilerplate ships with, open the [Placeholder files reference](/resources/placeholders/). It links the live JSON for each sheet so you can search the keys before you open the editor.
+</Steps>
 
-## Edit and publish a placeholder value
+## How labels work in Commerce blocks
+
+A placeholder is a named text value that the storefront looks up at page load and displays on the page. The text for every button, heading, and message in a Commerce block comes from a placeholders sheet stored in your content folder. Each <Term>drop-in</Term> has its own sheet.
+
+Each sheet has two columns: Key and Value. The Key is a fixed label name such as `Cart.MiniCart.heading` that the drop-in uses to find the right text. The Value is the text shoppers see. You change the values, but the keys are defined by the drop-in code. Do not rename them.
+
+Most sheets are named after the block they serve, so `cart`, `checkout`, and `wishlist` hold the labels for their matching blocks. A few sheets group related blocks: `auth` covers login and account-creation blocks, `account` covers signed-in customer pages, `order` covers orders and returns, and `search` covers product listing and search. `pdp` is the one name that doesn't match its block (`product-details`). `global` holds labels reused across blocks, such as header buttons. If your storefront uses B2B drop-ins, you'll also see B2B-specific sheets such as `company`, `purchase-order`, and `quick-order`. For the full list and what each sheet controls, see [Placeholder sheets](/merchants/quick-start/placeholder-sheets/).
+
+The Adobe Commerce boilerplate ships with placeholders sheets already set up and connected, so you do not add the sheet or change any code to start using it.
+
+## Change a label step by step
 
 <Tasks>
 
 <Task>
 ### Open the right placeholders sheet
 
-In Document Authoring, navigate to the `placeholders` folder. Open the sheet whose drop-in owns the label you want to change (see the table above).
+In Document Authoring (da.live), navigate to the `placeholders` folder. Open the sheet for the drop-in that owns the label you want to change. If you're not sure which sheet to pick, [Placeholder sheets](/merchants/quick-start/placeholder-sheets/) lists every sheet and what it controls.
 
-The sheet opens in a spreadsheet view with two columns: Key and Value. If your site is multilingual and your project keeps locale-specific placeholders, edit the sheet under the locale folder that matches the storefront URL you preview (for example, `/fr/placeholders/cart`).
+The sheet opens in a spreadsheet view. If your site supports multiple languages, edit the sheet in the locale folder that matches the storefront URL you preview — for example, `/fr/placeholders/cart` for a French storefront.
 </Task>
 
 <Task>
@@ -57,67 +56,82 @@ The sheet opens in a spreadsheet view with two columns: Key and Value. If your s
 
 Find the row whose key matches the label you want to change. Edit only the Value cell. Keep the Key spelled exactly as it is, because the drop-in uses the key to look the value up. Renaming a key disconnects the value from the drop-in and the label disappears.
 
+{/* SCREENSHOT: A placeholders sheet open in Document Authoring, with the Key and Value columns clearly visible and one row about to be edited. Anchors steps 2 and 3 of the procedure. Ideally also shows the data and dnt tabs at the top so the next paragraph is actionable. */}
+
 If the sheet shows more than one tab at the top (for example, `data` and `dnt`), edit the `data` tab. The `dnt` tab is for do-not-translate values and does not control the shopper-visible label.
 </Task>
 
 <Task>
 ### Preview and publish the sheet
 
-Open the sidekick on the sheet itself, then choose Preview, then Publish.
+With the sheet open in Document Authoring, select **Preview** to save your changes and push them to the preview site. Confirm the new label looks right. When you're satisfied, select **Publish** to push the change to the live site.
 
-Until the sheet is published, the storefront page keeps serving the previous version of the JSON, and your change does not appear on the page. This is the most common reason a label change appears not to work: the storefront page got previewed, but the placeholders sheet did not.
+{/* SCREENSHOT: Close-up of the Preview and Publish buttons in the Document Authoring toolbar for a sheet. This is the most-skipped step, so a screenshot makes the buttons concrete. */}
+
+<Aside type="caution" title="Preview is not enough">
+Until you publish the sheet, the live storefront keeps serving the previous version of the labels, and your change does not appear for shoppers. This is the most common reason a label change looks like it did nothing: you previewed the storefront page but did not publish the placeholders sheet.
+</Aside>
 </Task>
 
 <Task>
-### Verify the JSON updated
-
-Open the published JSON in a new browser tab to confirm the new value is there. The URL pattern is:
-
-```
-https://<your-site>/placeholders/<sheet>.json
-```
-
-For example, `https://example.com/placeholders/cart.json`. Search the JSON for your key and confirm the value matches what you typed. If it still shows the old value, the sheet was not published — go back and Publish it.
-</Task>
-
-<Task>
-### Reload the storefront page without cache
+### See your change on the storefront
 
 Open the storefront page that uses the block (for example, your product detail page or cart page). Press Cmd+Shift+R on macOS, or Ctrl+Shift+R on Windows or Linux, to bypass the browser cache. The new label appears on the next load.
 
-The drop-in reads the placeholders sheet once when the page loads, so there is no live update. You must reload the page after publishing the sheet for the new value to take effect.
+The drop-in reads the placeholders sheet once when the page loads, so there is no live update when you edit the sheet. A regular reload may not clear the browser's cached copy of the sheet, so use a hard-refresh (Cmd+Shift+R on macOS, or Ctrl+Shift+R on Windows or Linux) to be sure.
 </Task>
 
 </Tasks>
 
-## Common failure modes
+## Troubleshooting
 
-### I changed it and nothing happened
+If your label change isn't showing up, start with the first item below. It covers most cases.
 
-This is almost always the publish step. Open `https://<your-site>/placeholders/<sheet>.json` and search for your key:
+### My change doesn't appear on the storefront
 
-- If you see the old value: the sheet was not published. Open the sidekick on the sheet and run Publish again.
+This is almost always a missing publish step on the sheet. To find out, [check what the sheet actually saved](#how-to-check-what-the-sheet-actually-saved) and look for your key:
+
+- If you see the old value: the sheet was not previewed or published. Return to the sheet in Document Authoring and select **Preview** or **Publish**.
 - If you see the new value but the storefront page still shows the old one: hard-refresh the page, and confirm the page URL is in the same locale folder as the sheet you edited.
 
-### The key isn't in the sheet yet
+### My change shows in preview but not on the live site
 
-Some keys fall back to a built-in default in the drop-in when the sheet does not override them. To customize one, add a new row with the exact key path and the value you want. Use the [Placeholder files reference](/resources/placeholders/) to find the full list of keys per drop-in.
+**Preview** and **Publish** are separate actions. **Preview** updates the preview site only. After you confirm the label looks right in preview, select **Publish** to push the change to the live site.
 
-### The label is partly translated, partly not
+### One language is right, another is wrong
 
 You may be editing one locale sheet while previewing a different locale page. Edit the sheet whose folder matches the URL you preview. For the multi-locale workflow, see [Commerce localization tasks](/merchants/quick-start/content-localization-commerce-tasks/).
 
-### My edit shows up in preview but not on the live site
+### The key I need isn't in the sheet
 
-Preview and Publish are separate actions in the sidekick. After Preview, run Publish too, then verify the published JSON URL above.
+If a key isn't in the sheet, the drop-in uses its built-in default text. To change that text, add a new row with the exact key (for example, `Cart.MiniCart.heading`) and the value you want. [Placeholder sheets](/merchants/quick-start/placeholder-sheets/) links to each sheet's live JSON so you can find the keys each drop-in supports.
 
-## Where this fits
+### How to check what the sheet actually saved
 
-Labels and placeholders live alongside two other authoring tools that change a block's behavior on a page:
+Each placeholders sheet is available as a JSON file (a text file your browser can open). Opening this file shows the saved value directly, without going through the storefront page. If the URL was already cached in your browser from an earlier check, hard-refresh the tab (Cmd+Shift+R or Ctrl+Shift+R) to fetch the latest version.
+
+{/* SCREENSHOT: A placeholders JSON file open in a browser tab, showing one key and value highlighted. Helps the reader recognize success when they see it. */}
+
+The URL pattern is:
+
+```text
+https://<branch>--<repo>--<org>.aem.page/placeholders/<sheet>.json
+https://<your-site>/placeholders/<sheet>.json
+```
+
+A real preview URL looks like `https://main--my-storefront--acme.aem.page/placeholders/cart.json`, where `main` is your branch, `my-storefront` is your repository, `acme` is your organization, and `cart` is the sheet name from the table above. The live URL replaces the `aem.page` host with your storefront's domain.
+
+Use the preview URL right after **Preview**, or the live URL after **Publish**. Search the JSON for your key and check that the value matches what you typed.
+
+If the URL returns nothing or a 404, the sheet has not been previewed or published yet. Go back to the sheet and run **Preview** or **Publish** first.
+
+## Related authoring tools
+
+Labels and placeholders work alongside two other authoring tools that control how a Commerce block appears on a page:
 
 - [Page metadata](/merchants/quick-start/page-metadata/) — page-level settings (title, description, caching, social sharing).
 - [Section metadata](/merchants/quick-start/section-metadata/) — visual styling for the section around a block.
 
-Page metadata and section metadata change how the page renders around a block. Labels and placeholders change the words inside the block. The three together cover the most common day-to-day authoring tasks for Commerce blocks.
+Page metadata and section metadata change how the page looks around a block. Labels and placeholders change the words inside the block. The three together cover the most common day-to-day authoring tasks for Commerce blocks.
 
-For multi-locale translation, see [Commerce localization tasks](/merchants/quick-start/content-localization-commerce-tasks/). For developer-side details on how drop-ins consume placeholders, see [Labeling and localizing drop-in components](/dropins/all/labeling/).
+For multi-locale translation, see [Commerce localization tasks](/merchants/quick-start/content-localization-commerce-tasks/). For developer-side details on how drop-ins use placeholders, see [Labeling and localizing drop-in components](/dropins/all/labeling/).

--- a/src/content/docs/merchants/quick-start/labels-and-placeholders.mdx
+++ b/src/content/docs/merchants/quick-start/labels-and-placeholders.mdx
@@ -1,0 +1,123 @@
+---
+title: Labels and Placeholders
+description: Change the words shoppers see in Commerce blocks (button text, headings, messages) by editing a placeholders sheet in Document Authoring, with the preview-and-publish step that often gets skipped.
+sidebar:
+  order: 5
+---
+
+import Tasks from '@components/Tasks.astro';
+import Task from '@components/Task.astro';
+import { Aside } from '@astrojs/starlight/components';
+import Link from '@components/Link.astro';
+import Term from '@components/Term.astro';
+
+This page explains how to change the words shoppers see on Commerce blocks (for example, "Add to Cart", price labels, or empty-cart messages) by editing a placeholders sheet in <Term>Document Authoring</Term>. The hardest part is not the edit itself; it is remembering to publish the sheet so the change actually reaches the page. The procedure below walks through the edit, the publish, and how to verify the result.
+
+## What a placeholder is
+
+A placeholder is a label key that the storefront looks up at page load and renders as text. The default text for every Commerce block lives in a placeholders sheet stored in your content folder. Each <Term>drop-in</Term> has its own sheet — for example, `pdp` for the product detail page, `cart` for the shopping cart, and `checkout` for checkout.
+
+Two columns matter: Key and Value. Keys use a dotted path such as `Cart.MiniCart.heading` that the drop-in knows how to look up. Values are the text shoppers see. Authors change values; developers (and the drop-ins themselves) own the keys.
+
+The Adobe Commerce boilerplate ships with placeholders sheets already wired up, so you do not add the sheet or change code to start using it.
+
+## Find the right sheet for your block
+
+Each Commerce block reads exactly one placeholders sheet — the sheet that belongs to the drop-in the block uses. Use the table below to pick the sheet:
+
+| Block (or area)                                                                  | Sheet to edit               |
+| -------------------------------------------------------------------------------- | --------------------------- |
+| `product-details`                                                                | `placeholders/pdp`          |
+| `commerce-cart`, `commerce-mini-cart`                                            | `placeholders/cart`         |
+| `commerce-checkout`, `commerce-checkout-success`                                 | `placeholders/checkout`     |
+| `commerce-login`, `commerce-create-account`, `commerce-create-password`, `commerce-forgot-password`, `commerce-confirm-account` | `placeholders/auth`         |
+| `commerce-account-*`, `commerce-customer-*`, `commerce-addresses`                | `placeholders/account`      |
+| `commerce-orders-list`, `commerce-order-*`, `commerce-create-return`, `commerce-return-*`, `commerce-returns-list` | `placeholders/order`        |
+| `commerce-wishlist`                                                              | `placeholders/wishlist`     |
+| `product-list-page`, `commerce-search-order`                                     | `placeholders/search`       |
+| Product recommendations                                                          | `placeholders/recommendations` |
+| Labels reused across blocks (header buttons, generic actions)                    | `placeholders/global`       |
+
+To see every default key and value the boilerplate ships with, open the [Placeholder files reference](/resources/placeholders/). It links the live JSON for each sheet so you can search the keys before you open the editor.
+
+## Edit and publish a placeholder value
+
+<Tasks>
+
+<Task>
+### Open the right placeholders sheet
+
+In Document Authoring, navigate to the `placeholders` folder. Open the sheet whose drop-in owns the label you want to change (see the table above).
+
+The sheet opens in a spreadsheet view with two columns: Key and Value. If your site is multilingual and your project keeps locale-specific placeholders, edit the sheet under the locale folder that matches the storefront URL you preview (for example, `/fr/placeholders/cart`).
+</Task>
+
+<Task>
+### Edit the value, not the key
+
+Find the row whose key matches the label you want to change. Edit only the Value cell. Keep the Key spelled exactly as it is, because the drop-in uses the key to look the value up. Renaming a key disconnects the value from the drop-in and the label disappears.
+
+If the sheet shows more than one tab at the top (for example, `data` and `dnt`), edit the `data` tab. The `dnt` tab is for do-not-translate values and does not control the shopper-visible label.
+</Task>
+
+<Task>
+### Preview and publish the sheet
+
+Open the sidekick on the sheet itself, then choose Preview, then Publish.
+
+Until the sheet is published, the storefront page keeps serving the previous version of the JSON, and your change does not appear on the page. This is the most common reason a label change appears not to work: the storefront page got previewed, but the placeholders sheet did not.
+</Task>
+
+<Task>
+### Verify the JSON updated
+
+Open the published JSON in a new browser tab to confirm the new value is there. The URL pattern is:
+
+```
+https://<your-site>/placeholders/<sheet>.json
+```
+
+For example, `https://example.com/placeholders/cart.json`. Search the JSON for your key and confirm the value matches what you typed. If it still shows the old value, the sheet was not published — go back and Publish it.
+</Task>
+
+<Task>
+### Reload the storefront page without cache
+
+Open the storefront page that uses the block (for example, your product detail page or cart page). Press Cmd+Shift+R on macOS, or Ctrl+Shift+R on Windows or Linux, to bypass the browser cache. The new label appears on the next load.
+
+The drop-in reads the placeholders sheet once when the page loads, so there is no live update. You must reload the page after publishing the sheet for the new value to take effect.
+</Task>
+
+</Tasks>
+
+## Common failure modes
+
+### I changed it and nothing happened
+
+This is almost always the publish step. Open `https://<your-site>/placeholders/<sheet>.json` and search for your key:
+
+- If you see the old value: the sheet was not published. Open the sidekick on the sheet and run Publish again.
+- If you see the new value but the storefront page still shows the old one: hard-refresh the page, and confirm the page URL is in the same locale folder as the sheet you edited.
+
+### The key isn't in the sheet yet
+
+Some keys fall back to a built-in default in the drop-in when the sheet does not override them. To customize one, add a new row with the exact key path and the value you want. Use the [Placeholder files reference](/resources/placeholders/) to find the full list of keys per drop-in.
+
+### The label is partly translated, partly not
+
+You may be editing one locale sheet while previewing a different locale page. Edit the sheet whose folder matches the URL you preview. For the multi-locale workflow, see [Commerce localization tasks](/merchants/quick-start/content-localization-commerce-tasks/).
+
+### My edit shows up in preview but not on the live site
+
+Preview and Publish are separate actions in the sidekick. After Preview, run Publish too, then verify the published JSON URL above.
+
+## Where this fits
+
+Labels and placeholders live alongside two other authoring tools that change a block's behavior on a page:
+
+- [Page metadata](/merchants/quick-start/page-metadata/) — page-level settings (title, description, caching, social sharing).
+- [Section metadata](/merchants/quick-start/section-metadata/) — visual styling for the section around a block.
+
+Page metadata and section metadata change how the page renders around a block. Labels and placeholders change the words inside the block. The three together cover the most common day-to-day authoring tasks for Commerce blocks.
+
+For multi-locale translation, see [Commerce localization tasks](/merchants/quick-start/content-localization-commerce-tasks/). For developer-side details on how drop-ins consume placeholders, see [Labeling and localizing drop-in components](/dropins/all/labeling/).

--- a/src/content/docs/merchants/quick-start/placeholder-sheets.mdx
+++ b/src/content/docs/merchants/quick-start/placeholder-sheets.mdx
@@ -1,0 +1,49 @@
+---
+title: Placeholder sheets
+description: Find which placeholders sheet controls each Commerce block and see what labels each sheet contains.
+sidebar:
+  label: Placeholder sheets
+tableOfContents: false
+---
+import Link from '@components/Link.astro';
+import TableWrapper from '@components/TableWrapper.astro';
+
+Each Commerce block reads the words shoppers see — button text, headings, and messages — from a placeholders sheet stored in Document Authoring. Each sheet has two columns: Key (the fixed identifier the drop-in looks up) and Value (the text shoppers see). This page lists every sheet and what part of the storefront it controls so you can find the right one quickly. To change a value, see [Labels and placeholders](/merchants/quick-start/labels-and-placeholders/).
+
+## Standard storefront sheets
+
+The following placeholder sheets ship with the Adobe Commerce boilerplate and are present on every storefront. Each name links to the live JSON on the boilerplate so you can see the current keys and values.
+
+<TableWrapper nowrap={[0]}>
+
+| Sheet | What it controls |
+| --- | --- |
+| <Link href="https://main--boilerplate--adobe-commerce.aem.page/placeholders/global.json" text="global" /> | Labels reused across the storefront, such as the quantity selector, the shared "Add to Cart" text, and back-navigation links used by multiple drop-ins. |
+| <Link href="https://main--boilerplate--adobe-commerce.aem.page/placeholders/pdp.json" text="pdp" /> | Product detail page — price labels, add-to-cart button, quantity controls, and the out-of-stock message. |
+| <Link href="https://main--boilerplate--adobe-commerce.aem.page/placeholders/cart.json" text="cart" /> | Mini cart and full cart page — headings, line items, edit and view actions, and totals. |
+| <Link href="https://main--boilerplate--adobe-commerce.aem.page/placeholders/checkout.json" text="checkout" /> | Checkout flow — shipping and billing addresses, address validation, payment, and order placement. |
+| <Link href="https://main--boilerplate--adobe-commerce.aem.page/placeholders/payment-services.json" text="payment-services" /> | Payment Services credit card form — field labels, placeholders, and validation messages. |
+| <Link href="https://main--boilerplate--adobe-commerce.aem.page/placeholders/order.json" text="order" /> | Order list, order detail, and the create-return and returns flows. |
+| <Link href="https://main--boilerplate--adobe-commerce.aem.page/placeholders/auth.json" text="auth" /> | Sign-in, account creation, password reset, and account-confirmation labels and validation messages. |
+| <Link href="https://main--boilerplate--adobe-commerce.aem.page/placeholders/account.json" text="account" /> | Signed-in customer pages — profile, addresses, change-password, and notification preferences. |
+| <Link href="https://main--boilerplate--adobe-commerce.aem.page/placeholders/search.json" text="search" /> | Product listing and search results — empty-results message, sort options, and search errors. |
+| <Link href="https://main--boilerplate--adobe-commerce.aem.page/placeholders/wishlist.json" text="wishlist" /> | Wishlist actions — empty state, add and move alerts, and the sign-in prompt. |
+| <Link href="https://main--boilerplate--adobe-commerce.aem.page/placeholders/recommendations.json" text="recommendations" /> | Product recommendation cards — add-to-cart, select-options, and view-product labels. |
+
+</TableWrapper>
+
+## B2B drop-in sheets
+
+The sheets below ship with the matching B2B drop-ins and appear in your `placeholders/` folder only when those drop-ins are installed on your storefront. Each name links to the live JSON on the B2B boilerplate so you can see the default keys and values.
+
+<TableWrapper nowrap={[0]}>
+
+| Sheet | What it controls |
+| --- | --- |
+| <Link href="https://main--boilerplate-b2b--adobe-commerce.aem.page/placeholders/company.json" text="company" /> | Company Management drop-in — company structure, roles, users, and team-administration labels. |
+| <Link href="https://main--boilerplate-b2b--adobe-commerce.aem.page/placeholders/purchase-order.json" text="purchase-order" /> | Purchase Order drop-in — creating a purchase order, the approval flow, and confirmation. |
+| <Link href="https://main--boilerplate-b2b--adobe-commerce.aem.page/placeholders/quote-management.json" text="quote-management" /> | Quote Management drop-in — the request-a-quote button and negotiable-quote messages. |
+| <Link href="https://main--boilerplate-b2b--adobe-commerce.aem.page/placeholders/quick-order.json" text="quick-order" /> | Quick Order drop-in — bulk add by SKU, CSV upload, and variant search. |
+| <Link href="https://main--boilerplate-b2b--adobe-commerce.aem.page/placeholders/requisition-list.json" text="requisition-list" /> | Requisition List drop-in — saved item lists for fast reordering. |
+
+</TableWrapper>

--- a/src/content/docs/resources/index.mdx
+++ b/src/content/docs/resources/index.mdx
@@ -3,21 +3,15 @@ title: Overview
 description: Reference the files that power the Adobe Commerce Storefront.
 ---
 
-import PlaceholdersTable from './placeholders.mdx';
 import CardGrid from '@components/CardGrid.astro';
-import Card from '@components/Card.astro';
 import LinkCard from '@components/LinkCard.astro';
 
 <CardGrid>
 <LinkCard
   noborder
   icon="commerce"
-  title="Placeholder files"
-  description="View the latest placeholder JSON files."
-  link="/resources/placeholders/"
-  rightIcon="external"
-  target="_blank"
-  rel="noopener noreferrer"
-  aria-label="Link (opens in a new tab)"
+  title="Placeholder sheets"
+  description="Find which placeholders sheet controls each Commerce block and view its live JSON."
+  link="/merchants/quick-start/placeholder-sheets/"
 />
 </CardGrid>

--- a/src/content/docs/resources/placeholders.mdx
+++ b/src/content/docs/resources/placeholders.mdx
@@ -1,28 +1,7 @@
 ---
 title: Placeholder files
-description: How placeholder JSON files supply storefront labels for drop-in components.
+description: This reference has moved. See Placeholder sheets in the Merchants section.
 tableOfContents: false
 ---
-import Link from '@components/Link.astro';
 
-
-Placeholder files are the source for storefront labels across drop-in components. Each file has two columns: **Key** and **Value**. The Key column contains the text variables that are replaced at runtime. The Value column contains the text values that replace the variables. These files give content creators and merchants a quick way to change the site's labels without developer involvement.
-
-## Placeholder default values
-
-The initial values in the placeholder files in the boilerplate starter content provide the default out-of-the-box labels for the drop-in components.
-
-You can view the current placeholder values for each drop-in component in the following JSON files:
-
-- <Link href={"https://main--boilerplate--adobe-commerce.aem.page/placeholders/global.json"} text={"Global placeholders"} />
-- <Link href={"https://main--boilerplate--adobe-commerce.aem.page/placeholders/account.json"} text={"Account placeholders"} />
-- <Link href={"https://main--boilerplate--adobe-commerce.aem.page/placeholders/auth.json"} text={"Auth placeholders"} />
-- <Link href={"https://main--boilerplate--adobe-commerce.aem.page/placeholders/cart.json"} text={"Cart placeholders"} />
-- <Link href={"https://main--boilerplate--adobe-commerce.aem.page/placeholders/checkout.json"} text={"Checkout placeholders"} />
-- <Link href={"https://main--boilerplate--adobe-commerce.aem.page/placeholders/order.json"} text={"Order placeholders"} />
-- <Link href={"https://main--boilerplate--adobe-commerce.aem.page/placeholders/pdp.json"} text={"Product Details Page placeholders"} />
-- <Link href={"https://main--boilerplate--adobe-commerce.aem.page/placeholders/search.json"} text={"Search placeholders"} />
-- <Link href={"https://main--boilerplate--adobe-commerce.aem.page/placeholders/wishlist.json"} text={"Wishlist placeholders"} />
-- <Link href={"https://main--boilerplate--adobe-commerce.aem.page/placeholders/recommendations.json"} text={"Recommendations placeholders"} />
-
-These JSON files contain all the current placeholder keys and their corresponding values. The `global.json` file contains placeholders that apply to the entire storefront, while the other JSON files contain placeholders specific to their respective drop-in components. You can reference these files to see the exact structure and values used in the boilerplate.
+This reference has moved to [Placeholder sheets](/merchants/quick-start/placeholder-sheets/) in the Merchants section. The new page lists every placeholders sheet, what part of the storefront it controls, and where to inspect its current JSON.


### PR DESCRIPTION
## Summary

Adds a new author-facing orientation page that closes two gaps in the merchant docs raised by COMDOX-1681: there is no shared page that connects drop-ins, blocks, and pages as one mental model, and there is no narrative that names the author, integrator, and developer roles so a request that does not fit the author tools has a clear handoff. This PR addresses both with one page placed in the Quick Start group of the merchants sidebar.

## Changes

- New page: `src/content/docs/merchants/quick-start/authoring-commerce-blocks.mdx`. Sections:
  - Three things you'll work with (drop-in, block, page — defined and related).
  - What you can change without code (table of author tasks with links to each authoring page).
  - What needs a developer (table of changes that require code or configuration outside the author tools).
  - Roles at a glance (author / integrator / developer responsibilities, with a ticket-writing tip).
  - How a typical task flows (decision flow from a request to a publish).
  - Where to go next (links into the block reference, labels-and-placeholders, page and section metadata).
- Sidebar: add the new page under Merchants > Quick Start between "Using Content and Commerce Blocks" and "How block tables work".
- `src/content/docs/merchants/blocks/index.mdx`: add a one-line lead pointing first-time authors at the new orientation page.
- `src/content/docs/merchants/quick-start/index.mdx`: add a row to the Get oriented section.

## Testing

- `npx astro sync` succeeds with only pre-existing route-collision warnings (none of which involve the new page).
- Internal links resolve to existing pages: `/merchants/quick-start/block-tables/`, `/merchants/quick-start/labels-and-placeholders/` (added in PR #903), `/merchants/quick-start/page-metadata/`, `/merchants/quick-start/section-metadata/`, `/merchants/quick-start/content-localization-commerce-tasks/`, `/merchants/blocks/b2c/`, `/merchants/blocks/b2b/`, `/merchants/edge-delivery-services/scheduling/`, `/dropins/all/introduction/`.

## Relationship to PR #903

This PR is independent of [#903](https://github.com/commerce-docs/microsite-commerce-storefront/pull/903) (the `product-details` rewrite and the new `labels-and-placeholders` shared page). They share the same JIRA ticket. Both touch `astro.sidebar.mjs` near the Merchants > Quick Start group, so a small merge may be needed depending on which PR lands first.

## JIRA

[COMDOX-1681](https://jira.corp.adobe.com/browse/COMDOX-1681)

Made with [Cursor](https://cursor.com)