### PR TITLE
Fix targeted-block docs: row labels and stale code example

### DIFF
--- a/src/content/docs/dropins/personalization/containers/targeted-block.mdx
+++ b/src/content/docs/dropins/personalization/containers/targeted-block.mdx
@@ -30,20 +30,28 @@ compact
 The following example demonstrates how to integrate the `TargetedBlock` container:
 
 ```javascript
+function prepareIds(providedIds) {
+  return providedIds.split(',').map((num) => btoa(num.trim()));
+}
+
 export default async function decorate(block) {
   const blockConfig = readBlockConfig(block);
 
   const {
     fragment,
     type,
-    segments,
-    groups,
-    cartRules,
+    'customer-segments': customerSegments,
+    'customer-groups': customerGroups,
+    'cart-rules': rules,
   } = blockConfig;
 
   const content = (blockConfig.fragment !== undefined)
     ? await loadFragment(fragment)
     : block.children[block.children.length - 1];
+
+  const segments = customerSegments !== undefined ? prepareIds(customerSegments) : [];
+  const groups = customerGroups !== undefined ? prepareIds(customerGroups) : [];
+  const cartRules = rules !== undefined ? prepareIds(rules) : [];
 
   render.render(TargetedBlock, {
     type,

--- a/src/content/docs/merchants/content-customizations/personalization.mdx
+++ b/src/content/docs/merchants/content-customizations/personalization.mdx
@@ -27,15 +27,15 @@ Add this table to your document to configure a targeted block. A targeted block 
 <td colspan="2" style="text-align: center; padding: 0.75rem; border: 1px solid var(--sl-color-gray-5); background-color: var(--sl-color-gray-6); font-weight: 600;">targeted-block</td>
 </tr>
 <tr>
-<td style="width: 50%; padding: 0.75rem; border: 1px solid var(--sl-color-gray-5);">segments</td>
+<td style="width: 50%; padding: 0.75rem; border: 1px solid var(--sl-color-gray-5);">Customer Segments</td>
 <td style="width: 50%; padding: 0.75rem; border: 1px solid var(--sl-color-gray-5);"><em style="color: var(--sl-color-gray-3); font-style: italic;">1, 2 <span style="font-size: 0.85em;">(example)</span></em></td>
 </tr>
 <tr>
-<td style="width: 50%; padding: 0.75rem; border: 1px solid var(--sl-color-gray-5);">groups</td>
+<td style="width: 50%; padding: 0.75rem; border: 1px solid var(--sl-color-gray-5);">Customer Groups</td>
 <td style="width: 50%; padding: 0.75rem; border: 1px solid var(--sl-color-gray-5);"><em style="color: var(--sl-color-gray-3); font-style: italic;">1, 3 <span style="font-size: 0.85em;">(example)</span></em></td>
 </tr>
 <tr>
-<td style="width: 50%; padding: 0.75rem; border: 1px solid var(--sl-color-gray-5);">cartRules</td>
+<td style="width: 50%; padding: 0.75rem; border: 1px solid var(--sl-color-gray-5);">Cart Rules</td>
 <td style="width: 50%; padding: 0.75rem; border: 1px solid var(--sl-color-gray-5);"><em style="color: var(--sl-color-gray-3); font-style: italic;">5 <span style="font-size: 0.85em;">(example)</span></em></td>
 </tr>
 <tr>
@@ -51,11 +51,11 @@ Add this table to your document to configure a targeted block. A targeted block 
 
 In the `targeted-block` table, most settings use a key-value row: a two-column row where the first cell is the setting name and the second cell is the value (for example, `true`, a number, or a label). If you do not set a fragment path, you must add a final merged full-width row—one cell that spans the full table width so you can place rich page content in one place (for example, headings, text, and images). The `targeted-block` table uses that row for inline content when you do not load a separate fragment document.
 
-- `segments` — A segment is a rule-based way to target experiences to qualifying shopper cohorts. This row holds a comma-separated list of customer segment IDs; the block only appears for shoppers who belong to those segments. Optional.
+- `Customer Segments` — A segment is a rule-based way to target experiences to qualifying shopper cohorts. This row holds a comma-separated list of customer segment IDs; the block only appears for shoppers who belong to those segments. Optional.
 
-- `groups` — A customer group in Commerce is used to segment shoppers for pricing, permissions, or targeted content. This row holds a comma-separated list of customer group IDs; the block only appears for shoppers in those groups. Optional.
+- `Customer Groups` — A customer group in Commerce is used to segment shoppers for pricing, permissions, or targeted content. This row holds a comma-separated list of customer group IDs; the block only appears for shoppers in those groups. Optional.
 
-- `cartRules` — A cart price rule is a Commerce rule you can use as a condition for targeting content or promotions. This row holds a comma-separated list of cart rule IDs; the block only appears when those cart price rules are satisfied. Optional.
+- `Cart Rules` — A cart price rule is a Commerce rule you can use as a condition for targeting content or promotions. This row holds a comma-separated list of cart rule IDs; the block only appears when those cart price rules are satisfied. Optional.
 
 - `fragment` — An optional path to a separate content document. When you set a fragment, the `TargetedBlock` loads content from that document. When you omit it, add your content in the last merged full-width row in this `targeted-block` table, as described above. Optional.
 
@@ -108,7 +108,7 @@ You can configure each page to display personalized content by setting targeting
    <td colspan="2" style="text-align: center; padding: 0.75rem; border: 1px solid var(--sl-color-gray-5); background-color: var(--sl-color-gray-6); font-weight: 600;">targeted-block</td>
    </tr>
    <tr>
-   <td style="width: 50%; padding: 0.75rem; border: 1px solid var(--sl-color-gray-5);">segments</td>
+   <td style="width: 50%; padding: 0.75rem; border: 1px solid var(--sl-color-gray-5);">Customer Segments</td>
    <td style="width: 50%; padding: 0.75rem; border: 1px solid var(--sl-color-gray-5);">1, 2</td>
    </tr>
    </tbody>
@@ -138,7 +138,7 @@ You can configure each page to display personalized content by setting targeting
    <td colspan="2" style="text-align: center; padding: 0.75rem; border: 1px solid var(--sl-color-gray-5); background-color: var(--sl-color-gray-6); font-weight: 600;">targeted-block</td>
    </tr>
    <tr>
-   <td style="width: 50%; padding: 0.75rem; border: 1px solid var(--sl-color-gray-5);">cartRules</td>
+   <td style="width: 50%; padding: 0.75rem; border: 1px solid var(--sl-color-gray-5);">Cart Rules</td>
    <td style="width: 50%; padding: 0.75rem; border: 1px solid var(--sl-color-gray-5);">5</td>
    </tr>
    <tr>


### PR DESCRIPTION
## Summary
- The Personalization setup doc's `targeted-block` example tables and reference list used `segments`, `groups`, and `cartRules` as row labels. `readBlockConfig()` normalizes row labels via `toClassName()`, which lowercases and replaces non-alphanumeric characters with `-`. A single camelCase word like `cartRules` has no non-alphanumeric character to replace, so it normalizes to `cartrules`, not `cart-rules`. `blocks/targeted-block/targeted-block.js` destructures `customer-segments`, `customer-groups`, and `cart-rules` from the config — none of which matched the documented labels, so following the doc as written means the block's targeting conditions are silently never read. Updated row labels to `Customer Segments`, `Customer Groups`, and `Cart Rules`, which normalize correctly.
- The `TargetedBlock` container docs' `decorate()` code example had the same root cause: it destructured `segments`/`groups`/`cartRules` straight off `blockConfig` and passed them directly into `personalizationData`, skipping the `prepareIds()` step the real block uses to split each comma-separated value and base64-encode (`btoa`) every ID. Updated the example to match `aem-boilerplate-commerce/blocks/targeted-block/targeted-block.js`.

## Test plan
- [ ] Confirm `Customer Segments` / `Customer Groups` / `Cart Rules` normalize to `customer-segments` / `customer-groups` / `cart-rules` via `toClassName()` in `aem-boilerplate-commerce/scripts/aem.js`
- [ ] Spot check the updated tables/list render correctly in a local Starlight preview
- [ ] Confirm the updated `decorate()` example matches current `aem-boilerplate-commerce/blocks/targeted-block/targeted-block.js`