### PR TITLE
Add redirects, sitemaps, and limits topics

### DIFF
--- a/astro.sidebar.mjs
+++ b/astro.sidebar.mjs
@@ -191,6 +191,8 @@ export function generateSidebar() {
             { label: 'SEO Overview', link: '/setup/seo/' },
             { label: 'SEO Indexing', link: '/setup/seo/indexing/' },
             { label: 'SEO Metadata', link: '/setup/seo/metadata/' },
+            { label: 'Sitemaps', link: '/setup/seo/sitemaps/' },
+            { label: 'Platform Limits', link: '/setup/seo/platform-limits/' },
           ],
         },
         {
@@ -846,7 +848,20 @@ export function generateSidebar() {
           ],
         },
         {
+          label: 'Edge Delivery Services',
+          collapsed: true,
+          items: [
+            { label: 'Overview', link: '/merchants/edge-delivery-services/' },
+            { label: 'Scheduling options', link: '/merchants/edge-delivery-services/scheduling/' },
+            { label: 'Content migration', link: '/merchants/edge-delivery-services/content-migration/' },
+            { label: 'Redirects', link: '/merchants/edge-delivery-services/redirects/' },
+            { label: 'Sitemaps', link: '/merchants/edge-delivery-services/sitemaps/' },
+            { label: 'File and content limits', link: '/merchants/edge-delivery-services/file-limits/' },
+          ],
+        },
+        {
           label: 'Commerce Blocks',
+          collapsed: true,
           items: [
             { label: 'Overview', link: '/merchants/blocks/' },
             { label: 'Content and Commerce blocks', link: '/merchants/blocks/content-commerce-blocks/' },
@@ -861,8 +876,6 @@ export function generateSidebar() {
               collapsed: true,
               items: [
                 { label: 'Overview', link: '/merchants/blocks/b2c/' },
-                { label: 'Personalization Setup', link: '/merchants/blocks/personalization/' },
-                { label: 'Product Recommendations Setup', link: '/merchants/blocks/product-recommendations/' },
                 { label: 'Account Header', link: '/merchants/blocks/commerce-account-header/' },
                 { label: 'Account Sidebar', link: '/merchants/blocks/commerce-account-sidebar/' },
                 { label: 'Addresses', link: '/merchants/blocks/commerce-addresses/' },
@@ -936,16 +949,7 @@ export function generateSidebar() {
           ],
         },
         {
-          label: 'Localization',
-          collapsed: true,
-          items: [
-            { label: 'Document Authoring Workflow', link: '/merchants/quick-start/content-localization/' },
-            { label: 'Universal Editor Workflow', link: '/merchants/quick-start/content-localization-universal-editor/' },
-            { label: 'Commerce-Specific Tasks', link: '/merchants/quick-start/content-localization-commerce-tasks/' },
-          ],
-        },
-        {
-          label: 'Content Customizations',
+          label: 'Storefront Features',
           items: [
             { label: 'Overview', link: '/merchants/content-customizations/' },
             { label: 'Enrichment', link: '/merchants/content-customizations/enrichment/' },
@@ -957,12 +961,12 @@ export function generateSidebar() {
           ],
         },
         {
-          label: 'Edge Delivery Services',
+          label: 'Localization',
           collapsed: true,
           items: [
-            { label: 'Overview', link: '/merchants/edge-delivery-services/' },
-            { label: 'Scheduling options', link: '/merchants/edge-delivery-services/scheduling/' },
-            { label: 'Content migration', link: '/merchants/edge-delivery-services/content-migration/' },
+            { label: 'Document Authoring Workflow', link: '/merchants/quick-start/content-localization/' },
+            { label: 'Universal Editor Workflow', link: '/merchants/quick-start/content-localization-universal-editor/' },
+            { label: 'Commerce-Specific Tasks', link: '/merchants/quick-start/content-localization-commerce-tasks/' },
           ],
         },
       ],

--- a/src/content/docs/merchants/edge-delivery-services/file-limits.mdx
+++ b/src/content/docs/merchants/edge-delivery-services/file-limits.mdx
@@ -6,28 +6,25 @@ description: Learn about file size limits and content limits in Edge Delivery Se
 import Link from '@components/Link.astro';
 import { Aside } from '@astrojs/starlight/components';
 
-Edge Delivery Services sets limits on the files you can upload and on the number of redirects and sitemap entries your site can have. See <Link href="https://www.aem.live/docs/limits" text="Limits on AEM.live" /> for the complete list.
+Edge Delivery Services limits the size of files you can upload and the number of redirects and sitemap entries your site can have. See <Link href="https://www.aem.live/docs/limits" text="Limits on AEM.live" /> for exact values.
 
 ## File upload limits
 
 Each file type you upload through <Link href="https://da.live" text="Document Authoring" /> has a maximum size. Documents and spreadsheets have the most generous limits; SVG files and favicons have much smaller ones. Files that exceed the limit cannot be previewed or published.
 
 <Aside type="tip" title="Files larger than the limit">
-If you need to use a file that exceeds the limit — such as a long product demo video — ask your development team to host it on a CDN or a third-party video platform instead. You can still embed or link to it from your storefront pages.
+To use a file that exceeds the limit — such as a long product demo video — ask your development team to host it on a CDN or a third-party video platform instead. You can embed or link to it from your storefront pages.
 </Aside>
 
 ## Redirect limits
 
-Your site's redirect spreadsheet has a maximum number of entries. If you are migrating from a large legacy site and importing many historical redirects, ask your development team to review the list and remove any that are no longer needed before reaching that limit. See <Link href="https://www.aem.live/docs/limits#redirect-limits" text="Redirect limits on AEM.live" /> for details.
+The redirect spreadsheet has a maximum number of entries. If you are importing a large list of historical redirects, review it first and remove entries that are no longer needed. See <Link href="https://www.aem.live/docs/limits#redirect-limits" text="Redirect limits on AEM.live" /> for the entry limit.
 
-See [Redirects](/merchants/edge-delivery-services/redirects/) for how to create and manage your redirect spreadsheet.
+To create or manage your redirect spreadsheet, see [Redirects](/merchants/edge-delivery-services/redirects/).
 
 ## Sitemap limits
 
-Each sitemap file has a maximum URL count and file size. If your site exceeds those limits, your development team should split the sitemap into multiple files and provide a sitemap index URL that references all of them. You can submit individual sitemap files or the index URL to Google Search Console or any other search engine's submission tool. Adding each sitemap URL to `robots.txt` lets crawlers find them automatically without manual submission.
+Each sitemap file has a maximum URL count and file size. If your site exceeds those limits, ask your development team to split the sitemap into multiple files and create a sitemap index.
 
-See [Sitemaps](/merchants/edge-delivery-services/sitemaps/) for how to submit your sitemap.
+To submit your sitemap, see [Sitemaps](/merchants/edge-delivery-services/sitemaps/).
 
-## Go deeper
-
-See <Link href="https://www.aem.live/docs/limits" text="Limits on AEM.live" /> for all limit types, including file upload sizes.

--- a/src/content/docs/merchants/edge-delivery-services/file-limits.mdx
+++ b/src/content/docs/merchants/edge-delivery-services/file-limits.mdx
@@ -4,28 +4,13 @@ description: Learn about file size limits and content limits in Edge Delivery Se
 ---
 
 import Link from '@components/Link.astro';
-import TableWrapper from '@components/TableWrapper.astro';
 import { Aside } from '@astrojs/starlight/components';
 
-Edge Delivery Services sets limits on the files you can upload and on the number of redirects and sitemap entries your site can have.
+Edge Delivery Services sets limits on the files you can upload and on the number of redirects and sitemap entries your site can have. See <Link href="https://www.aem.live/docs/limits" text="Limits on AEM.live" /> for the complete list.
 
 ## File upload limits
 
-These limits apply to files you upload through <Link href="https://da.live" text="Document Authoring" />. Files that exceed the limit cannot be previewed or published.
-
-<TableWrapper nowrap={[0]}>
-
-| File type | Maximum size |
-|-----------|-------------|
-| Documents (Word / Google Doc) | 100 MB |
-| Spreadsheets | 100,000 rows; 500,000 cells |
-| PDF | 20 MB |
-| Images (PNG, JPG, AVIF) | 20 MB |
-| Video (MP4) | 36 MB |
-| SVG | 40 KB |
-| Favicon (ICO) | 16 KB |
-
-</TableWrapper>
+Each file type you upload through <Link href="https://da.live" text="Document Authoring" /> has a maximum size. Documents and spreadsheets have the most generous limits; SVG files and favicons have much smaller ones. Files that exceed the limit cannot be previewed or published.
 
 <Aside type="tip" title="Files larger than the limit">
 If you need to use a file that exceeds the limit — such as a long product demo video — ask your development team to host it on a CDN or a third-party video platform instead. You can still embed or link to it from your storefront pages.
@@ -33,16 +18,16 @@ If you need to use a file that exceeds the limit — such as a long product demo
 
 ## Redirect limits
 
-Your site can hold up to 100,000 redirect rules in the redirects spreadsheet. If you are migrating from a large legacy site and importing many historical redirects, ask your development team to review the list and remove any that are no longer needed before reaching the limit.
+Your site's redirect spreadsheet has a maximum number of entries. If you are migrating from a large legacy site and importing many historical redirects, ask your development team to review the list and remove any that are no longer needed before reaching that limit. See <Link href="https://www.aem.live/docs/limits#redirect-limits" text="Redirect limits on AEM.live" /> for details.
 
 See [Redirects](/merchants/edge-delivery-services/redirects/) for how to create and manage your redirect spreadsheet.
 
 ## Sitemap limits
 
-Each sitemap file can hold up to 50,000 URLs and must be under 50 MB. If your site has more than 50,000 pages, your development team should set up multiple sitemap files. When submitting to Google Search Console, submit each sitemap file separately, or ask your development team for a sitemap index URL that references all of them.
+Each sitemap file has a maximum URL count and file size. If your site exceeds those limits, your development team should split the sitemap into multiple files and provide a sitemap index URL that references all of them. You can submit individual sitemap files or the index URL to Google Search Console or any other search engine's submission tool. Adding each sitemap URL to `robots.txt` lets crawlers find them automatically without manual submission.
 
-See [Sitemaps](/merchants/edge-delivery-services/sitemaps/) for how to submit your sitemap to Google Search Console.
+See [Sitemaps](/merchants/edge-delivery-services/sitemaps/) for how to submit your sitemap.
 
 ## Go deeper
 
-See <Link href="https://www.aem.live/docs/limits" text="Limits on AEM.live" />.
+See <Link href="https://www.aem.live/docs/limits" text="Limits on AEM.live" /> for all limit types, including file upload sizes.

--- a/src/content/docs/merchants/edge-delivery-services/file-limits.mdx
+++ b/src/content/docs/merchants/edge-delivery-services/file-limits.mdx
@@ -1,0 +1,48 @@
+---
+title: File and content limits
+description: Learn about file size limits and content limits in Edge Delivery Services, including what you can upload and when to ask your developer for help.
+---
+
+import Link from '@components/Link.astro';
+import TableWrapper from '@components/TableWrapper.astro';
+import { Aside } from '@astrojs/starlight/components';
+
+Edge Delivery Services sets limits on the files you can upload and on the number of redirects and sitemap entries your site can have.
+
+## File upload limits
+
+These limits apply to files you upload through <Link href="https://da.live" text="Document Authoring" />. Files that exceed the limit cannot be previewed or published.
+
+<TableWrapper nowrap={[0]}>
+
+| File type | Maximum size |
+|-----------|-------------|
+| Documents (Word / Google Doc) | 100 MB |
+| Spreadsheets | 100,000 rows; 500,000 cells |
+| PDF | 20 MB |
+| Images (PNG, JPG, AVIF) | 20 MB |
+| Video (MP4) | 36 MB |
+| SVG | 40 KB |
+| Favicon (ICO) | 16 KB |
+
+</TableWrapper>
+
+<Aside type="tip" title="Files larger than the limit">
+If you need to use a file that exceeds the limit — such as a long product demo video — ask your development team to host it on a CDN or a third-party video platform instead. You can still embed or link to it from your storefront pages.
+</Aside>
+
+## Redirect limits
+
+Your site can hold up to 100,000 redirect rules in the redirects spreadsheet. If you are migrating from a large legacy site and importing many historical redirects, ask your development team to review the list and remove any that are no longer needed before reaching the limit.
+
+See [Redirects](/merchants/edge-delivery-services/redirects/) for how to create and manage your redirect spreadsheet.
+
+## Sitemap limits
+
+Each sitemap file can hold up to 50,000 URLs and must be under 50 MB. If your site has more than 50,000 pages, your development team should set up multiple sitemap files. When submitting to Google Search Console, submit each sitemap file separately, or ask your development team for a sitemap index URL that references all of them.
+
+See [Sitemaps](/merchants/edge-delivery-services/sitemaps/) for how to submit your sitemap to Google Search Console.
+
+## Go deeper
+
+See <Link href="https://www.aem.live/docs/limits" text="Limits on AEM.live" />.

--- a/src/content/docs/merchants/edge-delivery-services/index.mdx
+++ b/src/content/docs/merchants/edge-delivery-services/index.mdx
@@ -1,21 +1,19 @@
 ---
 title: Edge Delivery Services
-description: Learn about AEM Edge Delivery Services features for your storefront, including scheduled publishing for storefront content.
+description: Learn about Edge Delivery Services features for merchants, including scheduling, redirects, sitemaps, and file and content limits.
 ---
 
 import CardGrid from '@components/CardGrid.astro';
 import Link from '@components/Link.astro';
 import LinkCard from '@components/LinkCard.astro';
 
-Edge Delivery Services (EDS) is Adobe's modern content delivery platform that powers your Commerce Storefront. It delivers exceptional page load speeds, high Lighthouse scores, and an intuitive authoring experience using <Link href="https://da.live" text="Document Authoring (DA)" />.
+Edge Delivery Services is Adobe's content delivery platform that powers your Commerce storefront. It delivers fast page load speeds, high Lighthouse scores, and an authoring experience built on <Link href="https://da.live" text="Document Authoring" />.
 
-For your storefront, Edge Delivery Services handles content management and delivery while integrating seamlessly with Adobe Commerce for product data, cart, checkout, account functionality, and more. This separation lets content authors update pages independently without requiring developer involvement.
+For your storefront, Edge Delivery Services handles content management and delivery while integrating with Adobe Commerce for product data, cart, checkout, account functionality, and more. This separation lets content authors update pages without developer involvement.
 
 Learn more about Edge Delivery Services in the <Link href="https://experienceleague.adobe.com/en/docs/experience-manager-cloud-service/content/edge-delivery/overview" text="Edge Delivery Services Overview" />.
 
 ## Features for merchants
-
-The topics below cover Edge Delivery Services features available to merchants for managing storefront content.
 
 <CardGrid>
   <LinkCard
@@ -32,6 +30,30 @@ The topics below cover Edge Delivery Services features available to merchants fo
     title="Content migration"
     description="Copy content between DA.live projects, then preview and publish on your storefront."
     link="/merchants/edge-delivery-services/content-migration/"
+    rightIcon="right-arrow"
+  />
+  <LinkCard
+    noborder
+    icon='document'
+    title="Redirects"
+    description="Create and manage redirects using a spreadsheet so old or changed URLs still reach the right page."
+    link="/merchants/edge-delivery-services/redirects/"
+    rightIcon="right-arrow"
+  />
+  <LinkCard
+    noborder
+    icon='document'
+    title="Sitemaps"
+    description="Learn how Edge Delivery Services generates sitemaps and how to submit them to Google Search Console."
+    link="/merchants/edge-delivery-services/sitemaps/"
+    rightIcon="right-arrow"
+  />
+  <LinkCard
+    noborder
+    icon='information'
+    title="File and content limits"
+    description="File size limits for PDFs, images, videos, and documents, plus redirect and sitemap count limits."
+    link="/merchants/edge-delivery-services/file-limits/"
     rightIcon="right-arrow"
   />
 </CardGrid>

--- a/src/content/docs/merchants/edge-delivery-services/redirects.mdx
+++ b/src/content/docs/merchants/edge-delivery-services/redirects.mdx
@@ -1,0 +1,23 @@
+---
+title: Redirects
+description: Create and manage redirects on your storefront using a spreadsheet in Edge Delivery Services.
+---
+
+import Link from '@components/Link.astro';
+import { Aside } from '@astrojs/starlight/components';
+
+You manage redirects on your storefront using a spreadsheet. No code changes are required.
+
+## Redirect behavior
+
+<Aside type="note" title="Redirects override existing pages">
+If you create a redirect for a URL that already has a published page, the redirect takes precedence and the published page becomes unreachable at that URL. The page content is not deleted. Removing the redirect rule restores access if the page was still published. If it was unpublished, you also need to republish it.
+</Aside>
+
+The redirect sheet matches URL paths only. The `Source` column accepts a relative path, so query parameters are not part of the match. This means it cannot distinguish between URLs that differ only in their query parameters. For example, `/search?q=shoes` and `/search?q=bags` are both treated as the path `/search`. If you need to redirect specific search terms, ask your developer to set up [search redirects](/how-tos/search-redirects/) instead.
+
+The redirect sheet can hold up to 100,000 entries. See [File and content limits](/merchants/edge-delivery-services/file-limits/) if you are managing a large legacy catalog migration. Once your redirects are live, submit your [sitemap](/merchants/edge-delivery-services/sitemaps/) to Google Search Console so search engines discover the updated URL structure faster.
+
+## Go deeper
+
+See <Link href="https://www.aem.live/docs/redirects" text="Redirects on AEM.live" />.

--- a/src/content/docs/merchants/edge-delivery-services/redirects.mdx
+++ b/src/content/docs/merchants/edge-delivery-services/redirects.mdx
@@ -1,22 +1,22 @@
 ---
 title: Redirects
-description: Create and manage redirects on your storefront using a spreadsheet in Edge Delivery Services.
+description: Learn how Edge Delivery Services handles redirects using a spreadsheet, including URL path matching, query parameter behavior, and entry limits.
 ---
 
 import Link from '@components/Link.astro';
 import { Aside } from '@astrojs/starlight/components';
 
-You manage redirects on your storefront using a spreadsheet. No code changes are required.
+Redirects are managed on your storefront using a spreadsheet. No code changes are required.
 
 ## Redirect behavior
 
 <Aside type="note" title="Redirects override existing pages">
-If you create a redirect for a URL that already has a published page, the redirect takes precedence and the published page becomes unreachable at that URL. The page content is not deleted. Removing the redirect rule restores access if the page was still published. If it was unpublished, you also need to republish it.
+If you create a redirect for a URL that has a published page, the redirect overrides it and the page becomes unreachable at that URL. The page is not deleted. Remove the redirect to restore access, then republish the page if it was also unpublished.
 </Aside>
 
-The redirect sheet matches URL paths only. The `Source` column accepts a relative path, so query parameters are not part of the match. This means it cannot distinguish between URLs that differ only in their query parameters. For example, `/search?q=shoes` and `/search?q=bags` are both treated as the path `/search`. If you need to redirect specific search terms, ask your developer to set up [search redirects](/how-tos/search-redirects/) instead.
+The redirect sheet matches URL paths, not query parameters. For example, `/search?q=shoes` and `/search?q=bags` both match `/search`. To target individual search terms, ask your developer to configure [search redirects](/how-tos/search-redirects/) instead.
 
-The redirect sheet has a maximum number of entries (see <Link href="https://www.aem.live/docs/limits#redirect-limits" text="Redirect limits on AEM.live" />). If you are managing a large legacy catalog migration, see [File and content limits](/merchants/edge-delivery-services/file-limits/) before importing historical redirects. Once your redirects are live, submit your [sitemap](/merchants/edge-delivery-services/sitemaps/) to Google Search Console so search engines discover the updated URL structure faster.
+The redirect sheet has a maximum number of entries (see <Link href="https://www.aem.live/docs/limits#redirect-limits" text="Redirect limits on AEM.live" />). If you are managing a large legacy migration, check [File and content limits](/merchants/edge-delivery-services/file-limits/) before importing historical redirects. Once your redirects are live, update your [sitemap](/merchants/edge-delivery-services/sitemaps/) so search engines find the new URLs.
 
 ## Go deeper
 

--- a/src/content/docs/merchants/edge-delivery-services/redirects.mdx
+++ b/src/content/docs/merchants/edge-delivery-services/redirects.mdx
@@ -16,7 +16,7 @@ If you create a redirect for a URL that already has a published page, the redire
 
 The redirect sheet matches URL paths only. The `Source` column accepts a relative path, so query parameters are not part of the match. This means it cannot distinguish between URLs that differ only in their query parameters. For example, `/search?q=shoes` and `/search?q=bags` are both treated as the path `/search`. If you need to redirect specific search terms, ask your developer to set up [search redirects](/how-tos/search-redirects/) instead.
 
-The redirect sheet can hold up to 100,000 entries. See [File and content limits](/merchants/edge-delivery-services/file-limits/) if you are managing a large legacy catalog migration. Once your redirects are live, submit your [sitemap](/merchants/edge-delivery-services/sitemaps/) to Google Search Console so search engines discover the updated URL structure faster.
+The redirect sheet has a maximum number of entries (see <Link href="https://www.aem.live/docs/limits#redirect-limits" text="Redirect limits on AEM.live" />). If you are managing a large legacy catalog migration, see [File and content limits](/merchants/edge-delivery-services/file-limits/) before importing historical redirects. Once your redirects are live, submit your [sitemap](/merchants/edge-delivery-services/sitemaps/) to Google Search Console so search engines discover the updated URL structure faster.
 
 ## Go deeper
 

--- a/src/content/docs/merchants/edge-delivery-services/sitemaps.mdx
+++ b/src/content/docs/merchants/edge-delivery-services/sitemaps.mdx
@@ -1,22 +1,22 @@
 ---
 title: Sitemaps
-description: Learn how Edge Delivery Services generates sitemaps for your storefront and how to submit them to Google Search Console.
+description: Learn how Edge Delivery Services generates sitemaps for your storefront, how to submit them to Google Search Console, and when to involve a developer.
 ---
 
 import Link from '@components/Link.astro';
 import { Aside } from '@astrojs/starlight/components';
 
-Edge Delivery Services generates a sitemap automatically at `/sitemap.xml` whenever you publish content. No configuration is needed for a working sitemap.
+Edge Delivery Services automatically generates a sitemap at `/sitemap.xml` when you publish content. No configuration is required.
 
 ## What gets included automatically
 
-Every page you publish is included in the sitemap. This covers marketing pages, landing pages, category pages you author directly, and any other document-based content.
+Every page you publish appears in the sitemap, including marketing pages, landing pages, authored category pages, and other document-based content.
 
-Product pages are not included automatically. If your developer has configured [AEM Commerce prerender](/setup/configuration/aem-prerender/), those pages appear in the sitemap. To get them included, contact your developer.
+Product pages are excluded by default. If [AEM Commerce prerender](/setup/configuration/aem-prerender/) is configured, it adds them automatically. Otherwise, ask your developer to include them.
 
 ## Submit your sitemap to Google Search Console
 
-In <Link href="https://search.google.com/search-console" text="Google Search Console" />, open the **Sitemaps** section for your property, enter your sitemap URL (typically `https://www.yoursite.com/sitemap.xml`), and choose **Submit**. Google starts crawling the URLs within a few days, and you can check indexing status and any errors in Search Console.
+In <Link href="https://search.google.com/search-console" text="Google Search Console" />, open the **Sitemaps** section for your property, enter your sitemap URL (typically `https://www.yoursite.com/sitemap.xml`), and choose **Submit**. Google starts crawling the submitted URLs within a few days. Check indexing status and errors in Search Console.
 
 <Aside type="tip" title="Multiple sitemaps">
 Large catalogs or multi-language sites may have more than one sitemap file. Ask your developer to give you the complete list of sitemap URLs, then submit each one to Google Search Console.
@@ -26,12 +26,11 @@ Large catalogs or multi-language sites may have more than one sitemap file. Ask 
 
 For most storefronts, the automatic sitemap is sufficient. Contact your developer when:
 
-- Product pages are missing from the sitemap and you need them included for SEO.
 - Your site supports multiple languages and search engines are indexing the wrong locale.
 - Your catalog has grown large enough that a single sitemap file cannot hold all product URLs. See [File and content limits](/merchants/edge-delivery-services/file-limits/) for the per-file limits.
 - You need custom configuration such as `hreflang` tags for a multi-store setup.
 
-If you recently restructured your site URLs, set up [Redirects](/merchants/edge-delivery-services/redirects/) to preserve SEO value from old URLs while the sitemap points search engines to the new ones.
+If you restructured your URLs, set up [Redirects](/merchants/edge-delivery-services/redirects/) to preserve SEO value from the old paths.
 
 ## Go deeper
 

--- a/src/content/docs/merchants/edge-delivery-services/sitemaps.mdx
+++ b/src/content/docs/merchants/edge-delivery-services/sitemaps.mdx
@@ -1,0 +1,38 @@
+---
+title: Sitemaps
+description: Learn how Edge Delivery Services generates sitemaps for your storefront and how to submit them to Google Search Console.
+---
+
+import Link from '@components/Link.astro';
+import { Aside } from '@astrojs/starlight/components';
+
+Edge Delivery Services generates a sitemap automatically at `/sitemap.xml` whenever you publish content. No configuration is needed for a working sitemap.
+
+## What gets included automatically
+
+Every page you publish is included in the sitemap. This covers marketing pages, landing pages, category pages you author directly, and any other document-based content.
+
+Product pages are not included automatically. If your developer has configured [AEM Commerce prerender](/setup/configuration/aem-prerender/), those pages appear in the sitemap. To get them included, contact your developer.
+
+## Submit your sitemap to Google Search Console
+
+In <Link href="https://search.google.com/search-console" text="Google Search Console" />, open the **Sitemaps** section for your property, enter your sitemap URL (typically `https://www.yoursite.com/sitemap.xml`), and choose **Submit**. Google starts crawling the URLs within a few days, and you can check indexing status and any errors in Search Console.
+
+<Aside type="tip" title="Multiple sitemaps">
+Large catalogs or multi-language sites may have more than one sitemap file. Ask your developer to give you the complete list of sitemap URLs, then submit each one to Google Search Console.
+</Aside>
+
+## When to involve a developer
+
+For most storefronts, the automatic sitemap is sufficient. Contact your developer when:
+
+- Product pages are missing from the sitemap and you need them included for SEO.
+- Your site supports multiple languages and search engines are indexing the wrong locale.
+- Your catalog has more than 50,000 products. See [File and content limits](/merchants/edge-delivery-services/file-limits/) for the per-file URL and size limits.
+- You need custom configuration such as `hreflang` tags for a multi-store setup.
+
+If you recently restructured your site URLs, set up [Redirects](/merchants/edge-delivery-services/redirects/) to preserve SEO value from old URLs while the sitemap points search engines to the new ones.
+
+## Go deeper
+
+See <Link href="https://www.aem.live/developer/sitemap" text="Sitemaps on AEM.live" />.

--- a/src/content/docs/merchants/edge-delivery-services/sitemaps.mdx
+++ b/src/content/docs/merchants/edge-delivery-services/sitemaps.mdx
@@ -28,7 +28,7 @@ For most storefronts, the automatic sitemap is sufficient. Contact your develope
 
 - Product pages are missing from the sitemap and you need them included for SEO.
 - Your site supports multiple languages and search engines are indexing the wrong locale.
-- Your catalog has more than 50,000 products. See [File and content limits](/merchants/edge-delivery-services/file-limits/) for the per-file URL and size limits.
+- Your catalog has grown large enough that a single sitemap file cannot hold all product URLs. See [File and content limits](/merchants/edge-delivery-services/file-limits/) for the per-file limits.
 - You need custom configuration such as `hreflang` tags for a multi-store setup.
 
 If you recently restructured your site URLs, set up [Redirects](/merchants/edge-delivery-services/redirects/) to preserve SEO value from old URLs while the sitemap points search engines to the new ones.

--- a/src/content/docs/setup/configuration/aem-prerender.mdx
+++ b/src/content/docs/setup/configuration/aem-prerender.mdx
@@ -223,7 +223,7 @@ The diagram below shows how these components connect and work together to genera
 />
 
 <Aside type="note" title="Catalog Size Considerations">
-For catalogs exceeding 50,000 products, consult the <Link href="https://www.aem.live/docs/limits" text="AEM indexing limits" /> documentation for sitemap splitting strategies and scaling considerations.
+For catalogs exceeding 50,000 products, see [Edge Delivery Services limits](/setup/seo/platform-limits/#indexing-and-sitemap-size) for sitemap splitting strategies and scaling considerations.
 </Aside>
 
 ## Product lifecycle management

--- a/src/content/docs/setup/configuration/content-delivery-network.mdx
+++ b/src/content/docs/setup/configuration/content-delivery-network.mdx
@@ -331,7 +331,7 @@ The following are optional configurations that can be added to the VCL snippets 
 
 ### URL rewrites
 
-Be aware that URLs in Edge Delivery Services may only contain a-z, 0-9, and the dash (`-`) character (see <Link href={"https://www.aem.live/docs/limits#document-naming"} text={"Document naming"} />). You may need to create a CDN rule to rewrite/remove these characters.
+Be aware that URLs in Edge Delivery Services may only contain a-z, 0-9, and the dash (`-`) character (see [Document naming restrictions](/setup/seo/platform-limits/#document-naming-and-url-format)). You may need to create a CDN rule to rewrite/remove these characters.
 
 As an example, consider one possible case where this applies with login referrer links. Luma may redirect to a page like `/login/referrer/<base64string>`. If the login page is implemented in Edge Delivery Services (with a Luma Bridge) and the base 64 string contains unsupported characters, this page will 404. Since the base64 part is only needed on the Edge Delivery Services client side to handle redirecting after a successful sign-in, this could be stripped for the request to the Edge Delivery Services backend.
 

--- a/src/content/docs/setup/seo/index.mdx
+++ b/src/content/docs/setup/seo/index.mdx
@@ -13,7 +13,7 @@ Search optimization on this storefront depends on two coordinated layers: how Ed
 
 ### Edge Delivery Services (platform)
 
-Edge Delivery Services (EDS) shapes the first HTML response: document-based pages (for example, marketing or editorial pages) usually ship most of their text there, while many catalog product detail pages (PDPs) load product details after that response for performance unless you publish server-side metadata or use prerender. Search engines and large language model (LLM) crawlers still rely heavily on that first payload, so Adobe publishes shared SEO and GEO guidance on <Link href="https://www.aem.live/docs/seo-geo" text="AEM.live" />. GEO sits alongside SEO on that page. For example, some bots do not fully render every page, so they lean on the initial HTML.
+Edge Delivery Services (EDS) shapes the first HTML response. Document-based pages usually ship most of their text there, while many catalog product detail pages (PDPs) load details later for performance unless you publish server-side metadata or use prerender. Search engines and large language model (LLM) crawlers still rely on that first payload, so Adobe publishes shared SEO and GEO guidance on <Link href="https://www.aem.live/docs/seo-geo" text="AEM.live" />. GEO sits alongside SEO on that page. For example, some bots do not fully render every page, so they lean on the initial HTML.
 
 <LinkCard
   noborder
@@ -29,13 +29,13 @@ Edge Delivery Services (EDS) shapes the first HTML response: document-based page
 
 ### Adobe Commerce storefront (catalog)
 
-Your Commerce layer adds URL patterns, folder mapping, canonical choices, structured metadata, and multi-store rules on top of those EDS defaults. Document-based routes and catalog routes behave differently, so search crawlers and social previews can treat thin or duplicate first HTML as low-value unless [SEO indexing](/setup/seo/indexing/) and [SEO metadata](/setup/seo/metadata/) stay aligned. SKUs, configurable products, and store-specific URLs all influence which URL should win and what appears in that first response.
+Your Commerce layer adds URL patterns, folder mapping, canonical choices, structured metadata, and multi-store rules on top of those EDS defaults. Document-based routes and catalog routes behave differently, so search crawlers and social previews can treat thin or duplicate first HTML as low-value unless [SEO indexing](/setup/seo/indexing/) and [SEO metadata](/setup/seo/metadata/) remain consistent. SKUs, configurable products, and store-specific URLs all influence which URL wins and what appears in that first response.
 
 The [SEO indexing](/setup/seo/indexing/) and [SEO metadata](/setup/seo/metadata/) pages spell out storefront-specific checks. They extend the platform baseline on <Link href="https://www.aem.live/docs/seo-geo" text="AEM.live" />.
 
 ### Keep both layers aligned
 
-Use the same story in the platform response and the catalog: one clear URL per indexable product context, metadata that matches that URL, and enough useful text in the first HTML when a bot stops after the first response.
+Use the same information in the platform response and the catalog: one clear URL per indexable product context, matching metadata, and enough useful text in the first HTML.
 
 - Match Edge Delivery Services expectations for sitemaps, robots, performance, and primary content in the first HTML. Treat <Link href="https://www.aem.live/docs/seo-geo" text="SEO and GEO best practices on AEM.live" /> as the baseline for your mix of document-based and catalog routes.
 - Implement URL rules, folder mapping, canonicals, hreflang, and store-specific crawling behavior from [SEO indexing](/setup/seo/indexing/) so the URLs you publish are the URLs you want indexed.
@@ -46,10 +46,12 @@ Use the same story in the platform response and the catalog: one clear URL per i
 
 Use these pages when you implement indexing, metadata, launch checks, or prerender for your storefront:
 
-- [SEO indexing](/setup/seo/indexing/) — canonical URLs, folder mapping, sitemaps, hreflang, and multi-store considerations.
+- [SEO indexing](/setup/seo/indexing/) — canonical URLs, product URL format, redirects, hreflang, and multi-store considerations.
 - [SEO metadata](/setup/seo/metadata/) — titles, descriptions, structured data, and PDP metadata workflows.
+- [Sitemaps](/setup/seo/sitemaps/) — sitemap configuration for catalog pages, prerender integration, and multi-store hreflang.
+- [Platform limits](/setup/seo/platform-limits/) — URL naming rules, index size caps, and redirect limits that affect Commerce storefronts.
 - [Launch checklist — SEO and indexing](/setup/launch/#seo-and-indexing) — tasks to verify before go-live.
-- [AEM Commerce prerender](/setup/configuration/aem-prerender/) — server-rendered HTML when catalog pages rely heavily on client-side data.
+- [AEM Commerce prerender](/setup/configuration/aem-prerender/) — server-rendered HTML when catalog pages rely on client-side data.
 
 <Aside type="tip" title="If validators show empty PDP HTML">
 Start with [SEO metadata](/setup/seo/metadata/) and [folder mapping](/setup/seo/indexing/#folder-mapping). If you still need full product markup in the initial HTML for crawlers, configure [AEM Commerce prerender](/setup/configuration/aem-prerender/).

--- a/src/content/docs/setup/seo/index.mdx
+++ b/src/content/docs/setup/seo/index.mdx
@@ -54,5 +54,5 @@ Use these pages when you implement indexing, metadata, launch checks, or prerend
 - [AEM Commerce prerender](/setup/configuration/aem-prerender/) — server-rendered HTML when catalog pages rely on client-side data.
 
 <Aside type="tip" title="If validators show empty PDP HTML">
-Start with [SEO metadata](/setup/seo/metadata/) and [folder mapping](/setup/seo/indexing/#folder-mapping). If you still need full product markup in the initial HTML for crawlers, configure [AEM Commerce prerender](/setup/configuration/aem-prerender/).
+Start with [SEO metadata](/setup/seo/metadata/) and [SEO indexing](/setup/seo/indexing/). If you still need full product markup in the initial HTML for crawlers, configure [AEM Commerce prerender](/setup/configuration/aem-prerender/).
 </Aside>

--- a/src/content/docs/setup/seo/index.mdx
+++ b/src/content/docs/setup/seo/index.mdx
@@ -54,5 +54,5 @@ Use these pages when you implement indexing, metadata, launch checks, or prerend
 - [AEM Commerce prerender](/setup/configuration/aem-prerender/) — server-rendered HTML when catalog pages rely on client-side data.
 
 <Aside type="tip" title="If validators show empty PDP HTML">
-Start with [SEO metadata](/setup/seo/metadata/) and [SEO indexing](/setup/seo/indexing/). If you still need full product markup in the initial HTML for crawlers, configure [AEM Commerce prerender](/setup/configuration/aem-prerender/).
+Start with [SEO metadata](/setup/seo/metadata/) and [URL format of catalog pages](/setup/seo/indexing/#url-format-of-catalog-pages). If you still need full product markup in the initial HTML for crawlers, configure [AEM Commerce prerender](/setup/configuration/aem-prerender/).
 </Aside>

--- a/src/content/docs/setup/seo/indexing.mdx
+++ b/src/content/docs/setup/seo/indexing.mdx
@@ -1,6 +1,6 @@
 ---
 title: SEO indexing
-description: Guidelines for canonical URLs, folder mapping, redirects, sitemaps, and multi-store crawling on Adobe Commerce storefronts with Edge Delivery Services.
+description: Guidelines for canonical URLs, redirects, sitemaps, and multi-store crawling on Adobe Commerce storefronts with Edge Delivery Services.
 ---
 import Link from '@components/Link.astro';
 
@@ -17,33 +17,20 @@ These recommendations come from customer and partner storefront projects on Edge
 
 ### Configurable products
 
-For configurable products, ensure that the canonical URL is set to the parent product URL. This is important because Google might index the child product URLs, which can lead to duplicate content issues.
+For configurable products, ensure that the canonical URL is set to the parent product URL. This behavior is important because Google indexes the child product URLs, which leads to duplicate content issues.
 
-### Folder mapping
+### URL format of catalog pages
 
-When using <Link href={"https://www.aem.live/developer/folder-mapping"} text={"folder mapping"} /> for Commerce pages (PDP, PLP), ensure that the server-side rendered response contains metadata that allows Google to differentiate pages.
-
-Folder-mapped pages (without using <Link href={"https://www.aem.live/docs/bulk-metadata"} text={"bulk metadata"} />) all look the same and Google might classify them as duplicate and not index them, despite different canonical URLs as Google considers canonical URLs a hint and not an absolute value.
-
-#### URL format of catalog pages
-
-By default, the boilerplate uses <Link href={"https://www.aem.live/developer/folder-mapping"} text={"folder mapping"} /> for product detail pages (PDP) and dedicated pages for product list pages (PLP). If your catalog has a large amount of PLPs, it might make sense to also use folder mapping for PLPs. A low number of PDPs or PLPs could justify creating dedicated pages for each.
-
-The URL format for folder-mapped PDPs looks like this:
+The default PDP URL format is:
 
 ```plaintext
 /products/{urlKey}/{sku}
 ```
 
-This is to include the SEO relevant `urlKey` parameter and the `SKU` which is needed to perform Catalog Service queries. Feel free to customize the format as needed. You might need to do advanced customization on the CDN.
+The `urlKey` carries the SEO-relevant product name and the `sku` is required for Catalog Service queries. You can customize the format, but changes to the URL structure require CDN configuration.
 
 <Aside type="note" title="Lowercase SKUs in URLs">
-The Commerce boilerplate enforces lowercase SKUs in all product URLs to ensure canonical consistency and comply with Edge Delivery Services <Link href={"https://www.aem.live/docs/limits#document-naming-restrictions"} text={"document naming restrictions"} />; SKUs must contain only `a-z`, `0-9`, `-`, and `.` (whitespace and other characters are not supported).
-
-- All product URLs now use lowercase SKUs by default
-- A centralized `getProductLink(urlKey, sku)` function ensures consistent URL generation
-- Sites with uppercase SKUs must either publish metadata or modify the URL generation function
-- See the [SEO metadata](/setup/seo/metadata/) documentation for implementation details
+The Commerce boilerplate enforces lowercase SKUs in all product URLs to comply with Edge Delivery Services [document naming restrictions](/setup/seo/platform-limits/#document-naming-and-url-format). The `getProductLink(urlKey, sku)` function handles this automatically. If your existing product URLs use uppercase SKUs, add redirects from the old paths to the new lowercase ones. See [SEO metadata](/setup/seo/metadata/) for implementation details.
 </Aside>
 
 ### Multi-store setups
@@ -60,7 +47,7 @@ For [multi-store setups](/setup/configuration/multistore-setup/) or stores suppo
 
 ### Cache-busting Query Parameter
 
-The <Link href={"https://github.com/hlxsites/aem-boilerplate-commerce/tree/main"} text={"Commerce boilerplate template"} /> includes a built-in way to prevent stale data from being served. It does this by adding a dynamic cache-busting parameter to Catalog Service requests.
+The <Link href={"https://github.com/hlxsites/aem-boilerplate-commerce/tree/main"} text={"Commerce boilerplate template"} /> includes a mechanism to prevent stale data from being served. It does this by adding a dynamic cache-busting parameter to Catalog Service requests.
 
 When your configuration headers change, the browser fetches fresh data instead of using cached responses. This helps keep your storefront content up to date.
 
@@ -83,23 +70,22 @@ The boilerplate always manages the `cb` parameter for you.
 
 ### Redirects
 
-Ensure proper redirects are set up using the redirects sheet or through your [CDN](/setup/configuration/content-delivery-network/).
+The Edge Delivery Services redirect sheet handles most migration-time URL changes: removing `.html` suffixes, restructuring content paths, and remapping product URLs after a replatform. Create the redirect list as a spreadsheet called `redirects` in the root of your project folder. Each row maps a source path to a destination URL or path. Preview changes before publishing so stakeholders can verify them on the `.page` preview site.
 
-- Fallbacks for any potential URL changes (for example, product URLs or missing .html suffixes)
-- Redirects that are set up in Adobe Commerce
+The redirect sheet matches URL paths only. The `Source` column accepts a relative path, so query parameters are not part of the match. It cannot target individual search terms like `/search?q=running`. For that use case, see the [search redirects tutorial](/how-tos/search-redirects/). For CDN-level wildcard redirects, see [Content delivery network](/setup/configuration/content-delivery-network/).
+
+If you are migrating from Adobe Commerce on Cloud (PaaS), that platform's URL rewrites (Marketing > SEO & Search > URL Rewrites) do not transfer to your EDS storefront. They are a PaaS-only feature. Re-create any active redirects as rows in the EDS redirect sheet instead.
+
+For the full reference — spreadsheet column names, wildcard CDN redirects, and SEO guidance for site migrations — see <Link href={"https://www.aem.live/docs/redirects"} text={"Redirects on AEM.live"} />.
 
 ### Sitemaps
 
-- Submit new sitemaps through Google Search Console (Google takes a while to detect new sitemaps).
-- If your site is using more than one sitemap, reference all sitemaps in your site's `robots.txt` file.
-- Validate sitemap XML (structure and URLs) with a dedicated sitemap or XML validator before you rely on it for discovery—not the hreflang tester, which checks language alternates only.
+Edge Delivery Services generates a sitemap automatically when you publish content, but Commerce storefronts often need additional configuration for prerendered catalog pages, multi-store `hreflang` tags, and large catalogs where the 50,000-URL-per-file limit applies.
 
-<Aside type="note" title="Generate sitemaps on Edge Delivery Services">
-See <Link href={"https://www.aem.live/developer/sitemap"} text={"sitemaps"} /> in the Edge Delivery Services documentation for more information on how to generate sitemaps.
-</Aside>
+See [Sitemaps](/setup/seo/sitemaps/) for configuration options and Commerce-specific guidance.
 
 ### Other
 
 - You can validate indexing using Google Search Console by inspecting the markup of the crawl to see if all important information was tracked.
 - Transactional pages (for example, cart, checkout, and account) should not be indexed.
-- Staging or any non-production environments must not be indexed. Once indexed, URLs from a staging environment can reduce traffic to the production environment. It might take a significant amount of time to remove staging URLs from the Google index.
+- Staging or any non-production environments must not be indexed. Once indexed, URLs from a staging environment can reduce traffic to the production environment. It takes a significant amount of time to remove staging URLs from the Google index.

--- a/src/content/docs/setup/seo/platform-limits.mdx
+++ b/src/content/docs/setup/seo/platform-limits.mdx
@@ -5,7 +5,6 @@ description: Understand which Edge Delivery Services platform limits affect Comm
 
 import Link from '@components/Link.astro';
 import LinkCard from '@components/LinkCard.astro';
-import TableWrapper from '@components/TableWrapper.astro';
 import { Aside } from '@astrojs/starlight/components';
 
 Edge Delivery Services enforces limits on URL format, index size, sitemap file size, and redirect count.
@@ -28,51 +27,25 @@ Switching to lowercase SKUs on a live site changes URLs, which affects indexing.
 
 ## Indexing and sitemap size
 
-<TableWrapper nowrap={[0]}>
+Each index file has a maximum page count. Each sitemap file has a maximum URL count and maximum uncompressed size. See <Link href="https://www.aem.live/docs/limits#sitemap-limits" text="Limits on AEM.live" />.
 
-| Limit | Value |
-|-------|-------|
-| Pages per index | 50,000 |
-| URLs per sitemap file | 50,000 |
-| Sitemap file size (uncompressed) | 50 MB |
+For large catalogs, these limits mean you need multiple query indexes and matching sitemap files. Reference all sitemap files in a `sitemap-index.xml` file and list each in `robots.txt`.
 
-</TableWrapper>
-
-For large catalogs, the 50,000-page index limit means you need multiple query indexes and matching sitemap files. Reference all sitemap files in a `sitemap-index.xml` file and list each in `robots.txt`.
-
-If you use the [AEM Commerce prerender](/setup/configuration/aem-prerender/) system for catalogs that exceed 50,000 products, plan to divide the sitemap before launch. Prerender publishes one HTML page per product via the BYOM API and then updates the sitemap via the AEM Admin API. A 60,000-product catalog, for example, requires at least two sitemap files to stay within the 50,000-URL limit.
+If you use the [AEM Commerce prerender](/setup/configuration/aem-prerender/) system for large catalogs, plan to split the sitemap before launch. Prerender publishes one HTML page per product via the BYOM API and then updates the sitemap via the AEM Admin API. A catalog that exceeds the per-file URL limit requires at least two sitemap files.
 
 See [Sitemaps](/setup/seo/sitemaps/) for configuration steps.
 
 ## Redirects
 
-Each site's redirect sheet can hold up to 100,000 entries. If you are migrating from a large legacy catalog with many URL changes, plan the redirect list in phases rather than importing all historical redirects at once.
+Your site's redirect sheet has a maximum number of entries. See <Link href="https://www.aem.live/docs/limits#redirect-limits" text="Redirect limits on AEM.live" />. If you are migrating from a large legacy catalog with many URL changes, plan the redirect list in phases rather than importing all historical redirects at once.
 
 See [SEO indexing — redirects](/setup/seo/indexing/#redirects) for the Commerce-specific redirect guidance.
 
 ## File upload limits
 
-These limits apply to files uploaded through <Link href="https://da.live" text="Document Authoring" />. They affect content authors uploading assets, not storefront code or product data.
+Each file type uploaded through <Link href="https://da.live" text="Document Authoring" /> has a maximum size. These limits affect content authors uploading assets, not storefront code or product data. Files that exceed the limit can still be served from a CDN or third-party asset host.
 
-<TableWrapper nowrap={[0]}>
-
-| File type | Limit |
-|-----------|-------|
-| Documents (`.docx` / Google Doc) | 100 MB |
-| Spreadsheets | 100,000 rows, 500,000 cells |
-| PDFs | 20 MB |
-| Images (`.png`, `.jpg`, `.avif`) | 20 MB |
-| Videos (`.mp4`) | 36 MB |
-| SVG | 40 KB |
-| Favicon (`.ico`) | 16 KB |
-
-</TableWrapper>
-
-<Aside type="tip" title="Larger files">
-Files that exceed these limits can still be served from your CDN or a third-party asset host.
-</Aside>
-
-For the merchant-facing summary of these limits, see [File and content limits](/merchants/edge-delivery-services/file-limits/).
+For the merchant-facing description of when you might hit these limits, see [File and content limits](/merchants/edge-delivery-services/file-limits/).
 
 ## Full reference
 

--- a/src/content/docs/setup/seo/platform-limits.mdx
+++ b/src/content/docs/setup/seo/platform-limits.mdx
@@ -11,45 +11,43 @@ Edge Delivery Services enforces limits on URL format, index size, sitemap file s
 
 ## Document naming and URL format
 
-Edge Delivery Services URLs contain only lowercase letters (`a-z`), numbers (`0-9`), and hyphens (`-`). Edge Delivery Services replaces all other characters with a single hyphen and removes leading and trailing hyphens. The full file path must not exceed 900 characters.
+URLs in Edge Delivery Services can contain only lowercase letters (`a-z`), numbers (`0-9`), and hyphens (`-`). Unsupported characters are replaced with hyphens. Leading and trailing hyphens are stripped. The full file path cannot exceed 900 characters.
 
 For Commerce storefronts, this means:
 
-- Product SKUs in URLs must be lowercase. The Adobe Commerce boilerplate enforces this automatically in the `getProductLink()` function.
-- If you write a custom URL function instead of using `getProductLink()`, make sure it applies the same character conversion — lowercase, no special characters, hyphens instead of spaces.
-- If you are migrating from a platform that used uppercase or special-character SKUs in URLs, add redirects from the old paths to the new lowercase ones. See [Redirects](/setup/seo/indexing/#redirects) for how to set up the redirects spreadsheet.
+- Product SKUs in URLs must be lowercase. The Commerce boilerplate enforces this automatically in the `getProductLink()` function.
+- If you write a custom URL function instead of using `getProductLink()`, apply the same rules: lowercase only, no special characters, and hyphens in place of spaces.
+- If you are migrating from a platform that used uppercase or special-character SKUs in URLs, add redirects from the old paths to the new lowercase ones. See [Redirects](/setup/seo/indexing/#redirects) for setup instructions.
 
-If your existing URLs contain characters that Edge Delivery Services does not support, add a CDN rewrite rule to normalize them before they reach the origin. See [Content delivery network](/setup/configuration/content-delivery-network/).
+If your existing URLs contain unsupported characters, add a CDN rewrite rule to normalize them before they reach the origin. See [Content delivery network](/setup/configuration/content-delivery-network/).
 
 <Aside type="note" title="Lowercase SKU enforcement">
-Switching to lowercase SKUs on a live site changes URLs, which affects indexing. Plan the lowercase transition as part of your launch preparation, not after go-live.
+Switching to lowercase SKUs on a live site changes URLs, which affects indexing. Plan the lowercase transition before launch.
 </Aside>
 
 ## Indexing and sitemap size
 
-Each index file has a maximum page count. Each sitemap file has a maximum URL count and maximum uncompressed size. See <Link href="https://www.aem.live/docs/limits#sitemap-limits" text="Limits on AEM.live" />.
+Index files have a maximum page count, and sitemap files have a maximum URL count and uncompressed size. See <Link href="https://www.aem.live/docs/limits#sitemap-limits" text="Sitemap limits on AEM.live" />.
 
-For large catalogs, these limits mean you need multiple query indexes and matching sitemap files. Reference all sitemap files in a `sitemap-index.xml` file and list each in `robots.txt`.
+When a catalog is too large for a single index or sitemap file, you need multiple query indexes and matching sitemap files. List all sitemap files in a `sitemap-index.xml` file and add each sitemap URL to `robots.txt`.
 
-If you use the [AEM Commerce prerender](/setup/configuration/aem-prerender/) system for large catalogs, plan to split the sitemap before launch. Prerender publishes one HTML page per product via the BYOM API and then updates the sitemap via the AEM Admin API. A catalog that exceeds the per-file URL limit requires at least two sitemap files.
+If you use [AEM Commerce prerender](/setup/configuration/aem-prerender/) for a large catalog, plan the sitemap split before launch. Prerender publishes one page per product and updates the sitemap, so the split must be configured before publishing begins.
 
 See [Sitemaps](/setup/seo/sitemaps/) for configuration steps.
 
 ## Redirects
 
-Your site's redirect sheet has a maximum number of entries. See <Link href="https://www.aem.live/docs/limits#redirect-limits" text="Redirect limits on AEM.live" />. If you are migrating from a large legacy catalog with many URL changes, plan the redirect list in phases rather than importing all historical redirects at once.
+The redirect sheet has a maximum number of entries. If you have many URL changes, import redirects in phases. See <Link href="https://www.aem.live/docs/limits#redirect-limits" text="Redirect limits on AEM.live" /> for the limit.
 
-See [SEO indexing — redirects](/setup/seo/indexing/#redirects) for the Commerce-specific redirect guidance.
+See [SEO indexing — redirects](/setup/seo/indexing/#redirects) for Commerce-specific guidance.
 
 ## File upload limits
 
-Each file type uploaded through <Link href="https://da.live" text="Document Authoring" /> has a maximum size. These limits affect content authors uploading assets, not storefront code or product data. Files that exceed the limit can still be served from a CDN or third-party asset host.
+Each file type you upload through <Link href="https://da.live" text="Document Authoring" /> has a maximum size. These limits apply to content authors, not to storefront code or product data. Files that exceed the limit should be hosted on a CDN or third-party asset service and linked from your storefront pages.
 
-For the merchant-facing description of when you might hit these limits, see [File and content limits](/merchants/edge-delivery-services/file-limits/).
+For merchant guidance on when these limits apply, see [File and content limits](/merchants/edge-delivery-services/file-limits/).
 
 ## Full reference
-
-The limits page on AEM.live has the complete list, including rate limits, GitHub Code Sync limits, and bring-your-own content source limits:
 
 <LinkCard
   noborder

--- a/src/content/docs/setup/seo/platform-limits.mdx
+++ b/src/content/docs/setup/seo/platform-limits.mdx
@@ -1,0 +1,91 @@
+---
+title: Edge Delivery Services limits
+description: Understand which Edge Delivery Services platform limits affect Commerce storefronts, including URL naming, index size, sitemap file size, and redirect counts.
+---
+
+import Link from '@components/Link.astro';
+import LinkCard from '@components/LinkCard.astro';
+import TableWrapper from '@components/TableWrapper.astro';
+import { Aside } from '@astrojs/starlight/components';
+
+Edge Delivery Services enforces limits on URL format, index size, sitemap file size, and redirect count.
+
+## Document naming and URL format
+
+Edge Delivery Services URLs contain only lowercase letters (`a-z`), numbers (`0-9`), and hyphens (`-`). Edge Delivery Services replaces all other characters with a single hyphen and removes leading and trailing hyphens. The full file path must not exceed 900 characters.
+
+For Commerce storefronts, this means:
+
+- Product SKUs in URLs must be lowercase. The Adobe Commerce boilerplate enforces this automatically in the `getProductLink()` function.
+- If you write a custom URL function instead of using `getProductLink()`, make sure it applies the same character conversion — lowercase, no special characters, hyphens instead of spaces.
+- If you are migrating from a platform that used uppercase or special-character SKUs in URLs, add redirects from the old paths to the new lowercase ones. See [Redirects](/setup/seo/indexing/#redirects) for how to set up the redirects spreadsheet.
+
+If your existing URLs contain characters that Edge Delivery Services does not support, add a CDN rewrite rule to normalize them before they reach the origin. See [Content delivery network](/setup/configuration/content-delivery-network/).
+
+<Aside type="note" title="Lowercase SKU enforcement">
+Switching to lowercase SKUs on a live site changes URLs, which affects indexing. Plan the lowercase transition as part of your launch preparation, not after go-live.
+</Aside>
+
+## Indexing and sitemap size
+
+<TableWrapper nowrap={[0]}>
+
+| Limit | Value |
+|-------|-------|
+| Pages per index | 50,000 |
+| URLs per sitemap file | 50,000 |
+| Sitemap file size (uncompressed) | 50 MB |
+
+</TableWrapper>
+
+For large catalogs, the 50,000-page index limit means you need multiple query indexes and matching sitemap files. Reference all sitemap files in a `sitemap-index.xml` file and list each in `robots.txt`.
+
+If you use the [AEM Commerce prerender](/setup/configuration/aem-prerender/) system for catalogs that exceed 50,000 products, plan to divide the sitemap before launch. Prerender publishes one HTML page per product via the BYOM API and then updates the sitemap via the AEM Admin API. A 60,000-product catalog, for example, requires at least two sitemap files to stay within the 50,000-URL limit.
+
+See [Sitemaps](/setup/seo/sitemaps/) for configuration steps.
+
+## Redirects
+
+Each site's redirect sheet can hold up to 100,000 entries. If you are migrating from a large legacy catalog with many URL changes, plan the redirect list in phases rather than importing all historical redirects at once.
+
+See [SEO indexing — redirects](/setup/seo/indexing/#redirects) for the Commerce-specific redirect guidance.
+
+## File upload limits
+
+These limits apply to files uploaded through <Link href="https://da.live" text="Document Authoring" />. They affect content authors uploading assets, not storefront code or product data.
+
+<TableWrapper nowrap={[0]}>
+
+| File type | Limit |
+|-----------|-------|
+| Documents (`.docx` / Google Doc) | 100 MB |
+| Spreadsheets | 100,000 rows, 500,000 cells |
+| PDFs | 20 MB |
+| Images (`.png`, `.jpg`, `.avif`) | 20 MB |
+| Videos (`.mp4`) | 36 MB |
+| SVG | 40 KB |
+| Favicon (`.ico`) | 16 KB |
+
+</TableWrapper>
+
+<Aside type="tip" title="Larger files">
+Files that exceed these limits can still be served from your CDN or a third-party asset host.
+</Aside>
+
+For the merchant-facing summary of these limits, see [File and content limits](/merchants/edge-delivery-services/file-limits/).
+
+## Full reference
+
+The limits page on AEM.live has the complete list, including rate limits, GitHub Code Sync limits, and bring-your-own content source limits:
+
+<LinkCard
+  noborder
+  icon="information"
+  title="Limits on AEM.live"
+  description="Complete reference for delivery, content source, GitHub sync, and Admin API rate limits across Edge Delivery Services."
+  link="https://www.aem.live/docs/limits"
+  rightIcon="external"
+  target="_blank"
+  rel="noopener noreferrer"
+  aria-label="Limits on AEM.live (opens in a new tab)"
+/>

--- a/src/content/docs/setup/seo/sitemaps.mdx
+++ b/src/content/docs/setup/seo/sitemaps.mdx
@@ -1,0 +1,58 @@
+---
+title: Sitemaps
+description: Configure sitemaps for Adobe Commerce storefronts on Edge Delivery Services, including catalog pages, prerender updates, and multi-store hreflang.
+---
+
+import Link from '@components/Link.astro';
+import LinkCard from '@components/LinkCard.astro';
+import { Aside } from '@astrojs/starlight/components';
+
+Edge Delivery Services generates a sitemap automatically at `/sitemap.xml` when you publish content. Most Commerce storefronts need additional configuration for catalog pages and multi-store setups.
+
+## How automatic sitemap generation works
+
+Document-based pages are added to the sitemap when you publish them.
+
+Product detail pages are not published documents, so they are not included in the sitemap by default. If you configure [AEM Commerce prerender](/setup/configuration/aem-prerender/), it publishes each product page as overlay content and updates the sitemap automatically. Without prerender, add a custom `helix-sitemap.yaml` that sources product URLs from your catalog.
+
+## Configure a custom sitemap
+
+Add `helix-sitemap.yaml` to the root of your GitHub repository for multi-language, aggregated, or custom sitemap configurations.
+
+<Aside type="note" title="50,000-URL limit per sitemap file">
+Each sitemap file can hold up to 50,000 URLs and must be under 50 MB uncompressed. If your catalog exceeds that size, split it into multiple sitemap files and reference all of them in your `sitemap-index.xml` and `robots.txt`. See [Edge Delivery Services limits](/setup/seo/platform-limits/) for more detail.
+</Aside>
+
+For configuration examples — simple sitemaps, multiple language sitemaps with `hreflang`, and aggregating multiple indexes into one file — see the full reference on AEM.live:
+
+<LinkCard
+  noborder
+  icon="document"
+  title="Sitemaps on AEM.live"
+  description="Configure helix-sitemap.yaml for simple, multi-language, and aggregated sitemaps. Includes hreflang, lastmod, and extension options."
+  link="https://www.aem.live/developer/sitemap"
+  rightIcon="external"
+  target="_blank"
+  rel="noopener noreferrer"
+  aria-label="Sitemaps on AEM.live (opens in a new tab)"
+/>
+
+## Multi-store setups
+
+Add `hreflang` attributes to your sitemap for storefronts that support multiple languages or locales.
+
+See [SEO indexing — multi-store setups](/setup/seo/indexing/#multi-store-setups) for the `hreflang` configuration steps that apply to your Commerce storefront.
+
+## Submit to Google Search Console
+
+After generating your sitemap, submit it to Google Search Console.
+
+Also add your sitemap URL to `robots.txt` so other crawlers can find it automatically:
+
+```plaintext
+Sitemap: https://www.example.com/sitemap.xml
+```
+
+If your site uses multiple sitemap files, reference each one in `robots.txt` or create a sitemap index file at `/sitemap-index.xml` that lists them all.
+
+Sitemap submission is also part of the [launch checklist](/setup/launch/) — verify it alongside other SEO tasks before go-live.

--- a/src/content/docs/setup/seo/sitemaps.mdx
+++ b/src/content/docs/setup/seo/sitemaps.mdx
@@ -19,11 +19,11 @@ Product detail pages are not published documents, so they are not included in th
 
 Add `helix-sitemap.yaml` to the root of your GitHub repository for multi-language, aggregated, or custom sitemap configurations.
 
-<Aside type="note" title="50,000-URL limit per sitemap file">
-Each sitemap file can hold up to 50,000 URLs and must be under 50 MB uncompressed. If your catalog exceeds that size, split it into multiple sitemap files and reference all of them in your `sitemap-index.xml` and `robots.txt`. See [Edge Delivery Services limits](/setup/seo/platform-limits/) for more detail.
+<Aside type="note" title="Sitemap file size limit">
+Each sitemap file has a maximum URL count and uncompressed file size. If your catalog exceeds those limits, split it into multiple sitemap files and reference all of them in your `sitemap-index.xml` and `robots.txt`. See <Link href="https://www.aem.live/docs/limits#sitemap-limits" text="Sitemap limits on AEM.live" /> for details.
 </Aside>
 
-For configuration examples — simple sitemaps, multiple language sitemaps with `hreflang`, and aggregating multiple indexes into one file — see the full reference on AEM.live:
+For configuration examples — simple sitemaps, multi-language sitemaps with `hreflang`, and aggregated sitemaps, see the full reference on AEM.live:
 
 <LinkCard
   noborder

--- a/src/content/docs/setup/seo/sitemaps.mdx
+++ b/src/content/docs/setup/seo/sitemaps.mdx
@@ -9,21 +9,19 @@ import { Aside } from '@astrojs/starlight/components';
 
 Edge Delivery Services generates a sitemap automatically at `/sitemap.xml` when you publish content. Most Commerce storefronts need additional configuration for catalog pages and multi-store setups.
 
-## How automatic sitemap generation works
+## What's included automatically
 
-Document-based pages are added to the sitemap when you publish them.
-
-Product detail pages are not published documents, so they are not included in the sitemap by default. If you configure [AEM Commerce prerender](/setup/configuration/aem-prerender/), it publishes each product page as overlay content and updates the sitemap automatically. Without prerender, add a custom `helix-sitemap.yaml` that sources product URLs from your catalog.
+Document-based pages appear in the sitemap when you publish them. Product detail pages are excluded by default. If you configure [AEM Commerce prerender](/setup/configuration/aem-prerender/), it publishes each product page and updates the sitemap automatically.
 
 ## Configure a custom sitemap
 
-Add `helix-sitemap.yaml` to the root of your GitHub repository for multi-language, aggregated, or custom sitemap configurations.
+Add `helix-sitemap.yaml` to the root of your GitHub repository to configure multi-language, aggregated, or custom sitemap behavior. For multi-store setups that need `hreflang` tags, see [SEO indexing — multi-store setups](/setup/seo/indexing/#multi-store-setups).
 
 <Aside type="note" title="Sitemap file size limit">
 Each sitemap file has a maximum URL count and uncompressed file size. If your catalog exceeds those limits, split it into multiple sitemap files and reference all of them in your `sitemap-index.xml` and `robots.txt`. See <Link href="https://www.aem.live/docs/limits#sitemap-limits" text="Sitemap limits on AEM.live" /> for details.
 </Aside>
 
-For configuration examples — simple sitemaps, multi-language sitemaps with `hreflang`, and aggregated sitemaps, see the full reference on AEM.live:
+For configuration examples, see the full reference on AEM.live:
 
 <LinkCard
   noborder
@@ -37,22 +35,12 @@ For configuration examples — simple sitemaps, multi-language sitemaps with `hr
   aria-label="Sitemaps on AEM.live (opens in a new tab)"
 />
 
-## Multi-store setups
+## Submit your sitemap
 
-Add `hreflang` attributes to your sitemap for storefronts that support multiple languages or locales.
-
-See [SEO indexing — multi-store setups](/setup/seo/indexing/#multi-store-setups) for the `hreflang` configuration steps that apply to your Commerce storefront.
-
-## Submit to Google Search Console
-
-After generating your sitemap, submit it to Google Search Console.
-
-Also add your sitemap URL to `robots.txt` so other crawlers can find it automatically:
+Add your sitemap URL to `robots.txt` so crawlers discover it automatically:
 
 ```plaintext
 Sitemap: https://www.example.com/sitemap.xml
 ```
 
-If your site uses multiple sitemap files, reference each one in `robots.txt` or create a sitemap index file at `/sitemap-index.xml` that lists them all.
-
-Sitemap submission is also part of the [launch checklist](/setup/launch/) — verify it alongside other SEO tasks before go-live.
+For Google Search Console submission steps, see [Sitemaps](/merchants/edge-delivery-services/sitemaps/) in the merchant guide. Sitemap submission is part of the [launch checklist](/setup/launch/).

--- a/src/data/glossary.ts
+++ b/src/data/glossary.ts
@@ -394,6 +394,18 @@ const glossaryEntries: GlossaryEntry[] = [
     aliases: ['key-value rows'],
   },
   {
+    term: 'BYOM',
+    definition:
+      "Bring Your Own Markup. Edge Delivery Services protocol for supplying page HTML from an external source instead of a document.",
+    aliases: ['Bring Your Own Markup'],
+  },
+  {
+    term: 'overlay content',
+    definition:
+      'A secondary BYOM content source layered over the primary one; EDS serves overlay HTML for a URL when available, falling back to the primary source otherwise.',
+    aliases: ['overlay', 'BYOM overlay'],
+  },
+  {
     term: 'Merged full-width row',
     definition:
       "A table row where one cell spans the full table width, so you can add rich page content in one large cell. Some blocks (like `targeted-block`) use this for inline content or layout when a separate fragment document is not used.",


### PR DESCRIPTION
## Purpose of this pull request

Adds new merchant-facing topics for redirects, sitemaps, and file/content limits in Edge Delivery Services, and adds developer-facing pages for sitemaps and platform limits in the SEO section. Also updates the SEO indexing page with expanded redirect and sitemap guidance, and restructures the merchant sidebar to surface the Edge Delivery Services section earlier.

### Associated JIRA ticket
https://jira.corp.adobe.com/browse/COMDOX-1740

### Staging preview

[Redirects](https://commerce-docs.github.io/microsite-commerce-storefront/merchants/edge-delivery-services/redirects/) for merchants
[Sitemaps](https://commerce-docs.github.io/microsite-commerce-storefront/merchants/edge-delivery-services/sitemaps/) for merchants
[Limits](https://commerce-docs.github.io/microsite-commerce-storefront/merchants/edge-delivery-services/file-limits/) for merchants
[Sitemaps](https://commerce-docs.github.io/microsite-commerce-storefront/setup/seo/sitemaps/) for developers
[Limits](https://commerce-docs.github.io/microsite-commerce-storefront/setup/seo/platform-limits/) for developers

## Affected pages

New pages:

- https://experienceleague.adobe.com/developer/commerce/storefront/merchants/edge-delivery-services/redirects/
- https://experienceleague.adobe.com/developer/commerce/storefront/merchants/edge-delivery-services/sitemaps/
- https://experienceleague.adobe.com/developer/commerce/storefront/merchants/edge-delivery-services/file-limits/
- https://experienceleague.adobe.com/developer/commerce/storefront/setup/seo/sitemaps/
- https://experienceleague.adobe.com/developer/commerce/storefront/setup/seo/platform-limits/

Updated pages:

- https://experienceleague.adobe.com/developer/commerce/storefront/merchants/edge-delivery-services/
- https://experienceleague.adobe.com/developer/commerce/storefront/setup/seo/
- https://experienceleague.adobe.com/developer/commerce/storefront/setup/seo/indexing/
- https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/content-delivery-network/
- https://experienceleague.adobe.com/developer/commerce/storefront/setup/configuration/aem-prerender/

## Links to source code

<!--OPTIONAL Link to any associated source code PRs related to update-->

### What's New highlights

- [ ] Add `new-topic` label

whatsnew
Added new topics:
- [Redirects](https://experienceleague.adobe.com/developer/commerce/storefront/merchants/edge-delivery-services/redirects/) — how to create and manage redirects using a spreadsheet in Edge Delivery Services, including query-parameter limitations and migration guidance from Adobe Commerce on Cloud.
- [Sitemaps (merchants)](https://experienceleague.adobe.com/developer/commerce/storefront/merchants/edge-delivery-services/sitemaps/) — how Edge Delivery Services generates sitemaps automatically and when to involve a developer.
- [File and content limits](https://experienceleague.adobe.com/developer/commerce/storefront/merchants/edge-delivery-services/file-limits/) — file upload size limits for documents, images, video, and SVG, plus redirect and sitemap entry limits.
- [Sitemaps (developers)](https://experienceleague.adobe.com/developer/commerce/storefront/setup/seo/sitemaps/) — sitemap configuration for Commerce storefronts, including catalog pages, prerender integration, multi-store `hreflang`, and Google Search Console submission.
- [Edge Delivery Services limits](https://experienceleague.adobe.com/developer/commerce/storefront/setup/seo/platform-limits/) — URL naming rules, index size caps, sitemap file size limits, and redirect count limits that affect Commerce storefronts.