### PR TITLE
feat(audit-docs): validate drop-in version badges against registry

### DIFF
--- a/scripts/audit-docs.ts
+++ b/scripts/audit-docs.ts
@@ -104,12 +104,14 @@ function main(): void {
   let totalDropinsAudited = 0;
 
   for (const [dropinKey] of Object.entries(DROPIN_PATH_MAP)) {
-    const containers = containersRegistry.dropins[dropinKey]?.containers ?? [];
+    const dropinContainers = containersRegistry.dropins[dropinKey];
+    const containers = dropinContainers?.containers ?? [];
+    const registryVersion = dropinContainers?.version;
     const functions = apiFunctionsRegistry.dropins[dropinKey]?.functions ?? [];
     const i18nKeys = i18nRegistry.dropins[dropinKey]?.keys ?? {};
 
     log(
-      `Auditing ${dropinKey} (${containers.length} containers, ${functions.length} functions, ${Object.keys(i18nKeys).length} i18n keys)`
+      `Auditing ${dropinKey} (${containers.length} containers, ${functions.length} functions, ${Object.keys(i18nKeys).length} i18n keys, registry v${registryVersion ?? 'unknown'})`
     );
 
     allGaps[dropinKey] = auditDropin(
@@ -119,7 +121,8 @@ function main(): void {
       functions,
       allEvents,
       sdkEvents,
-      i18nKeys
+      i18nKeys,
+      registryVersion
     );
     totalDropinsAudited++;
   }

--- a/scripts/audit-docs/audit.ts
+++ b/scripts/audit-docs/audit.ts
@@ -6,6 +6,7 @@ import type {
   EventEntry,
   FunctionEntry,
   SdkEventGaps,
+  VersionGap,
 } from './types.js';
 import {
   isSdkEvent,
@@ -16,6 +17,7 @@ import {
   parseMdxDictionaryKeys,
   parseMdxSlots,
   parseSdkEventNames,
+  parseMdxVersion,
 } from './mdx-parsers.js';
 import {
   KNOWN_PROP_OMISSIONS,
@@ -72,7 +74,8 @@ export function auditDropin(
   functions: FunctionEntry[],
   events: EventEntry[],
   sdkEvents: Set<string>,
-  i18nKeys: Record<string, string>
+  i18nKeys: Record<string, string>,
+  registryVersion?: string
 ): DropinGaps {
   const gaps: DropinGaps = {
     missingContainerPages: [],
@@ -86,6 +89,7 @@ export function auditDropin(
     phantomI18nKeys: [],
     missingSlots: [],
     phantomSlots: [],
+    versionMismatch: null,
   };
 
   const FRAMEWORK_PROPS = new Set(['initialData', 'children', 'scope', 'className']);
@@ -238,6 +242,23 @@ export function auditDropin(
     for (const container of containersWithSlots) {
       for (const slot of container.slotNames) {
         gaps.missingSlots.push({ container: container.name, slot, reason: 'missing' });
+      }
+    }
+  }
+
+  // --- Version check ---
+  if (registryVersion) {
+    const initFile = micrositeDocPath(micrositePath, dropinKey, 'initialization.mdx');
+    if (existsSync(initFile)) {
+      const initContent = readFileSync(initFile, 'utf8');
+      const docVersion = parseMdxVersion(initContent);
+      if (docVersion !== registryVersion) {
+        const versionGap: VersionGap = {
+          registryVersion,
+          docVersion,
+          reason: docVersion === null ? 'missing' : 'mismatch',
+        };
+        gaps.versionMismatch = versionGap;
       }
     }
   }

--- a/scripts/audit-docs/mdx-parsers.ts
+++ b/scripts/audit-docs/mdx-parsers.ts
@@ -209,6 +209,19 @@ export function parseMdxSlots(content: string): Map<string, Set<string>> {
 }
 
 /**
+ * Parse the documented drop-in version from an initialization MDX file.
+ *
+ * Matches the styled version badge used across all drop-in init pages:
+ *   <strong>Version: X.Y.Z</strong>
+ *
+ * Returns the semver string (e.g. "3.2.0") or null when no badge is found.
+ */
+export function parseMdxVersion(content: string): string | null {
+  const match = /<strong>Version:\s*(\d+\.\d+\.\d+)<\/strong>/i.exec(content);
+  return match ? match[1] : null;
+}
+
+/**
  * Extract event names from the shared common-events.mdx page.
  * Each event has a dedicated `## eventName` section heading.
  */

--- a/scripts/audit-docs/report.ts
+++ b/scripts/audit-docs/report.ts
@@ -12,7 +12,8 @@ export function hasGaps(gaps: DropinGaps): boolean {
     gaps.missingI18nKeys.length > 0 ||
     gaps.phantomI18nKeys.length > 0 ||
     gaps.missingSlots.length > 0 ||
-    gaps.phantomSlots.length > 0
+    gaps.phantomSlots.length > 0 ||
+    gaps.versionMismatch !== null
   );
 }
 
@@ -62,6 +63,7 @@ export function renderGapsReport(
     if (!hasGaps(gaps)) continue;
 
     const dropinTotal =
+      (gaps.versionMismatch !== null ? 1 : 0) +
       gaps.missingContainerPages.length +
       gaps.missingProps.length +
       gaps.phantomProps.length +
@@ -77,6 +79,25 @@ export function renderGapsReport(
     totalGaps += dropinTotal;
     lines.push(`## ${dropin} (${dropinTotal} gaps)`);
     lines.push('');
+
+    if (gaps.versionMismatch !== null) {
+      const { registryVersion, docVersion, reason } = gaps.versionMismatch;
+      lines.push('### Version Mismatch');
+      if (reason === 'missing') {
+        lines.push(
+          `The \`initialization.mdx\` file does not contain a version badge. Expected \`${registryVersion}\`.`
+        );
+      } else {
+        lines.push(
+          `The documented version does not match the registry version. Update \`initialization.mdx\` to \`${registryVersion}\`.`
+        );
+        lines.push('');
+        lines.push('| Documented | Registry |');
+        lines.push('|---|---|');
+        lines.push(`| \`${docVersion}\` | \`${registryVersion}\` |`);
+      }
+      lines.push('');
+    }
 
     if (gaps.missingContainerPages.length > 0) {
       lines.push('### Missing Container Pages');

--- a/scripts/audit-docs/types.ts
+++ b/scripts/audit-docs/types.ts
@@ -84,6 +84,12 @@ export interface SlotGap {
   reason: 'missing' | 'phantom';
 }
 
+export interface VersionGap {
+  registryVersion: string;
+  docVersion: string | null;
+  reason: 'mismatch' | 'missing';
+}
+
 export interface DropinGaps {
   missingContainerPages: string[];
   missingProps: PropGap[];
@@ -96,6 +102,7 @@ export interface DropinGaps {
   phantomI18nKeys: I18nGap[];
   missingSlots: SlotGap[];
   phantomSlots: SlotGap[];
+  versionMismatch: VersionGap | null;
 }
 
 export interface SdkEventGaps {

--- a/src/content/docs/dropins-b2b/quick-order/initialization.mdx
+++ b/src/content/docs/dropins-b2b/quick-order/initialization.mdx
@@ -11,6 +11,10 @@ import { Aside } from '@astrojs/starlight/components';
 
 The **Quick Order initializer** configures the Quick Order B2B drop-in for bulk ordering: it sets the GraphQL endpoint (Core Service), loads placeholders from `placeholders/quick-order.json`, and passes language definitions. The drop-in reads the store configuration (`quickOrderActive`) to enable or disable the feature.
 
+<div style="background-color: var(--sl-color-blue-low); border-left: 4px solid var(--sl-color-blue); padding: 0.75rem 1rem; border-radius: 0.25rem; margin: 1rem 0;">
+<strong>Version: 1.1.0</strong>
+</div>
+
 ## Configuration options
 
 <TableWrapper nowrap={[0,1]}>


### PR DESCRIPTION
## Purpose of this pull request

Extends the audit-docs script to catch version badge drift. The audit now reads the `<strong>Version: X.Y.Z</strong>` badge from each drop-in and compares it against the version recorded in the dropins-mcp registry
### Associated JIRA ticket

<!--OPTIONAL Add link to JIRA ticket associated with update.-->


### Staging preview

<!--OPTIONAL Link to staging preview if available-->


## Affected pages

<!-- REQUIRED List the affected pages on experienceleague.adobe.com (URLs). Not necessary for large numbers of files. -->

- ...

## Links to source code

<!--OPTIONAL Link to any associated source code PRs related to update-->

### What's New highlights

<!--  _OPTIONAL - REMOVE THIS SECTION IF NOT USED._

If this pull request introduces changes that should be highlighted in What's New documentation reports.
-->

