### PR TITLE
COMDOX-1739: Added docs for Fastly maintenance mode

### DIFF
--- a/src/content/docs/setup/configuration/content-delivery-network.mdx
+++ b/src/content/docs/setup/configuration/content-delivery-network.mdx
@@ -505,21 +505,21 @@ In the domains configuration, you must use a wildcard. Since the Commerce Admin 
 
 ### Maintenance mode
 
-The Commerce Storefront has no built-in maintenance mode. To redirect all storefront traffic to a maintenance page, add a VCL snippet with the following logic. It redirects every request that is not already going to the maintenance path, so the maintenance page itself remains accessible.
+The storefront has no built-in maintenance mode. The VCL snippet below redirects all incoming requests to your maintenance page. It excludes requests to the `/maintenance` path, so the maintenance page itself stays reachable.
 
-```js
+```txt
 if (req.url !~ "^/maintenance") {
   error 302 "https://yoursite.com/maintenance";
 }
 ```
 
-Replace `https://yoursite.com/maintenance` with the URL of your maintenance page. Work with your Fastly administrator to confirm the correct snippet type and priority before applying it.
+The `error 302` instruction issues an HTTP 302 (temporary redirect) to the URL you specify. Replace `https://yoursite.com/maintenance` with the URL of your maintenance page. Work with your Fastly administrator to confirm the correct snippet type and priority before applying the snippet.
+
+<Aside type="note" title="API and GraphQL traffic">
+  This redirect applies to all incoming requests, including GraphQL and API Mesh requests.
+</Aside>
 
 To end maintenance mode, remove or disable the snippet in your Fastly configuration.
-
-:::note
-This redirect applies to all incoming requests, including GraphQL and API Mesh requests.
-:::
 
 ### Multiple set-cookie headers workaround
 

--- a/src/content/docs/setup/configuration/content-delivery-network.mdx
+++ b/src/content/docs/setup/configuration/content-delivery-network.mdx
@@ -505,7 +505,7 @@ In the domains configuration, you must use a wildcard. Since the Commerce Admin 
 
 ### Maintenance mode
 
-The storefront has no built-in maintenance mode. However, you can add a custom VCL snippet similar to the one below to redirect  all incoming requests to your maintenance page. This snippet excludes requests to the `/maintenance` path, so the maintenance page itself stays reachable.
+The storefront has no built-in maintenance mode. However, you can add a custom VCL snippet similar to the one below to redirect all incoming requests to your maintenance page. This snippet excludes requests to the `/maintenance` path, so the maintenance page itself stays reachable.
 
 ```txt
 if (req.url !~ "^/maintenance") {

--- a/src/content/docs/setup/configuration/content-delivery-network.mdx
+++ b/src/content/docs/setup/configuration/content-delivery-network.mdx
@@ -503,9 +503,23 @@ if (req.backend == F_edge) {
 
 In the domains configuration, you must use a wildcard. Since the Commerce Admin doesn't let you do this, you must do it using the Fastly CLI (which also shows the wildcard URL in the Admin).
 
-### Maintenance page workaround
+### Maintenance mode
 
-The maintenance page can block requests to API Mesh/GraphQL. The solution is to create a VCL snippet with low priority that comes before the maintenance check in VCL and allows GraphQL requests through.
+The Commerce Storefront has no built-in maintenance mode. To redirect all storefront traffic to a maintenance page, add a VCL snippet with the following logic. It redirects every request that is not already going to the maintenance path, so the maintenance page itself remains accessible.
+
+```js
+if (req.url !~ "^/maintenance") {
+  error 302 "https://yoursite.com/maintenance";
+}
+```
+
+Replace `https://yoursite.com/maintenance` with the URL of your maintenance page. Work with your Fastly administrator to confirm the correct snippet type and priority before applying it.
+
+To end maintenance mode, remove or disable the snippet in your Fastly configuration.
+
+:::note
+This redirect applies to all incoming requests, including GraphQL and API Mesh requests.
+:::
 
 ### Multiple set-cookie headers workaround
 

--- a/src/content/docs/setup/configuration/content-delivery-network.mdx
+++ b/src/content/docs/setup/configuration/content-delivery-network.mdx
@@ -505,7 +505,7 @@ In the domains configuration, you must use a wildcard. Since the Commerce Admin 
 
 ### Maintenance mode
 
-The storefront has no built-in maintenance mode. The VCL snippet below is one example of a redirect snippet you can use to send all incoming requests to your maintenance page. It excludes requests to the `/maintenance` path, so the maintenance page itself stays reachable.
+The storefront has no built-in maintenance mode. However, you can add a custom VCL snippet similar to the one below to redirect  all incoming requests to your maintenance page. This snippet excludes requests to the `/maintenance` path, so the maintenance page itself stays reachable.
 
 ```txt
 if (req.url !~ "^/maintenance") {

--- a/src/content/docs/setup/configuration/content-delivery-network.mdx
+++ b/src/content/docs/setup/configuration/content-delivery-network.mdx
@@ -505,7 +505,7 @@ In the domains configuration, you must use a wildcard. Since the Commerce Admin 
 
 ### Maintenance mode
 
-The storefront has no built-in maintenance mode. The VCL snippet below redirects all incoming requests to your maintenance page. It excludes requests to the `/maintenance` path, so the maintenance page itself stays reachable.
+The storefront has no built-in maintenance mode. The VCL snippet below is one example of a redirect snippet you can use to send all incoming requests to your maintenance page. It excludes requests to the `/maintenance` path, so the maintenance page itself stays reachable.
 
 ```txt
 if (req.url !~ "^/maintenance") {
@@ -513,7 +513,9 @@ if (req.url !~ "^/maintenance") {
 }
 ```
 
-The `error 302` instruction issues an HTTP 302 (temporary redirect) to the URL you specify. Replace `https://yoursite.com/maintenance` with the URL of your maintenance page. Work with your Fastly administrator to confirm the correct snippet type and priority before applying the snippet.
+The `error 302` instruction issues an HTTP 302 (temporary redirect) to the URL you specify. Replace `https://yoursite.com/maintenance` with the URL of your maintenance page. Add this as a `recv` snippet with a priority lower than `100`, for example `5`, so it runs before the main routing logic.
+
+To add the snippet, see <Link href={"https://experienceleague.adobe.com/en/docs/commerce-cloud-service/user-guide/cdn/custom-vcl-snippets/fastly-vcl-custom-snippets"} text={"Getting started with custom VCL"} /> in the Fastly documentation, or use the <Link href={"https://github.com/fastly/fastly-magento2"} text={"fastly-magento2"} /> Admin module in the Commerce Admin. Work with your Fastly administrator to confirm the priority before applying the snippet.
 
 <Aside type="note" title="API and GraphQL traffic">
   This redirect applies to all incoming requests, including GraphQL and API Mesh requests.


### PR DESCRIPTION
## Purpose of this pull request

Rewrites the maintenance mode section of the CDN configuration page. The previous content was a single sentence describing how to allow GraphQL requests through a maintenance page check. The updated section explains how to put the storefront into maintenance mode using a Fastly VCL snippet, including the snippet itself, placeholder instructions, a note about redirect scope (all requests, including GraphQL and API Mesh), and steps to end maintenance mode.

### Associated JIRA ticket

https://jira.corp.adobe.com/browse/COMDOX-1739

<!--OPTIONAL Add link to JIRA ticket associated with update.-->

## Affected pages

- https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/content-delivery-network/