### PR TITLE
Remove redundant 'Improvements and fixes' subheading in release notes

### DIFF
--- a/src/content/docs/releases/index.mdx
+++ b/src/content/docs/releases/index.mdx
@@ -94,9 +94,7 @@ The Drop-in SDK (`@dropins/tools`) was upgraded to 1.9.0 in this release. The fo
 | `@adobe-commerce/recaptcha` | 1.2.0 |
 | `@adobe-commerce/storefront-design` | 1.1.0 |
 
-#### Improvements and fixes
-
-- **Bundle optimizations**: HTTP requests cut 29–85% per drop-in (tools: 34→24, Auth: 24→6, Cart: 13→2). TTI improved 22%; TBT halved. **Rebuild your drop-ins against this SDK release to get these gains** ([#200](https://github.com/adobe-commerce/StorefrontSDK/pull/200)).
+- **Bundle optimizations**: HTTP requests cut 29-85% per drop-in (tools: 34→24, Auth: 24→6, Cart: 13→2). TTI improved 22%; TBT halved. **Rebuild your drop-ins against this SDK release to get these gains** ([#200](https://github.com/adobe-commerce/StorefrontSDK/pull/200)).
 - **Node.js 22 LTS**: All drop-ins updated to the Node.js 22 LTS minimum runtime ([#201](https://github.com/adobe-commerce/StorefrontSDK/pull/201)).
 - **GraphQL fragment bundling fix**: GraphQL fragment files are no longer bundled into `chunks/api.js`, so you can override individual GraphQL fragments using the standalone `fragments.js` output again ([#210](https://github.com/adobe-commerce/StorefrontSDK/pull/210)).
 


### PR DESCRIPTION
## Purpose of this pull request

This pull request removes a redundant "Improvements and fixes" H4 subheading from the Drop-in SDK section of the release notes. The bullet list stands on its own without the extra heading level.
