### PR TITLE
USF-4121 Document ACCS-compatible token validation and ACO configuration

### DIFF
--- a/src/content/docs/dropins/user-auth/functions.mdx
+++ b/src/content/docs/dropins/user-auth/functions.mdx
@@ -368,31 +368,37 @@ Returns [`RevokeCustomerTokenModel`](#revokecustomertokenmodel).
 
 ## verifyToken
 
-The `verifyToken` function checks the validity of the provided authentication token. It verifies the token by making a `GraphQL` request to validate the customer. If valid, it emits an `authenticated` event with `true` and the customer's group ID. If invalid or missing, it emits an `authenticated` event with `false`, removes the token cookie, and clears the authentication header.
+The `verifyToken` function checks the validity of the stored customer token. It makes a GraphQL request to validate the token and, if valid, sets the authentication header and emits the `authenticated` event with `true`. If the token is invalid or missing, it removes the token cookie, clears the authentication header, and emits the `authenticated` event with `false`.
+
+By default, the validation query is compatible with all backends. When `adobeCommerceOptimizer` is set to `true`, the query additionally fetches `customer.group.uid` to emit the `auth/group-uid` event required for ACO price book resolution.
 
 ```ts
 const verifyToken = async (
   authType = 'Authorization',
-  type = 'Bearer'
-): Promise<any>
+  type = 'Bearer',
+  adobeCommerceOptimizer = false
+): Promise<boolean>
 ```
 
 <TableWrapper nowrap={[0,1]}>
 
 | Parameter | Type | Req? | Description |
 |---|---|---|---|
-| `authType` | `string` | No | The HTTP header name to use for authentication. Defaults to \`Authorization\`. This allows customization of the authentication header if your backend uses a different header name. |
-| `type` | `string` | No | The authentication scheme type to use. Defaults to \`Bearer\`. This is prepended to the token value in the authentication header (e.g., \`Bearer &lt;token&gt;\`). |
+| `authType` | `string` | No | The HTTP header name to use for authentication. Defaults to `Authorization`. |
+| `type` | `string` | No | The authentication scheme prefix prepended to the token value in the header (e.g., `Bearer <token>`). Defaults to `Bearer`. |
+| `adobeCommerceOptimizer` | `boolean` | No | When `true`, the validation query also fetches `customer.group.uid` and emits the `auth/group-uid` event for ACO price book resolution. Only enable this when using Adobe Commerce Optimizer. Defaults to `false`. |
 
 </TableWrapper>
 
 ### Events
 
-Does not emit any drop-in events.
+Emits the [`authenticated`](/dropins/user-auth/events/#authenticated-emits) event.
+
+When `adobeCommerceOptimizer` is `true`, also emits the [`auth/group-uid`](/dropins/user-auth/events/#authgroup-uid-emits) event.
 
 ### Returns
 
-Returns `void`.
+Returns `Promise<boolean>`. Returns `true` if the token is valid, `false` otherwise.
 
 ## Data Models
 

--- a/src/content/docs/dropins/user-auth/functions.mdx
+++ b/src/content/docs/dropins/user-auth/functions.mdx
@@ -26,7 +26,7 @@ The User Auth drop-in provides API functions that enable you to programmatically
 | [`confirmEmail`](#confirmemail) | Completes the customer activation process using the supplied `customerEmail` and `customerConfirmationKey` parameters. |
 | [`createCustomer`](#createcustomer) | Creates a customer account based on the data supplied in the forms parameter. |
 | [`createCustomerAddress`](#createcustomeraddress) | Defines a new customer address. |
-| [`getAdobeCommerceOptimizerData`](#getadobecommerceoptimizerdata) | This function fetches Adobe Commerce Optimizer data. |
+| [`getAdobeCommerceOptimizerData`](#getadobecommerceoptimizerdata) | Fetches Adobe Commerce Optimizer data. |
 | [`getAttributesForm`](#getattributesform) | Retrieves EAV attributes associated with customer and customer address frontend forms. |
 | [`getCustomerData`](#getcustomerdata) | Retrieves data about the customer represented by the `auth_dropin_user_token` cookie value. |
 | [`getCustomerRolePermissions`](#getcustomerrolepermissions) | Retrieves customer role permissions. |
@@ -139,7 +139,7 @@ Returns [`AdobeCommerceOptimizerModel`](#adobecommerceoptimizermodel).
 
 ## getAttributesForm
 
-The `getAttributesForm` function retrieves EAV attributes associated with customer and customer address frontend forms. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/attributes/queries/attributes-form/" text="attributesForm query" />.
+The `getAttributesForm` function retrieves entity-attribute-value (EAV) attributes associated with customer and customer address frontend forms. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/attributes/queries/attributes-form/" text="attributesForm query" />.
 
 ```ts
 const getAttributesForm = async (
@@ -165,7 +165,7 @@ Returns `AttributesFormModel[]`.
 
 ## getCustomerData
 
-The `getCustomerData` function retrieves data about the customer represented by the value of the `auth_dropin_user_token` parameter. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/queries/customer/" text="customer query" />.
+The `getCustomerData` function retrieves data about the customer represented by the value of the `auth_dropin_user_token` cookie. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/queries/customer/" text="customer query" />.
 
 ```ts
 const getCustomerData = async (
@@ -191,7 +191,7 @@ Returns [`CustomerModel`](#customermodel).
 
 ## getCustomerRolePermissions
 
-The `getCustomerRolePermissions` function retrieves customer role permissions. It uses efficient caching to minimize API calls and returns either cached data immediately or a promise for fresh data.
+The `getCustomerRolePermissions` function retrieves customer role permissions. It caches results to minimize API calls, returning cached data immediately when available or fetching fresh data when the cache is empty.
 
 ```ts
 const getCustomerRolePermissions = async (): Promise<PermissionsModel>
@@ -207,7 +207,7 @@ Returns [`PermissionsModel`](#permissionsmodel).
 
 ## getCustomerToken
 
-The `getCustomerToken` function handles the sign-in operation. It requires `email` and `password` (and accepts additional optional properties on the parameter object) and performs the following actions under the hood:
+The `getCustomerToken` function handles the sign-in operation. It requires `email` and `password` (and accepts additional optional properties on the parameter object) and performs these actions:
 
 1. Retrieves the customer token.
 2. Fetches customer data using the token.
@@ -352,7 +352,7 @@ Returns [`ResetPasswordModel`](#resetpasswordmodel).
 
 ## revokeCustomerToken
 
-The `revokeCustomerToken` function revokes the customer's token and clears the authentication cookie. It then publishes an ACDL event and emits an "authenticated" event. This API can also be used to build a custom sign-out flow that stays fully integrated with other drop-in components. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/revoke-token/" text="revokeCustomerToken mutation" />.
+The `revokeCustomerToken` function revokes the customer's token and clears the authentication cookie. It then publishes an ACDL event and emits an "authenticated" event. Use this function to build a custom sign-out flow that stays fully integrated with other drop-in components. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/customer/mutations/revoke-token/" text="revokeCustomerToken mutation" />.
 
 ```ts
 const revokeCustomerToken = async (): Promise<RevokeCustomerTokenModel>
@@ -368,9 +368,9 @@ Returns [`RevokeCustomerTokenModel`](#revokecustomertokenmodel).
 
 ## verifyToken
 
-The `verifyToken` function checks the validity of the stored customer token. It makes a GraphQL request to validate the token and, if valid, sets the authentication header and emits the `authenticated` event with `true`. If the token is invalid or missing, it removes the token cookie, clears the authentication header, and emits the `authenticated` event with `false`.
+The `verifyToken` function checks the validity of the stored customer token. If valid, it emits the `authenticated` event with `true`. If the token is invalid or missing, it clears the authentication cookies and header, and emits `authenticated` with `false`.
 
-By default, the validation query is compatible with all backends. When `adobeCommerceOptimizer` is set to `true`, the query additionally fetches `customer.group.uid` to emit the `auth/group-uid` event required for ACO price book resolution.
+By default, the validation query is compatible with all backends. When `adobeCommerceOptimizer` is set to `true`, the function also emits the `auth/group-uid` event required for Adobe Commerce Optimizer price book resolution.
 
 ```ts
 const verifyToken = async (
@@ -384,9 +384,9 @@ const verifyToken = async (
 
 | Parameter | Type | Req? | Description |
 |---|---|---|---|
-| `authType` | `string` | No | The HTTP header name to use for authentication. Defaults to `Authorization`. |
-| `type` | `string` | No | The authentication scheme prefix prepended to the token value in the header (e.g., `Bearer <token>`). Defaults to `Bearer`. |
-| `adobeCommerceOptimizer` | `boolean` | No | When `true`, the validation query also fetches `customer.group.uid` and emits the `auth/group-uid` event for ACO price book resolution. Only enable this when using Adobe Commerce Optimizer. Defaults to `false`. |
+| `authType` | `string` | No | The name of the HTTP authorization header. Defaults to `Authorization`. |
+| `type` | `string` | No | The credential type prefixed to the token in the authorization header (for example, `Bearer <token>`). Defaults to `Bearer`. |
+| `adobeCommerceOptimizer` | `boolean` | No | When `true`, emits the `auth/group-uid` event for Adobe Commerce Optimizer price book resolution. Defaults to `false`. |
 
 </TableWrapper>
 
@@ -402,7 +402,7 @@ Returns `Promise<boolean>`. Returns `true` if the token is valid, `false` otherw
 
 ## Data Models
 
-The following data models are used by functions in this drop-in.
+Functions in this drop-in use the following data models.
 
 ### AdobeCommerceOptimizerModel
 

--- a/src/content/docs/dropins/user-auth/initialization.mdx
+++ b/src/content/docs/dropins/user-auth/initialization.mdx
@@ -19,17 +19,15 @@ The **User Auth initializer** configures authentication and authorization featur
 
 ## Configuration options
 
-The following table describes the configuration options available for the **User Auth** initializer:
-
 <TableWrapper nowrap={[0,1]}>
 
 | Parameter | Type | Req? | Description |
 |---|---|---|---|
-| `langDefinitions` | [`LangDefinitions`](#langdefinitions) | No | Language definitions for internationalization (i18n). Override dictionary keys for localization or branding. |
-| `models` | [`Record<string, any>`](#models) | No | Custom data models for type transformations. Extend or modify default models with custom fields and transformers. |
-| `authHeaderConfig` | [`authHeaderConfig`](#authheaderconfig) | No | Configures authentication header format for API requests including custom header names and token prefix format (e.g., 'Bearer', 'Token'). |
-| `customerPermissionRoles` | `boolean` | No | When `true`, fetches and emits customer B2B role permissions via the `auth/permissions` event after authentication. |
-| `adobeCommerceOptimizer` | `boolean` | No | When `true`, enables Adobe Commerce Optimizer support. The token validation query will also fetch `customer.group.uid` to emit the `auth/group-uid` event for ACO price book resolution, and `getAdobeCommerceOptimizerData` will be called after authentication. |
+| `langDefinitions` | [`LangDefinitions`](#langdefinitions) | No | Overrides built-in text strings for localization or custom branding. Maps locale keys to replacement dictionary values. |
+| `models` | [`Record<string, any>`](#models) | No | Extends or replaces default data models. Provide custom fields and transformer functions to modify data returned from the backend. |
+| `authHeaderConfig` | [`authHeaderConfig`](#authheaderconfig) | No | Sets the HTTP header name and token prefix (for example, `Bearer` or `Token`) used in authentication requests. |
+| `customerPermissionRoles` | `boolean` | No | When `true`, fetches customer B2B role permissions after sign-in and emits them via the `auth/permissions` event. |
+| `adobeCommerceOptimizer` | `boolean` | No | When `true`, enables Adobe Commerce Optimizer support. Token validation also fetches `customer.group.uid` and emits it via the `auth/group-uid` event for price book resolution. Calls `getAdobeCommerceOptimizerData` after sign-in. |
 
 </TableWrapper>
 
@@ -83,8 +81,6 @@ Extend or transform data models by providing custom transformer functions. Use t
 
 ### Available models
 
-The following models can be customized through the `models` configuration option:
-
 <TableWrapper nowrap={[0]}>
 
 | Model | Description |
@@ -93,7 +89,7 @@ The following models can be customized through the `models` configuration option
 
 </TableWrapper>
 
-The following example shows how to customize the `CustomerModel` model for the **User Auth** drop-in:
+To customize `CustomerModel`, provide a transformer function that receives the raw GraphQL response and returns the shape your storefront needs:
 
 ```javascript title="scripts/initializers/user-auth.js"
 import { initializers } from '@dropins/tools/initializer.js';
@@ -116,7 +112,7 @@ await initializers.mountImmediately(initialize, { models });
 
 ## Drop-in configuration
 
-The **User Auth initializer** configures authentication and authorization features including login, registration, password management, and session handling. Use initialization to customize authentication flows and user data models.
+The following example shows all drop-in-specific options enabled together. Use it as a starting point when you need B2B role permissions and Adobe Commerce Optimizer support in the same storefront.
 
 ```javascript title="scripts/initializers/user-auth.js"
 import { initializers } from '@dropins/tools/initializer.js';
@@ -139,11 +135,9 @@ Refer to the [Configuration options](#configuration-options) table for detailed 
 
 ## Configuration types
 
-The following TypeScript definitions show the structure of each configuration object:
-
 ### authHeaderConfig
 
-Configures authentication header format for API requests including custom header names and token prefix format (e.g., 'Bearer', 'Token').
+Configures the authentication header format for API requests, including custom header names and token prefix format (for example, `Bearer` or `Token`).
 
 ```typescript
 authHeaderConfig?: {
@@ -176,8 +170,6 @@ models?: {
 
 
 ## Model definitions
-
-The following TypeScript definitions show the structure of each customizable model:
 
 ### CustomerModel
 

--- a/src/content/docs/dropins/user-auth/initialization.mdx
+++ b/src/content/docs/dropins/user-auth/initialization.mdx
@@ -28,8 +28,8 @@ The following table describes the configuration options available for the **User
 | `langDefinitions` | [`LangDefinitions`](#langdefinitions) | No | Language definitions for internationalization (i18n). Override dictionary keys for localization or branding. |
 | `models` | [`Record<string, any>`](#models) | No | Custom data models for type transformations. Extend or modify default models with custom fields and transformers. |
 | `authHeaderConfig` | [`authHeaderConfig`](#authheaderconfig) | No | Configures authentication header format for API requests including custom header names and token prefix format (e.g., 'Bearer', 'Token'). |
-| `customerPermissionRoles` | `boolean` | No |  |
-| `adobeCommerceOptimizer` | `boolean` | No |  |
+| `customerPermissionRoles` | `boolean` | No | When `true`, fetches and emits customer B2B role permissions via the `auth/permissions` event after authentication. |
+| `adobeCommerceOptimizer` | `boolean` | No | When `true`, enables Adobe Commerce Optimizer support. The token validation query will also fetch `customer.group.uid` to emit the `auth/group-uid` event for ACO price book resolution, and `getAdobeCommerceOptimizerData` will be called after authentication. |
 
 </TableWrapper>
 


### PR DESCRIPTION
## Purpose of this pull request

Document the ACCS token validation compatibility fix in the User Auth drop-in microsite.

This PR completes the documentation for the code changes that made `verifyToken` compatible with ACCS backends by conditionalizing the `group.uid query`. Specifically:
- `verifyToken` function: added documentation for the new `adobeCommerceOptimizer` parameter and clarified that token validation now works on all backends by default, with optional ACO support
- Init config options: Filled in missing descriptions for `customerPermissionRoles` and `adobeCommerceOptimizer` to explain their impact on the drop-in behavior

Related to: storefront-auth PR #102 (USF-4121 fix for ACCS compatibility)

### Associated JIRA ticket

[USF-4121](https://jira.corp.adobe.com/browse/USF-4121)

### Staging preview

<!--OPTIONAL Link to staging preview if available-->


## Affected pages

<!-- REQUIRED List the affected pages on experienceleague.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to source code

<!--OPTIONAL Link to any associated source code PRs related to update-->

### What's New highlights

<!--  _OPTIONAL - REMOVE THIS SECTION IF NOT USED._

If this pull request introduces changes that should be highlighted in What's New documentation reports.
-->

