### PR TITLE
fix(docs): update GraphQL API reference links to new URL structure

### DIFF
--- a/src/content/docs/dropins/product-details/functions.mdx
+++ b/src/content/docs/dropins/product-details/functions.mdx
@@ -176,7 +176,7 @@ Returns an array of [`ProductModel`](#productmodel) objects or `null` when no pr
 
 ## getRefinedProduct
 
-The `getRefinedProduct` function returns refined product data with specific options selected. This is used for configurable products where options have been chosen. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql-api/saas/index.html#query-refineProduct" text="refineProduct" /> query.
+The `getRefinedProduct` function returns refined product data with specific options selected. This is used for configurable products where options have been chosen. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/reference/graphql/saas/#refineproduct" text="refineProduct" /> query.
 
 For configurable products, the returned [`ProductModel`](#productmodel) always keeps the parent product’s `name` and `sku`. When refinement resolves to a simple variant (`SimpleProductView`), the model also includes `variantSku` and `variantName` for that variant so you can display or forward the child SKU and title (for example from the [`ProductHeader`](/dropins/product-details/containers/product-header/) container).
 

--- a/src/content/docs/dropins/product-details/functions.mdx
+++ b/src/content/docs/dropins/product-details/functions.mdx
@@ -176,7 +176,7 @@ Returns an array of [`ProductModel`](#productmodel) objects or `null` when no pr
 
 ## getRefinedProduct
 
-The `getRefinedProduct` function returns refined product data with specific options selected. This is used for configurable products where options have been chosen. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/reference/graphql/saas/#refineproduct" text="refineProduct" /> query.
+The `getRefinedProduct` function returns refined product data with specific options selected. This is used for configurable products where options have been chosen. The function calls the <Link href="https://developer.adobe.com/commerce/webapi/graphql/schema/catalog-service/queries/refine-product" text="refineProduct" /> query.
 
 For configurable products, the returned [`ProductModel`](#productmodel) always keeps the parent product’s `name` and `sku`. When refinement resolves to a simple variant (`SimpleProductView`), the model also includes `variantSku` and `variantName` for that variant so you can display or forward the child SKU and title (for example from the [`ProductHeader`](/dropins/product-details/containers/product-header/) container).
 

--- a/src/content/docs/setup/configuration/commerce-configuration.mdx
+++ b/src/content/docs/setup/configuration/commerce-configuration.mdx
@@ -67,7 +67,7 @@ The endpoints properties define the GraphQL API endpoints for your Commerce back
 
 **Configuration Properties:**
 
-- **`commerce-core-endpoint`** (read/write) - Core GraphQL endpoint for queries and mutations. This endpoint handles all write operations and some read operations. See <Link href="https://developer.adobe.com/commerce/webapi/graphql/reference/" text="Adobe Commerce GraphQL API" /> for details.
+- **`commerce-core-endpoint`** (read/write) - Core GraphQL endpoint for queries and mutations. This endpoint handles all write operations and some read operations. See <Link href="https://developer.adobe.com/commerce/webapi/reference/graphql/latest/" text="Adobe Commerce GraphQL API" /> for details.
 
 - **`commerce-endpoint`** (read-only) - Services GraphQL endpoint optimized for read-only operations with Catalog Service, Live Search, and Product Recommendations. It is also optimized for performance for product data retrieval. For details, see the following documentation:
    - For Adobe Commerce as a Cloud Service, see the <Link href="https://experienceleague.adobe.com/en/docs/commerce/catalog-service/installation#access-the-service" text="Catalog Service Guide" />.


### PR DESCRIPTION
## Purpose of this pull request

Updates two broken GraphQL API reference links to match the new Adobe Commerce WebAPI developer documentation URL structure. The old paths (`/graphql-api/saas/index.html#query-refineProduct` and `/graphql/reference/`) no longer resolve correctly; the new paths use the consolidated `/reference/graphql/` prefix.

## Affected pages

- https://experienceleague.adobe.com/developer/commerce/storefront/dropins/product-details/functions/
- https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/commerce-configuration/

